### PR TITLE
Fix Impala docs about switch default case

### DIFF
--- a/docs/Impala.md
+++ b/docs/Impala.md
@@ -109,7 +109,8 @@ The `for` statement increments by one and stops before the upper bound. Other lo
 for (i = 0 to TEST_SIZE)
         mydata[i] = myrand()
 ```
-The `switch` statement tests a value within a range. If the expression is outside the given bounds the whole statement is skipped. Cases do not fall through, so no `break` is needed:
+The `switch` statement tests a value within a range. If the expression is outside the given bounds the
+**default** case is executed. Cases do not fall through, so no `break` is needed:
 
 ```impala
 switch (i == 0 to 10) {

--- a/impala/ImpalaDemo.impala
+++ b/impala/ImpalaDemo.impala
@@ -275,7 +275,8 @@ locals int a, int b, int c, int d, int e, int ok
        }
 done:
 
-       // Switch statement example
+       // Switch statement example. Values outside the range invoke the default case.
+       a = 7;                                                             // Triggers the default case
        switch (a == 4 to 6) {
                case 4: print("four\n");
                case 5: print("five\n");


### PR DESCRIPTION
## Summary
- clarify that out-of-range switch values execute the default case
- update demo code to show default-case execution

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68761ff40d888332bc46bcbcb023c1fe