### PR TITLE
Add instruction set verification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ The tests compile each file in `tests/sources` and compare the results with gold
 
 ## Documentation
 
-- [Overview](docs/Overview.md) – general architecture and goals  
+- [Overview](docs/Overview.md) – general architecture and goals
+- [Instruction Set](docs/InstructionSet.md) – extracted opcode descriptions
 
 More technical notes are embedded in the Impala source files.
 

--- a/docs/InstructionSet.md
+++ b/docs/InstructionSet.md
@@ -1,0 +1,469 @@
+# Instruction Set
+
+Descriptions extracted from [`src/UnitTest.gazl`](../src/UnitTest.gazl).
+
+## ABSf
+- `float(d)        #float`
+- `float(d)        float`
+
+Absolute of float
+
+## ABSi
+- `int(d)          #int`
+- `int(d)          int`
+
+Absolute of int
+
+## ADDf
+- `float(d)        #float          #float`
+- `float(d)        #float          float`
+- `float(d)        float           #float`
+- `float(d)        float           float`
+
+Add floats
+
+## ADDi
+- `int(d)          #int            #int`
+- `int(d)          #int            int`
+- `int(d)          int             #int`
+- `int(d)          int             int`
+
+Add ints
+
+## ADDp
+- `ptr(d)          &address        #int`
+- `ptr(d)          &address        int`
+- `ptr(d)          ptr             #int`
+- `ptr(d)          ptr             int`
+
+Add to pointer
+
+## ADRL
+- `ptr(d)          var             *size`
+
+Load effective address of local `var` into `ptr(d)` `*size` should hint how many words is expected to be accessed from
+`ptr(d)`, i.e. typically one for a single variable or the array size for arrays. It may be used to optimize stack frame
+sizes, for bounds checking etc. It is always legal to specify a size of zero if you do not know.
+
+## ANDi
+- `int(d)          #int            #int`
+- `int(d)          #int            int`
+- `int(d)          int             #int`
+- `int(d)          int             int`
+
+Bitwise AND ints
+
+## CALL
+- `&function`
+- `&function       %temp           *size`
+- `^native`
+- `^native         %temp           *size`
+- `ptr`
+- `ptr             %temp           *size`
+
+Function call. %temp should specify the "transient" variable for the first parameter (e.g. %0, %1, %2 etc). *size is the
+number of parameters (counting both input and output parameters). In GAZL 1.0 there is no compile-time check on the
+types and number of parameters passed to a function. The size operand is merely a hint that might be used to optimize
+stack frame sizes or for bounds checking etc.
+
+## CNST
+- `*size`
+
+Declare a constant data section / array `*size` defines the size of the section (in number of words). Define the data
+with DAT directives. You may not define more data items than `*size`, but you may define fewer (remaining items will be
+zeroed). Data in a constant section is placed in a write-protected segment of the run-time memory. See consts
+declarations in top of this file for examples.
+
+## DATf
+- `#float`
+
+
+## COPY
+- `&address(w)     &address(r)     *size`
+- `&address(w)     ptr             *size`
+- `ptr             &address(r)     *size`
+- `ptr             ptr             *size`
+
+Copies memory. Behaviour is undefined if target and source overlaps. This instruction can be used to accelerate memory
+access since global and constant data must otherwise be accessed with individual PEEK and POKE instructions. With COPY
+you can copy a range of global / constant data to a local array which can then be used directly with arbitrary
+instructions. (Just remember that you need to use ADRL to obtain the address to the local array.)
+
+## DIFp
+- `int(d)          &address        &address`
+- `int(d)          &address        ptr`
+- `int(d)          ptr             &address`
+- `int(d)          ptr             ptr`
+
+Difference of two pointers You cannot use SUBp to subtract a pointer from another. SUBp is only used for negatively
+offsetting a pointer. Notice that for the first variant with two constant addresses, both addresses need to be declared
+before the instruction. (The other variants accepts forward declarations.) The motivation behind this exception is that
+the difference of two constant addresses becomes another constant, and this may be utilized for local optimizations etc.
+
+## DIVf
+- `float(d)        #float          #float`
+- `float(d)        #float          float`
+- `float(d)        float           #float`
+- `float(d)        float           float`
+
+Divide floats Division by 0 is considered illegal and should generate a run-time error (or compile-time error if 0 is a
+constant).
+
+## DIVi
+- `int(d)          #int            #int`
+- `int(d)          #int            int`
+- `int(d)          int             #int`
+- `int(d)          int             int`
+
+Divide ints Note: this test assumes truncation towards zero (also for negative numbers) although this is not guaranteed
+by all C/C++ compilers. In case this test fails (for example `i3` turns out #760) the C/C++ compiler that built the VM
+uses an unusual truncation mode and that would be a bad thing that would have to be fixed in an upgrade of GAZL.
+Division by 0 is considered illegal and should generate a run-time error (or compile-time error if 0 is a constant).
+
+## EQUf
+- `#float          #float          @label`
+- `#float          float           @label`
+- `float           #float          @label`
+- `float           float           @label`
+
+Branch on equal floats
+
+## EQUi
+- `#int            #int            @label`
+- `#int            int             @label`
+- `int             #int            @label`
+- `int             int             @label`
+
+Branch on equal ints
+
+## EQUp
+- `&address        &address        @label`
+- `&address        ptr             @label`
+- `ptr             &address        @label`
+- `ptr             ptr             @label`
+
+Branch on equal pointers
+
+## FLOf
+- `float(d)        #float`
+- `float(d)        float`
+
+Floor of float. Notice that there is no ceil instruction, but ceil is equivalent to -floor(-x).
+
+## FORi
+- `int(d)          #int            @label`
+- `int(d)          int             @label`
+
+Increment `int(d)` and branch to `@label` if it is less than `#int` / `int`
+
+## FORp
+- `ptr(d)          &address        @label`
+- `ptr(d)          ptr             @label`
+
+Increment `ptr(d)` and branch to `@label` if it is less than `&address` / `ptr`
+
+## FUNC
+
+Declares the beginning of a new function. Any previous function must have ended with either RETU or GOTO.
+
+## GEQf
+- `#float          #float          @label`
+- `#float          float           @label`
+- `float           #float          @label`
+- `float           float           @label`
+
+Branch on greater or equal float
+
+## GEQi
+- `#int            #int            @label`
+- `#int            int             @label`
+- `int             #int            @label`
+- `int             int             @label`
+
+Branch on greater or equal int
+
+## GEQp
+- `&address        &address        @label`
+- `&address        ptr             @label`
+- `ptr             &address        @label`
+- `ptr             ptr             @label`
+
+Branch on greater or equal pointer
+
+## GETL
+- `var(d)          var             int`
+
+Get local variable `var` (any type) with offset `int`
+
+## GLOB
+- `*size`
+
+Declare a global (writable) data section / array `*size` defines the size of the section (in number of words). You may
+optionally want to define the initial data with
+
+## GOTO
+- `@label`
+
+Unconditionally branch to `@label`
+
+## GRTf
+- `#float          #float          @label`
+- `#float          float           @label`
+- `float           #float          @label`
+- `float           float           @label`
+
+Branch on greater float
+
+## GRTi
+- `#int            #int            @label`
+- `#int            int             @label`
+- `int             #int            @label`
+- `int             int             @label`
+
+Branch on greater int
+
+## GRTp
+- `&address        &address        @label`
+- `&address        ptr             @label`
+- `ptr             &address        @label`
+- `ptr             ptr             @label`
+
+Branch on greater pointer
+
+## INPf
+
+
+## IORi
+- `int(d)          #int            #int`
+- `int(d)          #int            int`
+- `int(d)          int             #int`
+- `int(d)          int             int`
+
+Bitwise (inclusive) OR ints
+
+## LEQf
+- `#float          #float          @label`
+- `#float          float           @label`
+- `float           #float          @label`
+- `float           float           @label`
+
+Branch on less or equal float
+
+## LEQi
+- `#int            #int            @label`
+- `#int            int             @label`
+- `int             #int            @label`
+- `int             int             @label`
+
+Branch on less or equal int
+
+## LEQp
+- `&address        &address        @label`
+- `&address        ptr             @label`
+- `ptr             &address        @label`
+- `ptr             ptr             @label`
+
+Branch on less or equal pointer
+
+## LOCA
+- `*size`
+
+Declare a local data section / array (any type) `*size` defines the size of the section (in number of words). LOCA
+declarations must appear after a FUNC declaration but before any real instruction. You would not normally place LOCA
+before INP, OUT and PARA declarations either.
+
+## LOCf
+
+
+## LSSf
+- `#float          #float          @label`
+- `#float          float           @label`
+- `float           #float          @label`
+- `float           float           @label`
+
+Branch on less float
+
+## LSSi
+- `#int            #int            @label`
+- `#int            int             @label`
+- `int             #int            @label`
+- `int             int             @label`
+
+Branch on less int
+
+## LSSp
+- `&address        &address        @label`
+- `&address        ptr             @label`
+- `ptr             &address        @label`
+- `ptr             ptr             @label`
+
+Branch on less pointer
+
+## MODi
+- `int(d)          #int            #int`
+- `int(d)          #int            int`
+- `int(d)          int             #int`
+- `int(d)          int             int`
+
+Modulus two ints Note: this test assumes truncation towards zero (also for negative numbers) although this is not
+guaranteed by all C/C++ compilers. In case this test fails the C/C++ compiler that built the VM uses an unusual
+truncation mode and that would be a bad thing that would have to be fixed in an upgrade of GAZL. Modulus by 0 is
+considered illegal and should generate a run-time error (or compile-time error if 0 is a constant).
+
+## MOVE
+- `var(d)          var`
+
+
+## MULf
+- `float(d)        #float          #float`
+- `float(d)        #float          float`
+- `float(d)        float           #float`
+- `float(d)        float           float`
+
+Multiply two floats
+
+## MULi
+- `int(d)          #int            #int`
+- `int(d)          #int            int`
+- `int(d)          int             #int`
+- `int(d)          int             int`
+
+Multiply two ints
+
+## NEQf
+- `#float          #float          @label`
+- `#float          float           @label`
+- `float           #float          @label`
+- `float           float           @label`
+
+Branch on unequal floats
+
+## NEQi
+- `#int            #int            @label`
+- `#int            int             @label`
+- `int             #int            @label`
+- `int             int             @label`
+
+Branch on unequal ints
+
+## NEQp
+- `&address        &address        @label`
+- `&address        ptr             @label`
+- `ptr             &address        @label`
+- `ptr             ptr             @label`
+
+Branch on unequal pointers
+
+## NOOP
+
+No operation The NOOP instruction does nothing and will not consume any CPU cycles (it is effectively removed during
+assembly). It can be used to define a branching label without associating it with a specific instruction (since every
+line in
+
+## OUTf
+
+
+## PARA
+- `*size`
+
+Declare a local parameter section / array (any type, input or output) `*size` defines the size of the section (in number
+of words). PARA declarations must appear after a FUNC declaration but before any real instruction. You would also
+normally place PARA before LOC declarations.
+
+## POKE
+- `&address(w)     #const`
+- `&address(w)     var`
+- `&address(w)     int             #const`
+- `&address(w)     int             var`
+- `ptr             #const`
+- `ptr             #int            #const`
+- `ptr             #int            var`
+- `ptr             var`
+- `ptr             int             #const`
+- `ptr             int             var`
+
+Write a value to random access memory with an optional integer offset.
+
+## RETU
+
+Returns from function call.
+
+## SETL
+- `var(d)          int             #const`
+- `var(d)          int             var`
+
+Set local variable `var` (any type) with offset `int`
+
+## SHLi
+- `int(d)          #int            #int`
+- `int(d)          #int            int`
+- `int(d)          int             #int`
+- `int(d)          int             int`
+
+Shift bits left
+
+## SHRi
+- `int(d)          #int            #int`
+- `int(d)          #int            int`
+- `int(d)          int             #int`
+- `int(d)          int             int;`
+
+Shift bits right (arithmetic, i.e. replicate most significant bit and keep sign)
+
+## SHRu
+- `int(d)          #int            #int`
+- `int(d)          #int            int`
+- `int(d)          int             #int`
+- `int(d)          int             int`
+
+Shift bits right (logical, i.e. shift in zeroes and lose sign)
+
+## SUBf
+- `float(d)        #float          #float`
+- `float(d)        #float          float`
+- `float(d)        float           #float`
+- `float(d)        float           float`
+
+Subtract floats
+
+## SUBi
+- `int(d)          #int            #int`
+- `int(d)          #int            int`
+- `int(d)          int             #int`
+- `int(d)          int             int`
+
+Subtract ints
+
+## SUBp
+- `ptr(d)          &address        #int`
+- `ptr(d)          &address        int`
+- `ptr(d)          ptr             #int`
+- `ptr(d)          ptr             int`
+
+Subtract from pointer
+
+## SWCH
+- `int             *size           @label`
+
+Switch (multi-way branch) The switch instruction creates an internal switch table of a chosen size (`*size`) for quick
+multi-way branching on `int`. Case labels can be defined for integer values between 0 and `*size` - 1. Case labels
+should be formed by appending integer constants to `@label` with either a period `.` or `#` in between. Use `#` to allow
+any constant literal or compile-time variable. E.g. `@myLabel#'B'` and `@myLabel#<A>` are valid case labels. If `int` is
+out of range (< 0 or >= `*size`) or a case label is not defined, the default case label (`@label`) is used. This label
+is the only one that must be declared. The greater the `*size` the more memory will be required for the jump table, so
+avoid huge switch ranges.
+
+## TEMP
+- `*size`
+
+Like `GLOB` but hints that this section contains temporary data that can be ignored in case the GAZL host supports
+memory serialization.
+
+## XORi
+- `int(d)          #int            #int`
+- `int(d)          #int            int`
+- `int(d)          int             #int`
+- `int(d)          int             int`
+
+Bitwise XOR ints
+

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -149,3 +149,4 @@ A complete list of compile‑time opcodes is found in [`src/UnitTest.gazl`](../s
 ## Further Reference
 
 The file `src/UnitTest.gazl` acts as a living specification of the instruction set. It contains comments for nearly every operation and illustrates how globals, constants and memory operations work. Consult it when implementing new code or interfacing with the VM.
+For a condensed view, see the [Instruction Set](InstructionSet.md) reference which extracts these comment blocks into a single document.

--- a/tools/check_instructionset.py
+++ b/tools/check_instructionset.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+
+docs_file = Path('docs/InstructionSet.md')
+source_file = Path('src/UnitTest.gazl')
+
+docs_instructions = set()
+for line in docs_file.read_text().splitlines():
+    m = re.match(r"##\s+([A-Za-z0-9_]+)", line)
+    if m:
+        docs_instructions.add(m.group(1))
+
+source_instructions = set()
+for line in source_file.read_text().splitlines():
+    line = line.rstrip()
+    m = re.match(r"^;\s*!?\s*([A-Za-z0-9_]+)(?:\s{2,}|$)", line)
+    if m:
+        name = m.group(1)
+        if name.isupper():
+            source_instructions.add(name)
+
+missing = sorted(i for i in source_instructions if i not in docs_instructions)
+if missing:
+    print("Missing instructions in docs:", ', '.join(missing))
+    raise SystemExit(1)
+print("All instructions accounted for.")


### PR DESCRIPTION
## Summary
- add `tools/check_instructionset.py` to compare documented instructions
- script ensures that every opcode comment block in `src/UnitTest.gazl` has a corresponding entry in `docs/InstructionSet.md`

## Testing
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68755ec73ddc83328081a91bf480a577