### PR TITLE
Ignore generated command executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 /output
 impala/GAZLCmd
+impala/GAZLCmd.exe
 externals/PikaCmd/PikaCmd
+externals/PikaCmd/PikaCmd.exe
 /projects/build


### PR DESCRIPTION
## Summary
- ignore generated `GAZLCmd.exe` and `PikaCmd.exe` executables

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a9ae2684088332b801c368abb757d4