### PR TITLE
Add libFuzzer build helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ Both the **beta** and **release** targets are compiled with optimizations enable
 - `build.sh` / `build.cmd` – build all tools and run the full test + demo sequence
 - `tools/buildGAZLCmd.sh` / `.cmd` – build just `GAZLCmd` (VM executable)
 - `tools/BuildImpala.sh` / `.cmd` – build `PikaCmd` and stage the compiler into `output/`
+- `tools/build_gazl_fuzz.sh` / `.cmd` – build libFuzzer harness for `GAZLCmd`
+
+## Building the fuzz target
+
+The `tools/build_gazl_fuzz.sh` script compiles `tools/GAZLCmd.cpp` using clang and libFuzzer:
+
+```bash
+bash tools/build_gazl_fuzz.sh
+```
+
+The resulting binary is placed in `output/GAZLFuzz` and can be run with a directory containing seed inputs:
+
+```bash
+./output/GAZLFuzz corpus/
+```
+
+On macOS the default clang from Xcode does not ship the libFuzzer runtime.
+Install the `llvm` package via Homebrew and invoke the script with that compiler:
+
+```bash
+CPP_COMPILER=$(brew --prefix llvm)/bin/clang++ bash tools/build_gazl_fuzz.sh
+```
 
 ## Documentation
 

--- a/tools/GAZLCmd.cpp
+++ b/tools/GAZLCmd.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <cmath>
 #include <cstdlib>
+#include <stdint.h>
 #include <string>
 #include "../src/GAZL.h"
 

--- a/tools/build_gazl_fuzz.cmd
+++ b/tools/build_gazl_fuzz.cmd
@@ -1,0 +1,13 @@
+@ECHO OFF
+SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
+CD /D %~dp0
+IF NOT EXIST ..\output MKDIR ..\output
+IF "%CPP_COMPILER%"=="" SET CPP_COMPILER=clang++
+IF "%CPP_OPTIONS%"=="" SET CPP_OPTIONS=-fsanitize=fuzzer,address -DLIBFUZZ
+%CPP_COMPILER% -pipe -fvisibility=hidden -fvisibility-inlines-hidden ^
+		-Wno-trigraphs -Wreturn-type -Wunused-variable -Os -DNDEBUG %CPP_OPTIONS% ^
+		-I.. GAZLCmd.cpp ..\src\GAZL.cpp -o ..\output\GAZLFuzz.exe || GOTO error
+ATTRIB +x ..\output\GAZLFuzz.exe >NUL 2>&1
+EXIT /b 0
+:error
+EXIT /b %ERRORLEVEL%

--- a/tools/build_gazl_fuzz.sh
+++ b/tools/build_gazl_fuzz.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"
+mkdir -p ../output
+CPP_COMPILER=${CPP_COMPILER:-clang++}
+CPP_OPTIONS=${CPP_OPTIONS:-"-fsanitize=fuzzer,address -DLIBFUZZ"}
+CPP_COMPILER="$CPP_COMPILER" CPP_OPTIONS="$CPP_OPTIONS" \
+		bash BuildCpp.sh release native ../output/GAZLFuzz \
+		-I.. GAZLCmd.cpp ../src/GAZL.cpp
+chmod +x ../output/GAZLFuzz 2>/dev/null || true


### PR DESCRIPTION
## Summary
- add build_gazl_fuzz.sh/.cmd to compile GAZLCmd with libFuzzer
- document fuzz-target build and usage in README
- include `<stdint.h>` so libFuzzer harness compiles

## Testing
- `bash tools/build_gazl_fuzz.sh`
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_688fa32d32c48332a433bac6dd73c401