### PR TITLE
Add build/test guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # GAZL
-GAZL: a fast, typed VM with readable assembly. Impala: a simple C-like compiler targeting GAZL.
+
+GAZL is a lightweight, typed virtual machine with a readable assembly language. The
+`impala` directory contains a small C-like compiler that targets GAZL.
+
+## Building
+
+The project is built using the helper scripts in `tools/`. On a UNIX like system
+you can build both `PikaCmd`, `GAZLCmd` and the Impala compiler using:
+
+```sh
+# from the repository root
+CPP_MODEL=native ./tools/BuildImpala.sh
+```
+
+The default build script uses macOS specific compiler flags which may not work on
+Linux. Setting `CPP_MODEL=native` avoids these cross compilation flags. The
+script also runs `ImpalaDemo.impala` once the build completes.
+
+## Running the demo
+
+The build script runs this demo once automatically. You can run it again
+manually with:
+
+```sh
+cd impala
+./PikaCmd impala.pika run ImpalaDemo.impala
+```
+
+## Running the test suite
+
+Run the Impala test suite using `PikaCmd`:
+
+```sh
+cd impala
+./PikaCmd runTests.pika
+```
+
+When set up correctly the suite reports `Total errors: 0 / 53`.
+
+The tests compile each file in `tests/sources` and compare the output with the
+reference files in `tests/golden`.

--- a/impala/runTests.pika
+++ b/impala/runTests.pika
@@ -1,4 +1,4 @@
-#! /usr/local/bin/PikaCmd
+#! /usr/bin/env PikaCmd
 
 include('systools.pika');
 include('stdlib.pika');
@@ -12,7 +12,7 @@ totalFiles = 0;
 dir(sourcesDir # "*.impala", >{
 	goldFilename = bake('tests{DIR_SLASH}golden{DIR_SLASH}{basenameOfPath($0) # ".gazl"}');
 	print("Compiling " # $0);
-	result = pipe(bake('pika impala.pika compile {sourcesDir}{$0} - 1234'), false, @err, @rc);
+        result = pipe(bake('{::run.root}PikaCmd impala.pika compile {sourcesDir}{$0} - 1234'), false, @err, @rc);
 	if (rc === 2) throw("user aborted")
 	else if (rc !== 0) {
 		print("<<< Error compiling >>>");

--- a/tools/BuildCpp.sh
+++ b/tools/BuildCpp.sh
@@ -10,7 +10,7 @@ if [ "$1" == "debug" ] || [ "$1" == "beta" ] || [ "$1" == "release" ]; then
 	shift
 fi
 
-if [ "$1" == "x64" ] || [ "$1" == "x86" ] || [ "$1" == "arm64" ]; then
+if [ "$1" == "x64" ] || [ "$1" == "x86" ] || [ "$1" == "arm64" ] || [ "$1" == "native" ] || [ "$1" == "host" ]; then
 	CPP_MODEL="$1"
 	shift
 fi
@@ -27,14 +27,16 @@ else
 fi
 
 if [ "$CPP_MODEL" == "x64" ]; then
-	CPP_OPTIONS="-m64 -target x86_64-apple-macos $CPP_OPTIONS"
+        CPP_OPTIONS="-m64 -target x86_64-apple-macos $CPP_OPTIONS"
 elif [ "$CPP_MODEL" == "x86" ]; then
-	CPP_OPTIONS="-m32 -target x86_64-apple-macos $CPP_OPTIONS"
+        CPP_OPTIONS="-m32 -target x86_64-apple-macos $CPP_OPTIONS"
 elif [ "$CPP_MODEL" == "arm64" ]; then
-	CPP_OPTIONS="-m64 -target arm64-apple-macos $CPP_OPTIONS"
+        CPP_OPTIONS="-m64 -target arm64-apple-macos $CPP_OPTIONS"
+elif [ "$CPP_MODEL" == "native" ] || [ "$CPP_MODEL" == "host" ]; then
+        CPP_OPTIONS="$CPP_OPTIONS"
 else
-	echo Unrecognized CPP_MODEL "$CPP_MODEL"
-	exit 1
+        echo Unrecognized CPP_MODEL "$CPP_MODEL"
+        exit 1
 fi
 
 CPP_OPTIONS="-fvisibility=hidden -fvisibility-inlines-hidden -Wno-trigraphs -Wreturn-type -Wunused-variable $CPP_OPTIONS"

--- a/tools/BuildImpala.sh
+++ b/tools/BuildImpala.sh
@@ -30,6 +30,5 @@ cp -f PikaCmd/PikaCmd ../impala/ >/dev/null
 cp -f PikaCmd/systools.pika ../impala/ >/dev/null
 cd ../impala/
 ./PikaCmd impala.pika rebuild
-chmod +x ../impala/impala >/dev/null 2>&1
-./impala run ImpalaDemo.impala
+./PikaCmd impala.pika run ImpalaDemo.impala
 exit 0


### PR DESCRIPTION
## Summary
- document build, demo and test workflow
- support a `native` build target in `BuildCpp.sh`
- fix build script to run demo using `PikaCmd`
- run tests directly using `PikaCmd` without symlink
- clarify test instructions in README

## Testing
- `CPP_MODEL=native ./tools/BuildImpala.sh`
- `cd impala && ./PikaCmd runTests.pika`

------
https://chatgpt.com/codex/tasks/task_e_686cf960e0048332a0439a9bb99e7079