### PR TITLE
Remove obsolete Pika.cmd

### DIFF
--- a/impala/impala.cmd
+++ b/impala/impala.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
 SET "SCRIPT_DIR=%~dp0"
-"%SCRIPT_DIR%..\tools\PikaCmd\Pika.cmd" "%SCRIPT_DIR%impala.pika" %*
+"%SCRIPT_DIR%..\tools\PikaCmd\PikaCmd.exe" "%SCRIPT_DIR%impala.pika" %*

--- a/tools/BuildImpala.bat
+++ b/tools/BuildImpala.bat
@@ -23,6 +23,7 @@ COPY /Y ..\impala\impala.pika %outdir%\ >NUL
 COPY /Y ..\impala\impalaCompiler.pika %outdir%\ >NUL
 COPY /Y ..\impala\initPPEG.pika %outdir%\ >NUL
 COPY /Y ..\impala\systools.pika %outdir%\ >NUL
+COPY /Y ..\impala\impala.cmd %outdir%\ >NUL
 EXIT /B 0
 
 

--- a/tools/BuildImpala.sh
+++ b/tools/BuildImpala.sh
@@ -27,4 +27,7 @@ fi
 	cp ../impala/impala.pika ../impala/impalaCompiler.pika \
     ../impala/initPPEG.pika ../impala/systools.pika "$outdir"
 
+# Copy helper script
+cp ../impala/impala.cmd "$outdir"/ 2>/dev/null || true
+
 


### PR DESCRIPTION
## Summary
- drop unused `Pika.cmd`
- update all references to use `PikaCmd.exe`
- copy `impala.cmd` with the staged compiler
- revert changes in `tools/PikaCmd`

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6873b2d151708332b82811729c859207