### PR TITLE
Remove chmod from Impala build script

### DIFF
--- a/tools/BuildImpala.sh
+++ b/tools/BuildImpala.sh
@@ -3,8 +3,7 @@ set -e -o pipefail -u
 cd "$(dirname "$0")"
 
 # Build PikaCmd
-# Ensure sub script is executable since it's invoked directly
-(cd ../externals/PikaCmd && chmod +x BuildCpp.sh && bash BuildPikaCmd.sh)
+(cd ../externals/PikaCmd && bash BuildPikaCmd.sh)
 
 # Copy PikaCmd to output so Impala can run from there
 if [ -f ../externals/PikaCmd/PikaCmd ]; then


### PR DESCRIPTION
## Summary
- invoke PikaCmd build script with bash in `BuildImpala.sh`, removing the need to chmod `BuildCpp.sh`

## Testing
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a9ae228a588332b8b4d6f6f076221a