### PR TITLE
Restore LICENSE and headers

### DIFF
--- a/impala/ImpalaDemo.impala
+++ b/impala/ImpalaDemo.impala
@@ -18,22 +18,15 @@
 	The Impala compiler is implemented using the PikaScript PEG parser. The compiler is slow and should be considered a
 	prototype implementation.
 
-	Impala is released under the "New Simplified BSD License". http://www.opensource.org/licenses/bsd-license.php
-	
-	Copyright (c) 2010-2012, NuEdge Development / Magnus Lidstroem
-	All rights reserved.
+	Impala is released under the BSD 2-Clause License.
 
-	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-	following conditions are met:
+	Copyright 2010-2012, NuEdge Development / Magnus Lidstroem
 
-	Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-	disclaimer. 
-	
-	Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
-	disclaimer in the documentation and/or other materials provided with the distribution. 
-	
-	Neither the name of the NuEdge Development nor the names of its contributors may be used to endorse or promote
-	products derived from this software without specific prior written permission.
+	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 	
 	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
 	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE

--- a/impala/impala.ppeg
+++ b/impala/impala.ppeg
@@ -25,22 +25,15 @@
 ##      The Impala compiler is implement using the PikaScript PEG parser. The compiler is slow and should be considered
 ##      a prototype implementation.
 ##
-##      Impala is released under the "New Simplified BSD License". http://www.opensource.org/licenses/bsd-license.php
-##      
-##      Copyright (c) 2010-2012, NuEdge Development / Magnus Lidstroem
-##      All rights reserved.
-##  
-##      Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-##      following conditions are met:
-##  
-##      Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-##      disclaimer. 
-##  
-##      Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
-##      disclaimer in the documentation and/or other materials provided with the distribution. 
-##  
-##      Neither the name of the NuEdge Development nor the names of its contributors may be used to endorse or promote
-##      products derived from this software without specific prior written permission.
+##      Impala is released under the BSD 2-Clause License.
+##
+##      Copyright 2010-2012, NuEdge Development / Magnus Lidstroem
+##
+##      Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+##
+##      1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+##
+##      2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 ##      
 ##      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
 ##      INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE

--- a/impala/tests/sources/ImpalaDemo.impala
+++ b/impala/tests/sources/ImpalaDemo.impala
@@ -18,22 +18,15 @@
 	The Impala compiler is implemented using the PikaScript PEG parser. The compiler is slow and should be considered a
 	prototype implementation.
 
-	Impala is released under the "New Simplified BSD License". http://www.opensource.org/licenses/bsd-license.php
-	
-	Copyright (c) 2010-2012, NuEdge Development / Magnus Lidstroem
-	All rights reserved.
+	Impala is released under the BSD 2-Clause License.
 
-	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-	following conditions are met:
+	Copyright 2010-2012, NuEdge Development / Magnus Lidstroem
 
-	Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-	disclaimer. 
-	
-	Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
-	disclaimer in the documentation and/or other materials provided with the distribution. 
-	
-	Neither the name of the NuEdge Development nor the names of its contributors may be used to endorse or promote
-	products derived from this software without specific prior written permission.
+	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+	1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 	
 	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
 	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE

--- a/impala/tests/sources/chess.impala
+++ b/impala/tests/sources/chess.impala
@@ -13,22 +13,15 @@
 	It is important to compile this code with NDEBUG defined for release builds. Due to the massive invariance testing,
 	the code is extremely slow otherwise.
 
-	Priyome is released under the "New Simplified BSD License". http://www.opensource.org/licenses/bsd-license.php
+	Priyome is released under the BSD 2-Clause License.
 
-	Copyright (c) 2013-2014, NuEdge Development / Magnus Lidstroem
-	All rights reserved.
+	Copyright 2013-2014, NuEdge Development / Magnus Lidstroem
 
-	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
-	following conditions are met:
+	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
-	Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-	disclaimer. 
-	
-	Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
-	disclaimer in the documentation and/or other materials provided with the distribution. 
-	
-	Neither the name of the NuEdge Development nor the names of its contributors may be used to endorse or promote
-	products derived from this software without specific prior written permission.
+	1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 	
 	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
 	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE

--- a/src/GAZL.cpp
+++ b/src/GAZL.cpp
@@ -1,15 +1,15 @@
 /*
 	GAZL is released under the BSD 2-Clause License.
 	
-	Copyright (c) 2010-2025, Magnus Lidström
+	Copyright 2010-2025, Magnus Lidström
 	
 	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 	following conditions are met:
 	
-	Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+	1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
 	disclaimer.
 	
-	Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+	2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
 	disclaimer in the documentation and/or other materials provided with the distribution.
 	
 	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,

--- a/src/GAZL.h
+++ b/src/GAZL.h
@@ -39,15 +39,15 @@
 
 	GAZL is released under the BSD 2-Clause License.
 
-	Copyright (c) 2010-2025, Magnus Lidström
+	Copyright 2010-2025, Magnus Lidström
 
 	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 	following conditions are met:
 
-	Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+	1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
 	disclaimer.
 
-	Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+	2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
 	disclaimer in the documentation and/or other materials provided with the distribution.
 
 	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,

--- a/tools/GAZLCmd.cpp
+++ b/tools/GAZLCmd.cpp
@@ -1,15 +1,15 @@
 /*
 	GAZL is released under the BSD 2-Clause License.
 	
-	Copyright (c) 2010-2025, Magnus Lidström
+	Copyright 2010-2025, Magnus Lidström
 	
 	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 	following conditions are met:
 	
-	Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+	1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
 	disclaimer.
 	
-	Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+	2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
 	disclaimer in the documentation and/or other materials provided with the distribution.
 	
 	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,


### PR DESCRIPTION
## Summary
- ensure LICENSE matches GitHub's BSD 2-Clause text
- update BSD 2-Clause license blocks in `impala/*.impala` and `impala.ppeg`

## Testing
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_6878ee8e543c8332866f45500b9a41cd