### PR TITLE
Add origin metadata to Impala signature comments

### DIFF
--- a/docs/Impala.md
+++ b/docs/Impala.md
@@ -193,16 +193,19 @@ The compiler can emit human-readable signature comments alongside the
 `.gazl` instructions it produces. Each definition, global, and call site
 is annotated with its expected `{int, float, ptr, funcptr, void}`
 categories so cross-unit mismatches can be caught after concatenating
-multiple files. Functions that omit an explicit `returns` clause map the
-compiler's implicit `?` type to `void` in the comment stream, keeping the
-metadata aligned with the language's behaviour.
+multiple files. When the compiler knows the original source location it
+appends `@ path:line:column` to the end of each comment, allowing the
+validator to cite precise spans in diagnostics. Functions that omit an
+explicit `returns` clause map the compiler's implicit `?` type to `void`
+in the comment stream, keeping the metadata aligned with the language's
+behaviour.
 
 ```gazl
 ; signatures version=1
-FUNC showoff         ; signature func showoff(ptr text) -> void
-LOC demoFloat        ; signature global demoFloat : float
-CALL showoff         ; expects showoff(ptr) -> void
-; signature extern func print(ptr message) -> void
+FUNC showoff         ; signature func showoff(ptr text) -> void @ ImpalaDemo.impala:42:1
+LOC demoFloat        ; signature global demoFloat : float @ ImpalaDemo.impala:9:1
+CALL showoff         ; expects showoff(ptr) -> void @ ImpalaDemo.impala:49:9
+; signature extern func print(ptr message) -> void @ ImpalaDemo.impala:3:1
 ```
 
 Run the validator to compare the expectations recorded by callers with

--- a/docs/ImpalaTypeCheckingSpec.md
+++ b/docs/ImpalaTypeCheckingSpec.md
@@ -112,19 +112,19 @@ However, those `ArgsDecl` entries are discarded once `declare` runs, so `FuncCal
     - [x] Attach signature metadata for function definitions, globals, constants, and call sites.
     - [x] Extend extern declarations to emit or preserve compatible signature comments.
   - [x] Persist the ordered parameter list from `ArgsDecl` in each function symbol, compare it against the call-site operands inside `FuncCall`, and invoke `typeError` when intra-unit calls disagree on category or arity before emitting the `()` instruction.【F:impala/jspeg/impala.jspeg†L1006-L1055】【F:impala/jspeg/impala.jspeg†L1719-L1738】【F:impala/jspeg/impala.jspeg†L1834-L1916】
-  - [ ] Teach the emitter to format argument lists and return categories using the `{int, float, ptr, funcptr, void}` vocabulary (while preserving the internal `i/f/p/F/?` mapping) and to include positional source spans where available for better diagnostics.
+  - [x] Teach the emitter to format argument lists and return categories using the `{int, float, ptr, funcptr, void}` vocabulary (while preserving the internal `i/f/p/F/?` mapping) and to include positional source spans where available for better diagnostics.
     - [x] Format function signatures, call expectations, and global annotations using the shared vocabulary helpers and stable parameter ordering.
-    - [ ] Thread explicit source-span markers through the emitted comments so downstream tooling can cite the original Impala locations when reporting validation errors.
-      - [ ] Expose a stable `sourceName` option on the compiler entry points and store it alongside the existing `sourceCode`/`sourceOffset` metadata for declarations and call sites.
-      - [ ] Derive 1-based line/column coordinates from the stored offsets and stash a formatted origin string on each signature or call expectation.
-      - [ ] Extend the signature-formatting helpers to append `@ <origin>` tokens to inline and standalone comments when origin data exists.
+    - [x] Thread explicit source-span markers through the emitted comments so downstream tooling can cite the original Impala locations when reporting validation errors.
+      - [x] Expose a stable `sourceName` option on the compiler entry points and store it alongside the existing `sourceCode`/`sourceOffset` metadata for declarations and call sites.
+      - [x] Derive 1-based line/column coordinates from the stored offsets and stash a formatted origin string on each signature or call expectation.
+      - [x] Extend the signature-formatting helpers to append `@ <origin>` tokens to inline and standalone comments when origin data exists.
 - [ ] **Comment schema**
   - [x] Lock down the comment grammar (for example, `FUNC foo    ; signature func foo(int a, ptr b) -> int` and `CALL foo    ; expects foo(int, ptr) -> int`) and document it alongside the Impala assembly reference so downstream tooling knows how to parse it.
   - [x] Ensure comments never break layout-sensitive sections by routing them through the same helpers that already insert `;`-prefixed notes when `-g` is enabled today.
 - [ ] **Validator tool**
   - [x] Create `tools/gazl-validate.{js,cmd}` (mirroring existing script conventions) that parses the signature comments, performs the matching described above, and exits non-zero on fatal mismatches unless `--warn-only` is passed.【F:tools/gazl-validate.js†L1-L338】【F:tools/gazl-validate.js†L486-L679】
   - [x] Add integration to `build.sh` behind an environment toggle (`GAZL_VALIDATE=1`), letting CI enable it without slowing local builds immediately.【F:build.sh†L18-L33】【F:build.cmd†L27-L42】
-  - [ ] Parse optional `@ <origin>` markers so mismatch diagnostics can cite both the importer and exporter spans when metadata is available.
+  - [x] Parse optional `@ <origin>` markers so mismatch diagnostics can cite both the importer and exporter spans when metadata is available.
 - [x] **Documentation & onboarding**
   - [x] Update `docs/Impala.md` and add a quickstart snippet showing how to run the validator on two sample units.
   - [x] Document how implicit void returns (`?`) in the compiler map to the signature comment’s `void` category so users understand the translation.【F:impala/jspeg/impala.jspeg†L1489-L1524】

--- a/impala/jspeg/impala.jspeg
+++ b/impala/jspeg/impala.jspeg
@@ -139,6 +139,7 @@
     var $$parser.ZEROES = {};
     var $$parser.TYPE_SUFFIXES  = {};
     var $$parser.VERBOSE_TYPES  = {};
+    var $$parser.sourceName = undefined;
     var $$parser.metacode = [];
     var $$parser.strings = { s:[], a:[] };
     var $$parser.labelCounter = 0;
@@ -236,7 +237,60 @@
         return parts.join(', ');
     }
 
-    $$parser.formatFunctionSignatureComment = function (name, signature, role) {
+    function computeOrigin(sourceName, sourceCode, sourceOffset) {
+        if (!sourceCode || sourceOffset == null) {
+            return undefined;
+        }
+
+        var offset = sourceOffset;
+        if (offset < 0) {
+            return undefined;
+        }
+        if (offset > sourceCode.length) {
+            offset = sourceCode.length;
+        }
+
+        var line = 1;
+        var column = 1;
+        for (var idx = 0; idx < offset; ++idx) {
+            var ch = sourceCode.charAt(idx);
+            if (ch === '\r') {
+                if (idx + 1 < sourceCode.length && sourceCode.charAt(idx + 1) === '\n') {
+                    idx += 1;
+                }
+                line += 1;
+                column = 1;
+                continue;
+            }
+            if (ch === '\n') {
+                line += 1;
+                column = 1;
+                continue;
+            }
+            column += 1;
+        }
+
+        var origin = line + ':' + column;
+        if (sourceName) {
+            origin = sourceName + ':' + origin;
+        }
+        return origin;
+    }
+
+    function appendOrigin(comment, sourceName, sourceCode, sourceOffset) {
+        if (!comment) {
+            return comment;
+        }
+
+        var origin = computeOrigin(sourceName, sourceCode, sourceOffset);
+        if (origin) {
+            return comment + ' @ ' + origin;
+        }
+        return comment;
+    }
+
+    $$parser.formatFunctionSignatureComment = function (name, signature, role,
+                                                         sourceName, sourceCode, sourceOffset) {
         if (!signature) {
             return undefined;
         }
@@ -246,10 +300,16 @@
         var returnType = signatureReturnCategory(signature.returns, hasReturn);
         var kind = (role ? role : 'func');
 
-        return 'signature ' + kind + ' ' + name + '(' + paramsText + ') -> ' + returnType;
+        var originName = (sourceName !== undefined ? sourceName : (signature ? signature.sourceName : undefined));
+        var originCode = (sourceCode !== undefined ? sourceCode : (signature ? signature.sourceCode : undefined));
+        var originOffset = (sourceOffset !== undefined ? sourceOffset : (signature ? signature.sourceOffset : undefined));
+
+        return appendOrigin('signature ' + kind + ' ' + name + '(' + paramsText + ') -> ' + returnType,
+                            originName, originCode, originOffset);
     };
 
-    $$parser.formatCallExpectationComment = function (name, signature, actualTypes, callResultType) {
+    $$parser.formatCallExpectationComment = function (name, signature, actualTypes, callResultType,
+                                                      sourceName, sourceCode, sourceOffset) {
         var label = (name || 'function');
         var paramsText;
         var hasSignature = !!(signature && signature.params);
@@ -272,7 +332,8 @@
         }
         var returnType = signatureReturnCategory(returnCode, !!signature);
 
-        return 'expects ' + label + '(' + paramsText + ') -> ' + returnType;
+        return appendOrigin('expects ' + label + '(' + paramsText + ') -> ' + returnType,
+                            sourceName, sourceCode, sourceOffset);
     };
 
     $$parser.emitFunctionSignature = function (name) {
@@ -304,7 +365,8 @@
         }
     }
 
-    $$parser.formatGlobalSignatureComment = function (section, name, type, size, flavor) {
+    $$parser.formatGlobalSignatureComment = function (section, name, type, size, flavor,
+                                                      sourceName, sourceCode, sourceOffset) {
         if (!name) {
             return undefined;
         }
@@ -313,11 +375,13 @@
 
         if (type === 'A') {
             var extent = (size !== undefined ? '[' + size + ']' : '[]');
-            return 'signature ' + prefix + 'array ' + name + extent + ' : unknown';
+            return appendOrigin('signature ' + prefix + 'array ' + name + extent + ' : unknown',
+                                sourceName, sourceCode, sourceOffset);
         }
 
-        return 'signature ' + prefix + signatureRoleForSection(section) + ' ' +
-               name + ' : ' + signatureParamCategory(type);
+        return appendOrigin('signature ' + prefix + signatureRoleForSection(section) + ' ' +
+                            name + ' : ' + signatureParamCategory(type),
+                            sourceName, sourceCode, sourceOffset);
     };
 
     function emitStandaloneSignatureComment(comment) {
@@ -330,12 +394,13 @@
         }
     }
 
-    $$parser.formatConstSignatureComment = function (name, type) {
+    $$parser.formatConstSignatureComment = function (name, type, sourceName, sourceCode, sourceOffset) {
         if (!name) {
             return undefined;
         }
 
-        return 'signature const ' + name + ' : ' + signatureParamCategory(type);
+        return appendOrigin('signature const ' + name + ' : ' + signatureParamCategory(type),
+                            sourceName, sourceCode, sourceOffset);
     };
 
     /* 4  label & metacode helpers */
@@ -1205,7 +1270,9 @@
                 kind: kind,
                 signature: prev && prev.signature,
                 sourceCode: sourceCode,
-                sourceOffset: sourceOffset
+                sourceOffset: sourceOffset,
+                sourceName: ($$parser.sourceName !== undefined ? $$parser.sourceName
+                                                               : (prev ? prev.sourceName : undefined))
             };
         }
     };
@@ -1656,6 +1723,7 @@ FuncDecl    <-  FUNCTION _ id:Identifier '('_                         {
                                                                              entry.signature.returnName = undefined;
                                                                              entry.signature.sourceCode = $$s;
                                                                              entry.signature.sourceOffset = $$i;
+                                                                             entry.signature.sourceName = $$parser.sourceName;
                                                                          }
                                                                      }
                 inp:ArgsDecl ')'_ 
@@ -1766,40 +1834,53 @@ ExternDecl  <-  EXTERN _                                              { $$.scope
                                                                                  if (!signature) {
                                                                                      signature = entry.signature = {};
                                                                                  }
+                                                                                 if (signature.sourceName === undefined) {
+                                                                                     signature.sourceName = $$parser.sourceName;
+                                                                                 }
                                                                                  if (signature.sourceCode === undefined) {
                                                                                      signature.sourceCode = $$s;
                                                                                      signature.sourceOffset = $$i;
+                                                                                     signature.sourceName = $$parser.sourceName;
                                                                                  }
-                                                                             }
+                                                                            }
 
-                                                                             var role = ($$.type === 'N' ? 'extern native' : 'extern func');
-                                                                             var prototypeComment = $$parser.formatFunctionSignatureComment(
-                                                                                 $$.name,
-                                                                                 signature,
-                                                                                 role
-                                                                             );
+                                                                            var role = ($$.type === 'N' ? 'extern native' : 'extern func');
+                                                                            var prototypeComment = $$parser.formatFunctionSignatureComment(
+                                                                                $$.name,
+                                                                                signature,
+                                                                                role,
+                                                                                $$parser.sourceName,
+                                                                                $$s,
+                                                                                $$i
+                                                                            );
 
-                                                                             if (!prototypeComment) {
-                                                                                 prototypeComment = $$parser.formatFunctionSignatureComment(
-                                                                                     $$.name,
-                                                                                     { params: [], returns: undefined },
-                                                                                     role
-                                                                                 );
-                                                                             }
+                                                                            if (!prototypeComment) {
+                                                                                prototypeComment = $$parser.formatFunctionSignatureComment(
+                                                                                    $$.name,
+                                                                                    { params: [], returns: undefined },
+                                                                                    role,
+                                                                                    $$parser.sourceName,
+                                                                                    $$s,
+                                                                                    $$i
+                                                                                );
+                                                                            }
 
                                                                              emitStandaloneSignatureComment(prototypeComment);
                                                                          } else if ($$.scope === 'globals') {
-                                                                             emitStandaloneSignatureComment(
-                                                                                 $$parser.formatGlobalSignatureComment(
-                                                                                     'GLOB',
-                                                                                     $$.name,
-                                                                                     $$.type,
-                                                                                     $$.size,
-                                                                                     'extern'
-                                                                                 )
-                                                                             );
-                                                                         }
-                                                                     }
+                                                                            emitStandaloneSignatureComment(
+                                                                                $$parser.formatGlobalSignatureComment(
+                                                                                    'GLOB',
+                                                                                    $$.name,
+                                                                                    $$.type,
+                                                                                    $$.size,
+                                                                                    'extern',
+                                                                                    $$parser.sourceName,
+                                                                                    $$s,
+                                                                                    $$i
+                                                                                )
+                                                                            );
+                                                                        }
+                                                                    }
 
 ConstDecl   <-  CONST _ type:BASE_TYPE _                              {
                                                                          $t  = $$parser.CASTS_TO_TYPES[$type];
@@ -1808,13 +1889,19 @@ ConstDecl   <-  CONST _ type:BASE_TYPE _                              {
                                                                      }
                  id:Identifier
                  (   '=' _ x:Expr                                     {
-                                                                             $$parser.declare(
-                                                                                 '! DEF?', 'defines',
-                                                                                 $id, $t, true,
-                                                                                 $$parser.makeConstant($x, $t, $$s, $$i),
-                                                                                 $$s, $$i,
-                                                                                 $$parser.formatConstSignatureComment($id, $t)
-                                                                             );
+                                                                            $$parser.declare(
+                                                                                '! DEF?', 'defines',
+                                                                                $id, $t, true,
+                                                                                $$parser.makeConstant($x, $t, $$s, $$i),
+                                                                                $$s, $$i,
+                                                                                $$parser.formatConstSignatureComment(
+                                                                                    $id,
+                                                                                    $t,
+                                                                                    $$parser.sourceName,
+                                                                                    $$s,
+                                                                                    $$i
+                                                                                )
+                                                                            );
                                                                          }
                  /                                                     {
                                                                              $$parser.declare(
@@ -1845,28 +1932,46 @@ GlobalDecl  <-  (   GLOBAL                                            { $section
                                                                          }
                          ( '=' _ x:Expr                               { $init = $$parser.makeConstant($x, $v.type, $$s, $$i); } )?
                                                                        {
-                                                                             $$parser.declare(
-                                                                                 'DAT?', 'globals',
-                                                                                 $v.name,
-                                                                                 $v.type,
-                                                                                 ($section === 'CNST'),
-                                                                                 $init,
-                                                                                 $$s, $$i,
-                                                                                 $$parser.formatGlobalSignatureComment($section, $v.name, $v.type)
-                                                                             );
+                                                                            $$parser.declare(
+                                                                                'DAT?', 'globals',
+                                                                                $v.name,
+                                                                                $v.type,
+                                                                                ($section === 'CNST'),
+                                                                                $init,
+                                                                                $$s, $$i,
+                                                                                $$parser.formatGlobalSignatureComment(
+                                                                                    $section,
+                                                                                    $v.name,
+                                                                                    $v.type,
+                                                                                    undefined,
+                                                                                    undefined,
+                                                                                    $$parser.sourceName,
+                                                                                    $$s,
+                                                                                    $$i
+                                                                                )
+                                                                            );
                                                                          }
 
                    / # array ----------------------------------------------
                      a:ArrayDecl                                      {
-                                                                             $$parser.declare(
-                                                                                 $section, 'globals',
-                                                                                 $a.name,
-                                                                                 'A',
-                                                                                 ($section === 'CNST'),
-                                                                                 '*' + $a.size,
-                                                                                 $$s, $$i,
-                                                                                 $$parser.formatGlobalSignatureComment($section, $a.name, 'A', $a.size)
-                                                                             );
+                                                                            $$parser.declare(
+                                                                                $section, 'globals',
+                                                                                $a.name,
+                                                                                'A',
+                                                                                ($section === 'CNST'),
+                                                                                '*' + $a.size,
+                                                                                $$s, $$i,
+                                                                                $$parser.formatGlobalSignatureComment(
+                                                                                    $section,
+                                                                                    $a.name,
+                                                                                    'A',
+                                                                                    $a.size,
+                                                                                    undefined,
+                                                                                    $$parser.sourceName,
+                                                                                    $$s,
+                                                                                    $$i
+                                                                                )
+                                                                            );
                                                                          }
                          ( '=' _ d:InitList )?
                  )
@@ -2102,7 +2207,10 @@ FuncCall    <-  '('_                               { if (!$$parser.dry) {
                                                            calleeName,
                                                            signature,
                                                            $$.types,
-                                                           callResultType
+                                                           callResultType,
+                                                           $$parser.sourceName,
+                                                           $$s,
+                                                           $$i
                                                        );
                                                        if (callComment) {
                                                            $$parser.emit(';', undefined, callComment, undefined, undefined);

--- a/impala/jspeg/impalaCompiler.js
+++ b/impala/jspeg/impalaCompiler.js
@@ -1,5 +1,5 @@
 var $$parser = {};
-var impalaCompiler = (function(_s) {
+var impalaCompilerImpl = (function(_s) {
 {
     /**
      * map(target, k1, v1, k2, v2, …)
@@ -137,6 +137,7 @@ var impalaCompiler = (function(_s) {
     var ZEROES = {};
     var TYPE_SUFFIXES  = {};
     var VERBOSE_TYPES  = {};
+    var sourceName = undefined;
     var metacode = [];
     var strings = { s:[], a:[] };
     var labelCounter = 0;
@@ -234,7 +235,60 @@ var impalaCompiler = (function(_s) {
         return parts.join(', ');
     }
 
-    formatFunctionSignatureComment = function (name, signature, role) {
+    function computeOrigin(sourceName, sourceCode, sourceOffset) {
+        if (!sourceCode || sourceOffset == null) {
+            return undefined;
+        }
+
+        var offset = sourceOffset;
+        if (offset < 0) {
+            return undefined;
+        }
+        if (offset > sourceCode.length) {
+            offset = sourceCode.length;
+        }
+
+        var line = 1;
+        var column = 1;
+        for (var idx = 0; idx < offset; ++idx) {
+            var ch = sourceCode.charAt(idx);
+            if (ch === '\r') {
+                if (idx + 1 < sourceCode.length && sourceCode.charAt(idx + 1) === '\n') {
+                    idx += 1;
+                }
+                line += 1;
+                column = 1;
+                continue;
+            }
+            if (ch === '\n') {
+                line += 1;
+                column = 1;
+                continue;
+            }
+            column += 1;
+        }
+
+        var origin = line + ':' + column;
+        if (sourceName) {
+            origin = sourceName + ':' + origin;
+        }
+        return origin;
+    }
+
+    function appendOrigin(comment, sourceName, sourceCode, sourceOffset) {
+        if (!comment) {
+            return comment;
+        }
+
+        var origin = computeOrigin(sourceName, sourceCode, sourceOffset);
+        if (origin) {
+            return comment + ' @ ' + origin;
+        }
+        return comment;
+    }
+
+    formatFunctionSignatureComment = function (name, signature, role,
+                                                         sourceName, sourceCode, sourceOffset) {
         if (!signature) {
             return undefined;
         }
@@ -244,10 +298,16 @@ var impalaCompiler = (function(_s) {
         var returnType = signatureReturnCategory(signature.returns, hasReturn);
         var kind = (role ? role : 'func');
 
-        return 'signature ' + kind + ' ' + name + '(' + paramsText + ') -> ' + returnType;
+        var originName = (sourceName !== undefined ? sourceName : (signature ? signature.sourceName : undefined));
+        var originCode = (sourceCode !== undefined ? sourceCode : (signature ? signature.sourceCode : undefined));
+        var originOffset = (sourceOffset !== undefined ? sourceOffset : (signature ? signature.sourceOffset : undefined));
+
+        return appendOrigin('signature ' + kind + ' ' + name + '(' + paramsText + ') -> ' + returnType,
+                            originName, originCode, originOffset);
     };
 
-    formatCallExpectationComment = function (name, signature, actualTypes, callResultType) {
+    formatCallExpectationComment = function (name, signature, actualTypes, callResultType,
+                                                      sourceName, sourceCode, sourceOffset) {
         var label = (name || 'function');
         var paramsText;
         var hasSignature = !!(signature && signature.params);
@@ -270,7 +330,8 @@ var impalaCompiler = (function(_s) {
         }
         var returnType = signatureReturnCategory(returnCode, !!signature);
 
-        return 'expects ' + label + '(' + paramsText + ') -> ' + returnType;
+        return appendOrigin('expects ' + label + '(' + paramsText + ') -> ' + returnType,
+                            sourceName, sourceCode, sourceOffset);
     };
 
     emitFunctionSignature = function (name) {
@@ -302,7 +363,8 @@ var impalaCompiler = (function(_s) {
         }
     }
 
-    formatGlobalSignatureComment = function (section, name, type, size, flavor) {
+    formatGlobalSignatureComment = function (section, name, type, size, flavor,
+                                                      sourceName, sourceCode, sourceOffset) {
         if (!name) {
             return undefined;
         }
@@ -311,11 +373,13 @@ var impalaCompiler = (function(_s) {
 
         if (type === 'A') {
             var extent = (size !== undefined ? '[' + size + ']' : '[]');
-            return 'signature ' + prefix + 'array ' + name + extent + ' : unknown';
+            return appendOrigin('signature ' + prefix + 'array ' + name + extent + ' : unknown',
+                                sourceName, sourceCode, sourceOffset);
         }
 
-        return 'signature ' + prefix + signatureRoleForSection(section) + ' ' +
-               name + ' : ' + signatureParamCategory(type);
+        return appendOrigin('signature ' + prefix + signatureRoleForSection(section) + ' ' +
+                            name + ' : ' + signatureParamCategory(type),
+                            sourceName, sourceCode, sourceOffset);
     };
 
     function emitStandaloneSignatureComment(comment) {
@@ -328,12 +392,13 @@ var impalaCompiler = (function(_s) {
         }
     }
 
-    formatConstSignatureComment = function (name, type) {
+    formatConstSignatureComment = function (name, type, sourceName, sourceCode, sourceOffset) {
         if (!name) {
             return undefined;
         }
 
-        return 'signature const ' + name + ' : ' + signatureParamCategory(type);
+        return appendOrigin('signature const ' + name + ' : ' + signatureParamCategory(type),
+                            sourceName, sourceCode, sourceOffset);
     };
 
     /* 4  label & metacode helpers */
@@ -1203,7 +1268,9 @@ var impalaCompiler = (function(_s) {
                 kind: kind,
                 signature: prev && prev.signature,
                 sourceCode: sourceCode,
-                sourceOffset: sourceOffset
+                sourceOffset: sourceOffset,
+                sourceName: (sourceName !== undefined ? sourceName
+                                                               : (prev ? prev.sourceName : undefined))
             };
         }
     };
@@ -1615,12 +1682,12 @@ var impalaCompiler = (function(_s) {
         }
     };
 };function root($){return (function(){var _b=_i;return _($)&&(function(){ start(); ; return true})()&&((function(){while((function(){var _b=_i;return FuncDecl($)||(_im=(_i>_im?_i:_im),_i=_b,false)||ExternDecl($)||(_im=(_i>_im?_i:_im),_i=_b,false)||ConstDecl($)||(_im=(_i>_im?_i:_im),_i=_b,false)||GlobalDecl($)||(_im=(_i>_im?_i:_im),_i=_b,false)||(_s[_i]===";")&&(++_i,true)&&_($)||(_im=(_i>_im?_i:_im),_i=_b,false)})());})(),true)&&(function(){var _l=_i,_x=(!!_s[_i])&&(++_i,true);_i=_l;return !_x})()&&(function(){ end(); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
-function FuncDecl($){var $id={},$inp={},$out={},$,$loc={};return (function(){var _b=_i;return FUNCTION($)&&_($)&&Identifier($id)&&(_s[_i]==="(")&&(++_i,true)&&_($)&&(function(){ assert(validateStock('%')); assert(validateStock('<')); output(''); output(';-----------------------------------------------------------------------------'); /* declare the function symbol */ declare( undefined, 'functions', $id._, 'U', true, undefined, _s, _i ); var entry = symbols.functions[$id._]; if (entry) { if (!entry.signature) { entry.signature = {}; } entry.signature.params = []; entry.signature.returns = '?'; entry.signature.returnName = undefined; entry.signature.sourceCode = _s; entry.signature.sourceOffset = _i; } ; return true})()&&ArgsDecl($inp)&&(_s[_i]===")")&&(++_i,true)&&_($)&&(function(){var _b=_i;return RETURNS($)&&_($)&&VarDecl($out)&&(function(){ declare( 'OUT?', 'locals', '$' + $out.name, $out.type, false, ($out.size !== undefined ? '*' + $out.size : undefined), _s, _i ); var entry = symbols.functions[$id._]; if (entry && entry.signature) { entry.signature.returns = $out.type; entry.signature.returnName = $out.name; } ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)||(function(){ /* implicit 1-word return */ declare( 'PARA', 'locals', undefined, '?', false, '*1', _s, _i ); var entry = symbols.functions[$id._]; if (entry && entry.signature) { entry.signature.returns = '?'; entry.signature.returnName = undefined; } ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()&&(function(){ /* declare input parameters */ var entry = symbols.functions[$id._]; if (entry && entry.signature) { entry.signature.params = []; for (var idx = 0; idx < $inp.n; ++idx) { var param = $inp._[idx]; entry.signature.params.push({ type: param.type, name: param.name, size: param.size }); } } emitFunctionSignature($id._); iterate($inp._, function (p) { declare( 'INP?', 'locals', '$' + p.name, p.type, true, (p.size !== undefined ? '*' + p.size : undefined), _s, _i ); }); ; return true})()&&((function(){var _b=_i;return LOCALS($)&&_($)&&LocalsDecl($loc)&&(function(){ iterate($loc._, function (v) { declare( 'LOC?', 'locals', '$' + v.name, v.type, false, (v.size !== undefined ? '*' + v.size : undefined), _s, _i ); }); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})(),true)&&(function(){ output(';-----------------------------------------------------------------------------'); ; return true})()&&Block($)&&(function(){ /* wrap-up body */ processBranches(); emit('--^', undefined, undefined, undefined, undefined); flushMetaCode('\t'); prune(symbols.locals); labelCounter = 0; output(''); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
+function FuncDecl($){var $id={},$inp={},$out={},$,$loc={};return (function(){var _b=_i;return FUNCTION($)&&_($)&&Identifier($id)&&(_s[_i]==="(")&&(++_i,true)&&_($)&&(function(){ assert(validateStock('%')); assert(validateStock('<')); output(''); output(';-----------------------------------------------------------------------------'); /* declare the function symbol */ declare( undefined, 'functions', $id._, 'U', true, undefined, _s, _i ); var entry = symbols.functions[$id._]; if (entry) { if (!entry.signature) { entry.signature = {}; } entry.signature.params = []; entry.signature.returns = '?'; entry.signature.returnName = undefined; entry.signature.sourceCode = _s; entry.signature.sourceOffset = _i; entry.signature.sourceName = sourceName; } ; return true})()&&ArgsDecl($inp)&&(_s[_i]===")")&&(++_i,true)&&_($)&&(function(){var _b=_i;return RETURNS($)&&_($)&&VarDecl($out)&&(function(){ declare( 'OUT?', 'locals', '$' + $out.name, $out.type, false, ($out.size !== undefined ? '*' + $out.size : undefined), _s, _i ); var entry = symbols.functions[$id._]; if (entry && entry.signature) { entry.signature.returns = $out.type; entry.signature.returnName = $out.name; } ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)||(function(){ /* implicit 1-word return */ declare( 'PARA', 'locals', undefined, '?', false, '*1', _s, _i ); var entry = symbols.functions[$id._]; if (entry && entry.signature) { entry.signature.returns = '?'; entry.signature.returnName = undefined; } ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()&&(function(){ /* declare input parameters */ var entry = symbols.functions[$id._]; if (entry && entry.signature) { entry.signature.params = []; for (var idx = 0; idx < $inp.n; ++idx) { var param = $inp._[idx]; entry.signature.params.push({ type: param.type, name: param.name, size: param.size }); } } emitFunctionSignature($id._); iterate($inp._, function (p) { declare( 'INP?', 'locals', '$' + p.name, p.type, true, (p.size !== undefined ? '*' + p.size : undefined), _s, _i ); }); ; return true})()&&((function(){var _b=_i;return LOCALS($)&&_($)&&LocalsDecl($loc)&&(function(){ iterate($loc._, function (v) { declare( 'LOC?', 'locals', '$' + v.name, v.type, false, (v.size !== undefined ? '*' + v.size : undefined), _s, _i ); }); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})(),true)&&(function(){ output(';-----------------------------------------------------------------------------'); ; return true})()&&Block($)&&(function(){ /* wrap-up body */ processBranches(); emit('--^', undefined, undefined, undefined, undefined); flushMetaCode('\t'); prune(symbols.locals); labelCounter = 0; output(''); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
 function ExternDecl($){var $id={};return (function(){var _b=_i;return EXTERN($)&&_($)&&(function(){ $.scope = 'globals'; ; return true})()&&(function(){var _b=_i;return (function(){var _b=_i;return FUNCTION($)&&(function(){ $.type  = 'U';  $.scope = 'functions'; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)||NATIVE($)&&(function(){ $.type  = 'N';  $.scope = 'functions'; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)||ARRAY($)&&(function(){ $.type  = 'A'; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()&&_($)&&Identifier($id)&&(function(){ $.name  = $id._; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)||VarDecl($)||(_im=(_i>_im?_i:_im),_i=_b,false)})()&&(function(){ declare( undefined,                 // no section for extern
                                                                              $.scope, $.name, $.type, false,                     // not readonly
-                                                                             '?', _s, _i ); if ($.scope === 'functions') { var entry = symbols.functions[$.name]; var signature = entry && entry.signature; if (entry) { if (!signature) { signature = entry.signature = {}; } if (signature.sourceCode === undefined) { signature.sourceCode = _s; signature.sourceOffset = _i; } } var role = ($.type === 'N' ? 'extern native' : 'extern func'); var prototypeComment = formatFunctionSignatureComment( $.name, signature, role ); if (!prototypeComment) { prototypeComment = formatFunctionSignatureComment( $.name, { params: [], returns: undefined }, role ); } emitStandaloneSignatureComment(prototypeComment); } else if ($.scope === 'globals') { emitStandaloneSignatureComment( formatGlobalSignatureComment( 'GLOB', $.name, $.type, $.size, 'extern' ) ); } ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
-function ConstDecl($){var $type={},$t,$nf,$id={},$x={};return (function(){var _b=_i;return CONST($)&&_($)&&BASE_TYPE($type)&&_($)&&(function(){ $t  = CASTS_TO_TYPES[$type._]; $nf = noForward; noForward = true; ; return true})()&&Identifier($id)&&(function(){var _b=_i;return (_s[_i]==="=")&&(++_i,true)&&_($)&&Expr($x)&&(function(){ declare( '! DEF?', 'defines', $id._, $t, true, makeConstant($x._, $t, _s, _i), _s, _i, formatConstSignatureComment($id._, $t) ); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)||(function(){ declare( undefined, 'defines', $id._, $t, true, undefined, _s, _i ); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()&&(function(){ noForward = $nf; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
-function GlobalDecl($){var $section,$v={},$init,$x={},$a={},$d={};return (function(){var _b=_i;return (function(){var _b=_i;return GLOBAL($)&&(function(){ $section = 'GLOB'; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)||READONLY($)&&(function(){ $section = 'CNST'; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)||TEMPORARY($)&&(function(){ $section = 'TEMP'; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()&&_($)&&(function(){var _b=_i;return VarDecl($v)&&(function(){ declare( $section, 'globals', undefined, $v.type, ($section === 'CNST'), '*1', _s, _i ); $init = ZEROES[$v.type]; ; return true})()&&((function(){var _b=_i;return (_s[_i]==="=")&&(++_i,true)&&_($)&&Expr($x)&&(function(){ $init = makeConstant($x._, $v.type, _s, _i); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})(),true)&&(function(){ declare( 'DAT?', 'globals', $v.name, $v.type, ($section === 'CNST'), $init, _s, _i, formatGlobalSignatureComment($section, $v.name, $v.type) ); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)||ArrayDecl($a)&&(function(){ declare( $section, 'globals', $a.name, 'A', ($section === 'CNST'), '*' + $a.size, _s, _i, formatGlobalSignatureComment($section, $a.name, 'A', $a.size) ); ; return true})()&&((function(){var _b=_i;return (_s[_i]==="=")&&(++_i,true)&&_($)&&InitList($d)||(_im=(_i>_im?_i:_im),_i=_b,false)})(),true)||(_im=(_i>_im?_i:_im),_i=_b,false)})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
+                                                                             '?', _s, _i ); if ($.scope === 'functions') { var entry = symbols.functions[$.name]; var signature = entry && entry.signature; if (entry) { if (!signature) { signature = entry.signature = {}; } if (signature.sourceName === undefined) { signature.sourceName = sourceName; } if (signature.sourceCode === undefined) { signature.sourceCode = _s; signature.sourceOffset = _i; signature.sourceName = sourceName; } } var role = ($.type === 'N' ? 'extern native' : 'extern func'); var prototypeComment = formatFunctionSignatureComment( $.name, signature, role, sourceName, _s, _i ); if (!prototypeComment) { prototypeComment = formatFunctionSignatureComment( $.name, { params: [], returns: undefined }, role, sourceName, _s, _i ); } emitStandaloneSignatureComment(prototypeComment); } else if ($.scope === 'globals') { emitStandaloneSignatureComment( formatGlobalSignatureComment( 'GLOB', $.name, $.type, $.size, 'extern', sourceName, _s, _i ) ); } ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
+function ConstDecl($){var $type={},$t,$nf,$id={},$x={};return (function(){var _b=_i;return CONST($)&&_($)&&BASE_TYPE($type)&&_($)&&(function(){ $t  = CASTS_TO_TYPES[$type._]; $nf = noForward; noForward = true; ; return true})()&&Identifier($id)&&(function(){var _b=_i;return (_s[_i]==="=")&&(++_i,true)&&_($)&&Expr($x)&&(function(){ declare( '! DEF?', 'defines', $id._, $t, true, makeConstant($x._, $t, _s, _i), _s, _i, formatConstSignatureComment( $id._, $t, sourceName, _s, _i ) ); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)||(function(){ declare( undefined, 'defines', $id._, $t, true, undefined, _s, _i ); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()&&(function(){ noForward = $nf; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
+function GlobalDecl($){var $section,$v={},$init,$x={},$a={},$d={};return (function(){var _b=_i;return (function(){var _b=_i;return GLOBAL($)&&(function(){ $section = 'GLOB'; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)||READONLY($)&&(function(){ $section = 'CNST'; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)||TEMPORARY($)&&(function(){ $section = 'TEMP'; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()&&_($)&&(function(){var _b=_i;return VarDecl($v)&&(function(){ declare( $section, 'globals', undefined, $v.type, ($section === 'CNST'), '*1', _s, _i ); $init = ZEROES[$v.type]; ; return true})()&&((function(){var _b=_i;return (_s[_i]==="=")&&(++_i,true)&&_($)&&Expr($x)&&(function(){ $init = makeConstant($x._, $v.type, _s, _i); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})(),true)&&(function(){ declare( 'DAT?', 'globals', $v.name, $v.type, ($section === 'CNST'), $init, _s, _i, formatGlobalSignatureComment( $section, $v.name, $v.type, undefined, undefined, sourceName, _s, _i ) ); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)||ArrayDecl($a)&&(function(){ declare( $section, 'globals', $a.name, 'A', ($section === 'CNST'), '*' + $a.size, _s, _i, formatGlobalSignatureComment( $section, $a.name, 'A', $a.size, undefined, sourceName, _s, _i ) ); ; return true})()&&((function(){var _b=_i;return (_s[_i]==="=")&&(++_i,true)&&_($)&&InitList($d)||(_im=(_i>_im?_i:_im),_i=_b,false)})(),true)||(_im=(_i>_im?_i:_im),_i=_b,false)})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
 function InitList($){var $d,$type,$x={};return (function(){var _b=_i;return (_s[_i]==="{")&&(++_i,true)&&_($)&&(function(){ $d = ' '; $type = undefined; ; return true})()&&((function(){var _b=_i;return Expr($x)&&(function(){ var xMeta = metaSlot($x._); $type = xMeta.type; $d += makeConstant(xMeta, $type, _s, _i); ; return true})()&&((function(){while((function(){var _b=_i;return (_s[_i]===",")&&(++_i,true)&&_($)&&Expr($x)&&(function(){ var xMeta = metaSlot($x._); var xType = xMeta.type; var constant = makeConstant(xMeta, xType, _s, _i); /* decide if we need to flush DATA */ if (  constant[0] === '<' || $d[1] === '<' || ($d + ' ' + constant).length >= 55) { declare( 'DATA', 'globals', undefined, xType, true, $d.substr(1), _s, _i ); $d = ''; } $d += ' ' + constant; $type = xType; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})());})(),true)||(_im=(_i>_im?_i:_im),_i=_b,false)})(),true)&&(_s[_i]==="}")&&(++_i,true)&&_($)&&(function(){ if ($d.substr(1) !== '') { declare( 'DATA', 'globals', undefined, $type, true, $d.substr(1), _s, _i ); } ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
 function ArgsDecl($){var $v={};return (function(){var _b=_i;return (function(){ $._ = []; $.n = 0; ; return true})()&&((function(){var _b=_i;return VarDecl($v)&&(function(){ var entry = {}; entry.type = $v.type; entry.name = $v.name; entry.size = $v.size; $._[$.n++] = entry; ; return true})()&&((function(){while((function(){var _b=_i;return (_s[_i]===",")&&(++_i,true)&&_($)&&VarDecl($v)&&(function(){ var entry = {}; entry.type = $v.type; entry.name = $v.name; entry.size = $v.size; $._[$.n++] = entry; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})());})(),true)||(_im=(_i>_im?_i:_im),_i=_b,false)})(),true)||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
 function LocalsDecl($){var $v={};return (function(){var _b=_i;return (function(){ $._ = []; $.n = 0; ; return true})()&&((function(){var _b=_i;return (function(){var _b=_i;return VarDecl($v)||(_im=(_i>_im?_i:_im),_i=_b,false)||ArrayDecl($v)||(_im=(_i>_im?_i:_im),_i=_b,false)})()&&(function(){ var entry = {}; entry.type = $v.type; entry.name = $v.name; entry.size = $v.size; $._[$.n++] = entry; ; return true})()&&((function(){while((function(){var _b=_i;return (_s[_i]===",")&&(++_i,true)&&_($)&&(function(){var _b=_i;return VarDecl($v)||(_im=(_i>_im?_i:_im),_i=_b,false)||ArrayDecl($v)||(_im=(_i>_im?_i:_im),_i=_b,false)})()&&(function(){ var entry = {}; entry.type = $v.type; entry.name = $v.name; entry.size = $v.size; $._[$.n++] = entry; ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})());})(),true)||(_im=(_i>_im?_i:_im),_i=_b,false)})(),true)||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
@@ -1633,7 +1700,7 @@ function AddSub($){var $op={},$r={};return (function(){var _b=_i;return MulDiv($
 function MulDiv($){var $op={},$r={};return (function(){var _b=_i;return PrePost($)&&((function(){while((function(){var _b=_i;return MULDIV_OP($op)&&_($)&&PrePost($r)&&(function(){ if (!dry) mulDivOp($op._, $._, $r._, _s, _i); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})());})(),true)||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
 function PrePost($){var $op={};return (function(){var _b=_i;return (function(){var _b=_i;return PREFIX_OP($op)&&_($)||(_im=(_i>_im?_i:_im),_i=_b,false)||(_s[_i]==="(")&&(++_i,true)&&_($)&&BASE_TYPE($op)&&_($)&&(_s[_i]===")")&&(++_i,true)&&_($)||(_im=(_i>_im?_i:_im),_i=_b,false)})()&&PrePost($)&&(function(){ if (!dry) unaryOp($op._, $._, _s, _i); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)||Value($)&&((function(){while((function(){var _b=_i;return FuncCall($)||(_im=(_i>_im?_i:_im),_i=_b,false)||Subscript($)||(_im=(_i>_im?_i:_im),_i=_b,false)})());})(),true)||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
 function Subscript($){var $s={};return (function(){var _b=_i;return (_s[_i]==="[")&&(++_i,true)&&_($)&&Expr($s)&&(_s[_i]==="]")&&(++_i,true)&&_($)&&(function(){ if (!dry) binaryOp('=[]', $._, $s._, _s, _i); ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
-function FuncCall($){var $type,$;return (function(){var _b=_i;return (_s[_i]==="(")&&(++_i,true)&&_($)&&(function(){ if (!dry) { $.count = 0; $.base  = borrowForCall(); $.types = []; } ; return true})()&&((function(){var _b=_i;return Argument($)&&((function(){while((function(){var _b=_i;return (_s[_i]===",")&&(++_i,true)&&_($)&&Argument($)||(_im=(_i>_im?_i:_im),_i=_b,false)})());})(),true)||(_im=(_i>_im?_i:_im),_i=_b,false)})(),true)&&(_s[_i]===")")&&(++_i,true)&&_($)&&(function(){ if (!dry) { var callee = metaSlot($._); var callResultType = '?'; var signature = null; var calleeName = null; if (span(callee.type, 'FN') !== 1) { typeError( 'Invalid type for function call ({$type1})', _s, _i, callee.type ); } if (callee.operator === ':=' && callee.operands[1] && callee.operands[1][0] === '&') { calleeName = callee.operands[1].substr(1); var entry = symbols.functions[calleeName]; if (entry && entry.kind === 'FUNC' && entry.signature) { signature = entry.signature; } } if (signature) { var params = signature.params || []; var actualCount = ($.types ? $.types.length : 0); var expectedCount = params.length; var label = (calleeName || 'function'); if (actualCount !== expectedCount) { fail( 'Invalid argument count when calling ' + label + ' (expected ' + expectedCount + ', got ' + actualCount + ')', _s, _i ); } for (var argIdx = 0; argIdx < expectedCount; ++argIdx) { var expected = params[argIdx].type; var actual = $.types[argIdx]; if (actual === undefined) { actual = '?'; } if (actual === '?' || expected === undefined) { continue; } if (actual !== expected) { typeError( 'Argument type mismatch when calling ' + label + ' ({$type1} vs expected {$type2})', _s, _i, actual, expected ); } } if (signature.returns !== undefined) { callResultType = signature.returns; } } var callComment = formatCallExpectationComment( calleeName, signature, $.types, callResultType ); if (callComment) { emit(';', undefined, callComment, undefined, undefined); } var func = makeRValue(callee, '&^$%'); emit('()', '?', func, '%' + $.base, '*' + ($.count + 1)); returnBack(func); while ($.count-- > 0) { returnBack('%' + ($.base + $.count + 1)); } makeMeta(callee, ':=', callResultType, undefined, '%' + $.base, undefined); } ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
+function FuncCall($){var $type,$;return (function(){var _b=_i;return (_s[_i]==="(")&&(++_i,true)&&_($)&&(function(){ if (!dry) { $.count = 0; $.base  = borrowForCall(); $.types = []; } ; return true})()&&((function(){var _b=_i;return Argument($)&&((function(){while((function(){var _b=_i;return (_s[_i]===",")&&(++_i,true)&&_($)&&Argument($)||(_im=(_i>_im?_i:_im),_i=_b,false)})());})(),true)||(_im=(_i>_im?_i:_im),_i=_b,false)})(),true)&&(_s[_i]===")")&&(++_i,true)&&_($)&&(function(){ if (!dry) { var callee = metaSlot($._); var callResultType = '?'; var signature = null; var calleeName = null; if (span(callee.type, 'FN') !== 1) { typeError( 'Invalid type for function call ({$type1})', _s, _i, callee.type ); } if (callee.operator === ':=' && callee.operands[1] && callee.operands[1][0] === '&') { calleeName = callee.operands[1].substr(1); var entry = symbols.functions[calleeName]; if (entry && entry.kind === 'FUNC' && entry.signature) { signature = entry.signature; } } if (signature) { var params = signature.params || []; var actualCount = ($.types ? $.types.length : 0); var expectedCount = params.length; var label = (calleeName || 'function'); if (actualCount !== expectedCount) { fail( 'Invalid argument count when calling ' + label + ' (expected ' + expectedCount + ', got ' + actualCount + ')', _s, _i ); } for (var argIdx = 0; argIdx < expectedCount; ++argIdx) { var expected = params[argIdx].type; var actual = $.types[argIdx]; if (actual === undefined) { actual = '?'; } if (actual === '?' || expected === undefined) { continue; } if (actual !== expected) { typeError( 'Argument type mismatch when calling ' + label + ' ({$type1} vs expected {$type2})', _s, _i, actual, expected ); } } if (signature.returns !== undefined) { callResultType = signature.returns; } } var callComment = formatCallExpectationComment( calleeName, signature, $.types, callResultType, sourceName, _s, _i ); if (callComment) { emit(';', undefined, callComment, undefined, undefined); } var func = makeRValue(callee, '&^$%'); emit('()', '?', func, '%' + $.base, '*' + ($.count + 1)); returnBack(func); while ($.count-- > 0) { returnBack('%' + ($.base + $.count + 1)); } makeMeta(callee, ':=', callResultType, undefined, '%' + $.base, undefined); } ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
 function Argument($){var $a={};return (function(){var _b=_i;return Expr($a)&&(function(){ if (!dry) { ++$.count; var meta = metaSlot($a._); if ($.types) { $.types.push(meta.type); } makeArgValue($a._, $.base + $.count); } ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
 function Group($){return (function(){var _b=_i;return (_s[_i]==="(")&&(++_i,true)&&_($)&&Expr($)&&(_s[_i]===")")&&(++_i,true)&&_($)||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
 function BoolGroup($){var $label;return (function(){var _b=_i;return (_s[_i]==="(")&&(++_i,true)&&_($)&&(function(){ $label = undefined; ; return true})()&&And($)&&((function(){while((function(){var _b=_i;return (_s.substr(_i,2)==="||")&&(_i+=2,true)&&_($)&&(function(){ if ($label === undefined) { $label = newLabel('t'); } emit('?->', true, $label, undefined, undefined); ; return true})()&&And($)||(_im=(_i>_im?_i:_im),_i=_b,false)})());})(),true)&&(_s[_i]===")")&&(++_i,true)&&_($)&&(function(){ if ($label !== undefined) { emit('<-?', true, $label, undefined, undefined); } ; return true})()||(_im=(_i>_im?_i:_im),_i=_b,false)})()};
@@ -1707,8 +1774,23 @@ function COMMENT($){return (function(){var _b=_i;return (_s.substr(_i,2)==="/*")
 var _i=0,_im=0,_o={_:void 0},_b=root(_o);
 return [_b,_o._,(_b?_i:_im)];
 });
+function impalaCompiler(source, options) {
+	var sourceName;
+	if (typeof options === 'string') {
+		sourceName = options;
+	} else if (options && Object.prototype.hasOwnProperty.call(options, 'sourceName')) {
+		sourceName = options.sourceName;
+	} else if (options && options.sourceName !== undefined) {
+		sourceName = options.sourceName;
+	} else {
+		sourceName = undefined;
+	}
+	$$parser.sourceName = sourceName;
+	return impalaCompilerImpl(source);
+}
 if (typeof module !== 'undefined' && module.exports) {
 	module.exports = impalaCompiler;
 	module.exports.impalaCompiler = impalaCompiler;
 	module.exports.default = impalaCompiler;
+	module.exports.raw = impalaCompilerImpl;
 }

--- a/impala/jspeg/impalaJsCompilerRunner.js
+++ b/impala/jspeg/impalaJsCompilerRunner.js
@@ -104,7 +104,10 @@ function compileWithJsImpala(source, options = {}) {
         new vm.Script(patchedCompilerSource, { filename: path.basename(compilerPath) }).runInContext(context);
 
         const compilerFn = context.module.exports;
-        const [ok, , index] = compilerFn(source);
+        const compilerOptions = (options && Object.prototype.hasOwnProperty.call(options, 'sourceName'))
+                ? { sourceName: options.sourceName }
+                : undefined;
+        const [ok, , index] = compilerFn(source, compilerOptions);
         if (!ok) {
                 throw new Error('JSPEG impala compiler failed to compile source');
         }

--- a/impala/jspeg/jspegCompilerTests.js
+++ b/impala/jspeg/jspegCompilerTests.js
@@ -61,7 +61,7 @@ if (impalaIndex !== impalaGrammar.length) {
 	process.exit(1);
 }
 const impalaExisting = fs.readFileSync(path.join(dir, 'impalaCompiler.js'), 'utf8');
-if (wrapCompilerSource('impalaCompiler', impalaGenerated, { prelude: 'var $$parser = {};' }).trim() !== impalaExisting.trim()) {
+if (wrapCompilerSource('impalaCompiler', impalaGenerated, { prelude: 'var $$parser = {};', exposeSourceNameOption: true }).trim() !== impalaExisting.trim()) {
         console.error('Generated compiler differs from impalaCompiler.js');
         process.exit(1);
 }
@@ -183,11 +183,11 @@ const tagCaptureCases = [
 testGrammarEquivalence('tagCaptureTest.jspeg', 'tagCaptureTest.jspeg', tagCaptureCases);
 
 const parityFixtures = [
-        { name: 'smoke', source: 'smoke.impala', expected: 'smoke.pika.gazl', options: { randomId: 42 } },
-        { name: 'bool', source: 'bool.impala', expected: 'bool.pika.gazl', options: { randomId: 42 } },
-        { name: 'control', source: 'control.impala', expected: 'control.pika.gazl', options: { randomId: 42 } },
-        { name: 'perfTest2', source: 'perfTest2.impala', expected: 'perfTest2.pika.gazl', options: { randomId: 42 } },
-        { name: 'inputTest', source: 'inputTest.impala', expected: 'inputTest.pika.gazl', options: { randomId: 42 } }
+        { name: 'smoke', source: 'smoke.impala', expected: 'smoke.pika.gazl', options: { randomId: 42, sourceName: 'smoke.impala' } },
+        { name: 'bool', source: 'bool.impala', expected: 'bool.pika.gazl', options: { randomId: 42, sourceName: 'bool.impala' } },
+        { name: 'control', source: 'control.impala', expected: 'control.pika.gazl', options: { randomId: 42, sourceName: 'control.impala' } },
+        { name: 'perfTest2', source: 'perfTest2.impala', expected: 'perfTest2.pika.gazl', options: { randomId: 42, sourceName: 'perfTest2.impala' } },
+        { name: 'inputTest', source: 'inputTest.impala', expected: 'inputTest.pika.gazl', options: { randomId: 42, sourceName: 'inputTest.impala' } }
 ];
 
 const legacySourceDir = path.join(dir, '..', '..', 'tests', 'impala', 'sources');
@@ -205,7 +205,7 @@ const legacyParityFixtures = fs
                         expected: `${name}.gazl`,
                         sourceDir: legacySourceDir,
                         expectedDir: legacyExpectedDir,
-                        options: { randomId: LEGACY_RANDOM_ID, retabulate: false }
+                        options: { randomId: LEGACY_RANDOM_ID, retabulate: false, sourceName: path.join(legacySourceDir, file) }
                 };
         });
 

--- a/impala/jspeg/testdata/bool.pika.gazl
+++ b/impala/jspeg/testdata/bool.pika.gazl
@@ -4,7 +4,7 @@
 
  ;-----------------------------------------------------------------------------
  					$value:		OUTi
- main:				FUNC		; signature func main() -> int
+ main:				FUNC		; signature func main() -> int @ 1:15
  ;-----------------------------------------------------------------------------
  								MOVi $value #0 					; value = 0
  								NEQi $value #0 @.f0				; if (value == 0)

--- a/impala/jspeg/testdata/control.pika.gazl
+++ b/impala/jspeg/testdata/control.pika.gazl
@@ -4,15 +4,15 @@
  .s_ABCD2a:			CNST *5
  					DATs ABCD
  					DATi #0
- SOURCE:			! DEFp &.s_ABCD2a ; signature const SOURCE : ptr
+ SOURCE:			! DEFp &.s_ABCD2a ; signature const SOURCE : ptr @ 1:30
  .s_WXYZ2a:			CNST *5
  					DATs WXYZ
  					DATi #0
- TARGET:			! DEFp &.s_WXYZ2a ; signature const TARGET : ptr
+ TARGET:			! DEFp &.s_WXYZ2a ; signature const TARGET : ptr @ 2:30
 
  ;-----------------------------------------------------------------------------
  					$result:	OUTi
- controlSample:		FUNC		; signature func controlSample() -> int
+ controlSample:		FUNC		; signature func controlSample() -> int @ 4:24
  					$sum:		LOCi
  					$index:		LOCi
  					$src:		LOCp

--- a/impala/jspeg/testdata/inputTest.pika.gazl
+++ b/impala/jspeg/testdata/inputTest.pika.gazl
@@ -1,27 +1,27 @@
  ; Compiled with Impala version 1.0
 
  ; signatures version=1
- ; signature extern native print() -> unknown
- ; signature extern native printLF() -> unknown
- ; signature extern native input() -> unknown
- ; signature extern native printInt() -> unknown
+ ; signature extern native print() -> unknown @ 1:20
+ ; signature extern native printLF() -> unknown @ 2:22
+ ; signature extern native input() -> unknown @ 3:20
+ ; signature extern native printInt() -> unknown @ 4:23
 
  ;-----------------------------------------------------------------------------
  								PARA *1
- main:				FUNC		; signature func main() -> void
+ main:				FUNC		; signature func main() -> void @ 6:15
  					$buffer:	LOCA *1024
  ;-----------------------------------------------------------------------------
  								MOVp %1 &.s_HEJ2a 				; print("HEJ")
- 								CALL ^print %0 *2				; expects function(ptr) -> unknown
- 								CALL ^printLF %0 *1				; expects function() -> unknown
+ 								CALL ^print %0 *2				; expects function(ptr) -> unknown @ 9:14
+ 								CALL ^printLF %0 *1				; expects function() -> unknown @ 9:25
  								MOVi %2 #10 					; printInt((int) input(10, buffer))
  								ADRL %3 $buffer *0
- 								CALL ^input %1 *3				; expects function(int, ptr) -> unknown
- 								CALL ^printInt %0 *2			; expects function(int) -> unknown
- 								CALL ^printLF %0 *1				; expects function() -> unknown
+ 								CALL ^input %1 *3				; expects function(int, ptr) -> unknown @ 10:34
+ 								CALL ^printInt %0 *2			; expects function(int) -> unknown @ 10:35
+ 								CALL ^printLF %0 *1				; expects function() -> unknown @ 10:46
  								ADRL %1 $buffer *0				; print(buffer)
- 								CALL ^print %0 *2				; expects function(ptr) -> unknown
- 								CALL ^printLF %0 *1				; expects function() -> unknown
+ 								CALL ^print %0 *2				; expects function(ptr) -> unknown @ 11:15
+ 								CALL ^printLF %0 *1				; expects function() -> unknown @ 11:26
  								RETU   							; }
 
  .s_HEJ2a:			CNST *4

--- a/impala/jspeg/testdata/perfTest2.pika.gazl
+++ b/impala/jspeg/testdata/perfTest2.pika.gazl
@@ -1,18 +1,18 @@
  ; Compiled with Impala version 1.0
 
  ; signatures version=1
- ; signature extern native printInt() -> unknown
+ ; signature extern native printInt() -> unknown @ 1:23
 
  ;-----------------------------------------------------------------------------
  					$x:			OUTi
- fib:				FUNC		; signature func fib(int y) -> int
+ fib:				FUNC		; signature func fib(int y) -> int @ 3:14
  					$y:			INPi
  ;-----------------------------------------------------------------------------
  								LSSi $y #2 @.f0					; if (y >= 2) 
  								SUBi %1 $y #1					; x = (int) fib(y - 1) + (int) fib(y - 2)
- 								CALL &fib %0 *2					; expects fib(int) -> int
+ 								CALL &fib %0 *2					; expects fib(int) -> int @ 7:24
  								SUBi %2 $y #2
- 								CALL &fib %1 *2					; expects fib(int) -> int
+ 								CALL &fib %1 *2					; expects fib(int) -> int @ 7:42
  								ADDi $x %0 %1
  								GOTO @.e1  						; } else 
  					.f0:		MOVi $x $y 						; x = y
@@ -21,10 +21,10 @@
 
  ;-----------------------------------------------------------------------------
  								PARA *1
- main:				FUNC		; signature func main() -> void
+ main:				FUNC		; signature func main() -> void @ 13:15
  ;-----------------------------------------------------------------------------
  								MOVi %2 #35 					; printInt(fib(35))
- 								CALL &fib %1 *2					; expects fib(int) -> int
- 								CALL ^printInt %0 *2			; expects function(int) -> unknown
+ 								CALL &fib %1 *2					; expects fib(int) -> int @ 15:18
+ 								CALL ^printInt %0 *2			; expects function(int) -> unknown @ 15:19
  								RETU   							; }
 

--- a/impala/jspeg/testdata/smoke.pika.gazl
+++ b/impala/jspeg/testdata/smoke.pika.gazl
@@ -4,7 +4,7 @@
 
  ;-----------------------------------------------------------------------------
  					$result:	OUTi
- main:				FUNC		; signature func main() -> int
+ main:				FUNC		; signature func main() -> int @ 1:15
  ;-----------------------------------------------------------------------------
  								MOVi $result #7 				; result = 7
  								RETU   							; }

--- a/impala/jspeg/testdata/validator/exports.gazl
+++ b/impala/jspeg/testdata/validator/exports.gazl
@@ -1,6 +1,6 @@
 ; signatures version=1
-FUNC foo	; signature func foo(int, ptr) -> int
+FUNC foo	; signature func foo(int, ptr) -> int @ exports.gazl:2:1
 	RETU
 
-LOC sharedValue	; signature global sharedValue : ptr
+LOC sharedValue	; signature global sharedValue : ptr @ exports.gazl:5:1
 	DATp #0

--- a/impala/jspeg/testdata/validator/imports-mismatch.gazl
+++ b/impala/jspeg/testdata/validator/imports-mismatch.gazl
@@ -1,2 +1,2 @@
 ; signatures version=1
-CALL foo	; expects foo(ptr, ptr) -> int
+CALL foo	; expects foo(ptr, ptr) -> int @ imports-mismatch.gazl:2:1

--- a/impala/jspeg/testdata/validator/imports-valid.gazl
+++ b/impala/jspeg/testdata/validator/imports-valid.gazl
@@ -1,2 +1,2 @@
 ; signatures version=1
-CALL foo	; expects foo(int, ptr) -> int
+CALL foo	; expects foo(int, ptr) -> int @ imports-valid.gazl:2:1

--- a/impala/jspeg/updateJSPEG.js
+++ b/impala/jspeg/updateJSPEG.js
@@ -22,7 +22,7 @@ function write(file, contents) {
 
 function wrapCompilerSource(exportName, generated, options = {}) {
         const body = generated.trimEnd();
-        const { prelude } = options;
+        const { prelude, exposeSourceNameOption } = options;
         const lines = [];
         if (prelude) {
                 const entries = Array.isArray(prelude) ? prelude : [prelude];
@@ -30,14 +30,45 @@ function wrapCompilerSource(exportName, generated, options = {}) {
                         lines.push(line);
                 });
         }
-        lines.push(
-                `var ${exportName} = ${body};`,
-                "if (typeof module !== 'undefined' && module.exports) {",
-                `\tmodule.exports = ${exportName};`,
-                `\tmodule.exports.${exportName} = ${exportName};`,
-                `\tmodule.exports.default = ${exportName};`,
-                '}'
-        );
+
+        if (exposeSourceNameOption) {
+                const implName = `${exportName}Impl`;
+                lines.push(`var ${implName} = ${body};`);
+                lines.push(
+                        `function ${exportName}(source, options) {`,
+                        "\tvar sourceName;",
+                        "\tif (typeof options === 'string') {",
+                        "\t\tsourceName = options;",
+                        "\t} else if (options && Object.prototype.hasOwnProperty.call(options, 'sourceName')) {",
+                        "\t\tsourceName = options.sourceName;",
+                        "\t} else if (options && options.sourceName !== undefined) {",
+                        "\t\tsourceName = options.sourceName;",
+                        "\t} else {",
+                        "\t\tsourceName = undefined;",
+                        "\t}",
+                        "\t$$parser.sourceName = sourceName;",
+                        `\treturn ${implName}(source);`,
+                        "}"
+                );
+                lines.push(
+                        "if (typeof module !== 'undefined' && module.exports) {",
+                        `\tmodule.exports = ${exportName};`,
+                        `\tmodule.exports.${exportName} = ${exportName};`,
+                        `\tmodule.exports.default = ${exportName};`,
+                        `\tmodule.exports.raw = ${implName};`,
+                        '}'
+                );
+        } else {
+                lines.push(
+                        `var ${exportName} = ${body};`,
+                        "if (typeof module !== 'undefined' && module.exports) {",
+                        `\tmodule.exports = ${exportName};`,
+                        `\tmodule.exports.${exportName} = ${exportName};`,
+                        `\tmodule.exports.default = ${exportName};`,
+                        '}'
+                );
+        }
+
         lines.push('');
         return lines.join('\n');
 }
@@ -115,7 +146,8 @@ function regenerate() {
         return {
                 jspegCompiler: wrappedGeneratedCompiler,
                 impalaCompiler: wrapCompilerSource('impalaCompiler', generatedImpala, {
-                        prelude: 'var $$parser = {};'
+                        prelude: 'var $$parser = {};',
+                        exposeSourceNameOption: true
                 })
         };
 }

--- a/tests/impala/golden/BitMaskMod_code.gazl
+++ b/tests/impala/golden/BitMaskMod_code.gazl
@@ -1,37 +1,37 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_4d2 &.s_4d2 &.s_4d2 &.s_4d2 &.s_BMSKHI4d3
 	DATA &.s_BMSKHI4d3:53 &.s_BMSKHI4d3:53 &.s_BMSKHI4d3:53
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-positions:	GLOB *2	; signature array positions[2] : unknown
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+positions:	GLOB *2	; signature array positions[2] : unknown @ 81:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 82:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 83:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
+instance:	DATi #0	; signature global instance : int @ 85:1
 	CNST *1
 	! SHLi <A> #1 #OPERATOR_2_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_2_HIGH_PARAM_INDEX
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #OPERAND_2_LOW_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 90:1
 	GLOB *1
-mask:	DATi #0	; signature global mask : int
+mask:	DATi #0	; signature global mask : int @ 90:16
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 114:17
 	$x:	LOCi
 	$y:	LOCi
 ;-----------------------------------------------------------------------------
@@ -52,7 +52,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-operate2:	FUNC	; signature func operate2() -> int
+operate2:	FUNC	; signature func operate2() -> int @ 134:19
 	$l:	LOCi
 	$x:	LOCi
 	$y:	LOCi

--- a/tests/impala/golden/FFTTest_code.gazl
+++ b/tests/impala/golden/FFTTest_code.gazl
@@ -1,25 +1,25 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_Sillyr4d2 &.s_4d3 &.s_4d3 &.s_LEFTDE4d4 &.s_4d3
 	DATA &.s_4d3 &.s_4d3 &.s_RINGMO4d5
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 81:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 82:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
-signal:	GLOB *2	; signature array signal[2] : unknown
-EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown
+instance:	DATi #0	; signature global instance : int @ 86:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 91:1
+EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown @ 91:41
 	DATA #0x0 #0x1 #0x2 #0x3 #0x4 #0x5 #0x6 #0x7 #0x8 #0x9
 	DATA #0xa #0xb #0xc #0xd #0xe #0xf #0x10 #0x11 #0x12 #0x13
 	DATA #0x14 #0x15 #0x16 #0x17 #0x18 #0x19 #0x1a #0x1b #0x1c
@@ -54,19 +54,19 @@ EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unkn
 	DATA #0x7c00 #0x8000 #0x8800 #0x9000 #0x9800 #0xa000
 	DATA #0xa800 #0xb000 #0xb800 #0xc000 #0xc800 #0xd000
 	DATA #0xd800 #0xe000 #0xe800 #0xf000 #0xffff
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 126:1
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 127:1
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 128:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 129:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 130:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 131:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 132:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 134:1
 
 ;-----------------------------------------------------------------------------
 	$a:	OUTp
-stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
+stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr @ 134:17
 	$d:	INPp
 	$s:	INPp
 	$b:	LOCp
@@ -84,7 +84,7 @@ stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr
+intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr @ 153:22
 	$i:	INPi
 	$radix:	INPi
 	$minLength:	INPi
@@ -131,7 +131,7 @@ intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
+traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void @ 171:20
 	$text:	INPp
 	$n:	INPi
 	$ints:	INPp
@@ -145,7 +145,7 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		EQUp $text &NULL @.f0	; if (text != null) p = (pointer) stpcpy(p, text)
 		MOVp %1 $p 	; p = (pointer) stpcpy(p, text)
 		MOVp %2 $text 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 178:49
 		MOVp $p %0 
 	.f0:	POKE $p #0 	; *p = 0
 		MOVi $i #0 	; for (i = 0 to n) 
@@ -158,18 +158,18 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		MOVi %4 #10 
 		MOVi %5 #1 
 		ADRL %6 $buffer *0
-		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr @ 182:62
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 182:63
 		MOVp $p %0 
 		FORi $i $n @.l2	; }
 	.e1:	ADRL %1 $line *0	; trace(line)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 184:13
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
+traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void @ 187:19
 	$text:	INPp
 	$i:	INPi
 	$ints:	LOCA *1
@@ -178,24 +178,24 @@ traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
 		MOVp %1 $text 	; traceInts(text, 1, ints)
 		MOVi %2 #1 
 		ADRL %3 $ints *0
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 191:26
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 194:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 196:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 197:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 200:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -209,16 +209,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 207:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4d7 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 210:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float)trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 211:35
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -226,7 +226,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 225:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -235,7 +235,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 229:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -258,18 +258,18 @@ cos:	FUNC	; signature func cos(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sin:	FUNC	; signature func sin(float x) -> float
+sin:	FUNC	; signature func sin(float x) -> float @ 241:14
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		SUBf %1 $x #HALF_PI	; y = (float) cos(x - HALF_PI)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 244:30
 		MOVf $y %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-square:	FUNC	; signature func square(float x) -> float
+square:	FUNC	; signature func square(float x) -> float @ 247:17
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		MULf $y $x $x	; y = x * x
@@ -278,7 +278,7 @@ square:	FUNC	; signature func square(float x) -> float
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-complexFFT:	FUNC	; signature func complexFFT(int n, ptr data) -> void
+complexFFT:	FUNC	; signature func complexFFT(int n, ptr data) -> void @ 253:21
 	$n:	INPi
 	$data:	INPp
 	$i:	LOCi
@@ -334,11 +334,11 @@ complexFFT:	FUNC	; signature func complexFFT(int n, ptr data) -> void
 		iTOf %1 $mmax #1.0
 		DIVf $theta <A> %1
 		MULf %2 $theta #0.5	; rx = 2.0 * (float) square((float) sin(theta * 0.5))
-		CALL &sin %1 *2	; expects sin(float) -> float
-		CALL &square %0 *2	; expects square(float) -> float
+		CALL &sin %1 *2	; expects sin(float) -> float @ 286:53
+		CALL &square %0 *2	; expects square(float) -> float @ 286:54
 		MULf $rx #2.0 %0
 		MOVf %1 $theta 	; ry = (float) sin(theta)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 287:26
 		MOVf $ry %0 
 		MOVf $px #1.0 	; px = 1.0
 		MOVf $py #0.0 	; py = 0.0
@@ -403,7 +403,7 @@ complexFFT:	FUNC	; signature func complexFFT(int n, ptr data) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-realFFT:	FUNC	; signature func realFFT(int n, ptr input, ptr output) -> void
+realFFT:	FUNC	; signature func realFFT(int n, ptr input, ptr output) -> void @ 314:18
 	$n:	INPi
 	$input:	INPp
 	$output:	INPp
@@ -435,7 +435,7 @@ realFFT:	FUNC	; signature func realFFT(int n, ptr input, ptr output) -> void
 		CALL ^assertFail %0 *1
 	.a2:	MOVi %1 $n 	; complexFFT(n, input)
 		MOVp %2 $input 
-		CALL &complexFFT %0 *3	; expects complexFFT(int, ptr) -> void
+		CALL &complexFFT %0 *3	; expects complexFFT(int, ptr) -> void @ 321:22
 		PEEK $r0 $input #0	; r0 = (float) input[0]
 		PEEK $i0 $input #1	; i0 = (float) input[1]
 		ADDf %0 $r0 $i0	; output[0] = (r0 + i0)
@@ -446,11 +446,11 @@ realFFT:	FUNC	; signature func realFFT(int n, ptr input, ptr output) -> void
 		iTOf %0 $n #1.0
 		DIVf $theta <A> %0
 		MULf %2 $theta #0.5	; rx = 2.0 * (float) square((float) sin(theta * 0.5))
-		CALL &sin %1 *2	; expects sin(float) -> float
-		CALL &square %0 *2	; expects square(float) -> float
+		CALL &sin %1 *2	; expects sin(float) -> float @ 331:53
+		CALL &square %0 *2	; expects square(float) -> float @ 331:54
 		MULf $rx #2.0 %0
 		MOVf %1 $theta 	; ry = (float) sin(theta)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 332:26
 		MOVf $ry %0 
 		MOVf $px #1.0 	; px = 1.0
 		MOVf $py #0.0 	; py = 0.0
@@ -507,7 +507,7 @@ realFFT:	FUNC	; signature func realFFT(int n, ptr input, ptr output) -> void
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-exp:	FUNC	; signature func exp(float x) -> float
+exp:	FUNC	; signature func exp(float x) -> float @ 379:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -531,7 +531,7 @@ exp:	FUNC	; signature func exp(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-log:	FUNC	; signature func log(float x) -> float
+log:	FUNC	; signature func log(float x) -> float @ 412:14
 	$x:	INPf
 	$a:	LOCf
 	$b:	LOCf
@@ -542,7 +542,7 @@ log:	FUNC	; signature func log(float x) -> float
 		LEQf $x #0.0 @.t0	; if (x <= 0.0 || x >= 1.0e38) error("Domain error")
 		LSSf $x #1.0e38 @.f1
 	.t0:	MOVp %1 &.s_Domain4d8 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 420:52
 		GOTO @.e2  
 	.f1:	MOVf $b #0.0 	; b = 0.0
 		MOVf $m $x 	; m = x
@@ -571,7 +571,7 @@ log:	FUNC	; signature func log(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-pow:	FUNC	; signature func pow(float x, float y) -> float
+pow:	FUNC	; signature func pow(float x, float y) -> float @ 440:14
 	$x:	INPf
 	$y:	INPf
 	$a:	LOCf
@@ -584,15 +584,15 @@ pow:	FUNC	; signature func pow(float x, float y) -> float
 		SUBf $a #0.0 $a	; a = -a
 	.f1:	LEQf $a #0.0 @.f2	; if (a > 0.0) z = (float) exp((float) log(a) * y)
 		MOVf %2 $a 	; z = (float) exp((float) log(a) * y)
-		CALL &log %1 *2	; expects log(float) -> float
+		CALL &log %1 *2	; expects log(float) -> float @ 447:46
 		MULf %1 %1 $y
-		CALL &exp %0 *2	; expects exp(float) -> float
+		CALL &exp %0 *2	; expects exp(float) -> float @ 447:50
 		MOVf $z %0 
 		GOTO @.e3  
 	.f2:	LSSf $a #0.0 @.t4	; if (a < 0.0 || y <= 0.0) error("Domain error")
 		GRTf $y #0.0 @.f5
 	.t4:	MOVp %1 &.s_Domain4d8 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 448:53
 	.f5:	NOOP
 	.e3:	EQUf $a $x @.f7	; if (a != x && (y * 0.5) != floor(y * 0.5)) z = -z
 		MULf %0 $y #0.5
@@ -605,49 +605,49 @@ pow:	FUNC	; signature func pow(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sqrt:	FUNC	; signature func sqrt(float x) -> float
+sqrt:	FUNC	; signature func sqrt(float x) -> float @ 452:15
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; y = (float) pow(x, 0.5)
 		MOVf %2 #0.5 
-		CALL &pow %0 *3	; expects pow(float, float) -> float
+		CALL &pow %0 *3	; expects pow(float, float) -> float @ 455:25
 		MOVf $y %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 467:15
 	$i:	LOCi
 	$buf:	LOCA *256
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4d9 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 470:15
 		PEEK %2 &instance 	; trace(intToString(global instance, 10, 1, buf))
 		MOVi %3 #10 
 		MOVi %4 #1 
 		ADRL %5 $buf *0
-		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr @ 471:48
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 471:49
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 478:16
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4da 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 480:16
 		MOVp %1 &.s_params4db 	; traceInts(" params: ", PARAM_COUNT, global params)
 		MOVi %2 #PARAM_COUNT 
 		MOVp %3 &params 
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 481:52
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 489:17
 	$buf:	LOCA *256
 	$params:	LOCA *PARAM_COUNT
 ;-----------------------------------------------------------------------------
@@ -656,7 +656,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 509:18
 	$idx:	LOCi
 	$maxI:	LOCi
 	$i:	LOCi
@@ -694,7 +694,7 @@ process:	FUNC	; signature func process() -> void
 		MULf %0 %0 #0.1
 		ADDf $a $a %0
 		MOVf %1 $ph 	; out = ftoi((float) sin(ph) * a * 2047.0)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 525:31
 		MULf %0 %0 $a
 		fTOi $out %0 #2047.0
 		POKE &signal:0 $out 	; global signal[0] = out
@@ -725,14 +725,14 @@ process:	FUNC	; signature func process() -> void
 		MULf $rate %0 #0.5
 	.f5:	NEQi $idx #384 @.f9	; if (idx == 384) 
 		DIVf %1 $maxY #512.0	; targetA = (float) sqrt(maxY / 512.0)
-		CALL &sqrt %0 *2	; expects sqrt(float) -> float
+		CALL &sqrt %0 *2	; expects sqrt(float) -> float @ 543:41
 		MOVf $targetA %0 
-	.f9:	CALL ^yield %0 *1	; expects function() -> unknown
+	.f9:	CALL ^yield %0 *1	; expects function() -> unknown @ 545:11
 		FORi $idx #512 @.l2	; }
 	.e1:	MOVi %1 #512 	; realFFT(512, fftInput, fftOutput)
 		ADRL %2 $fftInput *0
 		ADRL %3 $fftOutput *0
-		CALL &realFFT %0 *4	; expects realFFT(int, ptr, ptr) -> void
+		CALL &realFFT %0 *4	; expects realFFT(int, ptr, ptr) -> void @ 547:36
 		GOTO @.l0  	; }
 		RETU   	; }
 

--- a/tests/impala/golden/ImpalaDemo.gazl
+++ b/tests/impala/golden/ImpalaDemo.gazl
@@ -1,51 +1,51 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-DEBUG:	! DEFi #1	; signature const DEBUG : int
+DEBUG:	! DEFi #1	; signature const DEBUG : int @ 53:1
 	GLOB *1
-uninited:	DATi #0	; signature global uninited : int
+uninited:	DATi #0	; signature global uninited : int @ 60:1
 	GLOB *1
-inited:	DATi #23	; signature global inited : int
+inited:	DATi #23	; signature global inited : int @ 60:23
 	GLOB *1
-aFloat:	DATf #0.0	; signature global aFloat : float
+aFloat:	DATf #0.0	; signature global aFloat : float @ 63:20
 	GLOB *1
-aPointer:	DATp &aFloat	; signature global aPointer : ptr
+aPointer:	DATp &aFloat	; signature global aPointer : ptr @ 65:41
 	GLOB *1
-aFuncPointer:	DATp &NULL	; signature global aFuncPointer : funcptr
-defaultArray:	GLOB *100	; signature array defaultArray[100] : unknown
-initedArray:	GLOB *10	; signature array initedArray[10] : unknown
+aFuncPointer:	DATp &NULL	; signature global aFuncPointer : funcptr @ 68:28
+defaultArray:	GLOB *100	; signature array defaultArray[100] : unknown @ 73:31
+initedArray:	GLOB *10	; signature array initedArray[10] : unknown @ 78:30
 	DATA #1 #2.0 &defaultArray:0 #4
 	TEMP *1
-forgetMe:	DATi #0	; signature temporary forgetMe : int
-SOME_COUNT:	! DEFi #4	; signature const SOME_COUNT : int
-SOME_CONSTS:	CNST *SOME_COUNT	; signature array SOME_CONSTS[SOME_COUNT] : unknown
+forgetMe:	DATi #0	; signature temporary forgetMe : int @ 82:23
+SOME_COUNT:	! DEFi #4	; signature const SOME_COUNT : int @ 87:25
+SOME_CONSTS:	CNST *SOME_COUNT	; signature array SOME_CONSTS[SOME_COUNT] : unknown @ 94:40
 	DATA #100 #200 #300 #400
-; signature extern global defineMeLaterPlease : int
-; signature extern array futureArray[] : unknown
-; signature extern func thisFunctionInAnotherSource() -> unknown
-; signature extern native abort() -> unknown
+; signature extern global defineMeLaterPlease : int @ 98:31
+; signature extern array futureArray[] : unknown @ 101:25
+; signature extern func thisFunctionInAnotherSource() -> unknown @ 103:44
+; signature extern native abort() -> unknown @ 107:20
 .s_Welcom4d2:	CNST *20
 	DATs Welcome to Impala!
 	DATi #10 #0
-WELCOME:	! DEFp &.s_Welcom4d2	; signature const WELCOME : ptr
-VARIOUS_LITERALS:	CNST *15	; signature array VARIOUS_LITERALS[15] : unknown
+WELCOME:	! DEFp &.s_Welcom4d2	; signature const WELCOME : ptr @ 116:1
+VARIOUS_LITERALS:	CNST *15	; signature array VARIOUS_LITERALS[15] : unknown @ 116:37
 	DATA #123 #-393 #+494 #0xAA55 #-0x1F2E3C4D #'A' #-''
 	DATA #'ROFL' #34.0 #-123.0e10 #256.11E-10 &.s_string4d2
 	DATA &.s_allesc4d3 &NULL &NULL
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-abortOnZero:	FUNC	; signature func abortOnZero(int v) -> void
+abortOnZero:	FUNC	; signature func abortOnZero(int v) -> void @ 138:22
 	$v:	INPi
 ;-----------------------------------------------------------------------------
 		NEQi $v #0 @.f0	; if (v == 0) abort()
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^abort %0 *1	; expects function() -> unknown @ 140:21
 	.f0:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$fetched:	OUTi
-fetchSomeConst:	FUNC	; signature func fetchSomeConst(int index) -> int
+fetchSomeConst:	FUNC	; signature func fetchSomeConst(int index) -> int @ 143:25
 	$index:	INPi
 ;-----------------------------------------------------------------------------
 		PEEK $fetched &SOME_CONSTS $index	; fetched = (int) global SOME_CONSTS[index]
@@ -54,7 +54,7 @@ fetchSomeConst:	FUNC	; signature func fetchSomeConst(int index) -> int
 
 ;-----------------------------------------------------------------------------
 	$j:	OUTi
-findSmallest:	FUNC	; signature func findSmallest(int n, ptr vector) -> int
+findSmallest:	FUNC	; signature func findSmallest(int n, ptr vector) -> int @ 156:23
 	$n:	INPi
 	$vector:	INPp
 	$i:	LOCi
@@ -69,39 +69,39 @@ findSmallest:	FUNC	; signature func findSmallest(int n, ptr vector) -> int
 	.f2:	FORi $i $n @.l1
 	.e0:	RETU   	; }
 
-TEST_SIZE:	! DEFi #50	; signature const TEST_SIZE : int
-; signature extern func myrand() -> unknown
-; signature extern native printInt() -> unknown
-; signature extern native printLF() -> unknown
+TEST_SIZE:	! DEFi #50	; signature const TEST_SIZE : int @ 166:25
+; signature extern func myrand() -> unknown @ 167:23
+; signature extern native printInt() -> unknown @ 168:23
+; signature extern native printLF() -> unknown @ 169:22
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-test:	FUNC	; signature func test() -> void
+test:	FUNC	; signature func test() -> void @ 171:15
 	$i:	LOCi
 	$mydata:	LOCA *TEST_SIZE
 ;-----------------------------------------------------------------------------
 		MOVi $i #0 	; for (i = 0 to TEST_SIZE)
 		GEQi #0 #TEST_SIZE @.e0
-	.l1:	CALL &myrand %0 *1	; expects myrand() -> unknown
+	.l1:	CALL &myrand %0 *1	; expects myrand() -> unknown @ 176:23
 		SETL $mydata $i %0
 		FORi $i #TEST_SIZE @.l1
 	.e0:	MOVi $i #0 	; for (i = 0 to TEST_SIZE) 
 		GEQi #0 #TEST_SIZE @.e2
 	.l3:	GETL %1 $mydata $i	; printInt(mydata[i])
-		CALL ^printInt %0 *2	; expects function(unknown) -> unknown
-		CALL ^printLF %0 *1	; expects function() -> unknown
+		CALL ^printInt %0 *2	; expects function(unknown) -> unknown @ 178:22
+		CALL ^printLF %0 *1	; expects function() -> unknown @ 179:12
 		FORi $i #TEST_SIZE @.l3	; }
 	.e2:	MOVi %2 #TEST_SIZE 	; printInt(findSmallest(TEST_SIZE, mydata))
 		ADRL %3 $mydata *0
-		CALL &findSmallest %1 *3	; expects findSmallest(int, ptr) -> int
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
+		CALL &findSmallest %1 *3	; expects findSmallest(int, ptr) -> int @ 181:42
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 181:43
 		RETU   	; }
 
-; signature extern native printFloat() -> unknown
+; signature extern native printFloat() -> unknown @ 191:25
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-showoff:	FUNC	; signature func showoff() -> void
+showoff:	FUNC	; signature func showoff() -> void @ 193:18
 	$a:	LOCi
 	$b:	LOCi
 	$c:	LOCi
@@ -134,8 +134,8 @@ showoff:	FUNC	; signature func showoff() -> void
 		GOTO @.e1  
 	.f0:	MOVi $ok #0 	; ok = 0
 	.e1:	MOVi %1 $ok 	; printInt(ok)
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
-		CALL ^printLF %0 *1	; expects function() -> unknown
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 223:14
+		CALL ^printLF %0 *1	; expects function() -> unknown @ 224:11
 		MOVi $b #'xyz' 	; a = b = 'xyz'
 		MOVi $a #'xyz' 
 		! MULi <A> #345 #123	; a = b = 345 * 123
@@ -155,8 +155,8 @@ showoff:	FUNC	; signature func showoff() -> void
 	.e4:	MOVp $p &SOME_CONSTS 	; for (p = global SOME_CONSTS to &global SOME_CONSTS[0]) 
 		GEQp &SOME_CONSTS &SOME_CONSTS:0 @.e6
 	.l7:	MOVp %1 $p 	; printInt(p)
-		CALL ^printInt %0 *2	; expects function(ptr) -> unknown
-		CALL ^printLF %0 *1	; expects function() -> unknown
+		CALL ^printInt %0 *2	; expects function(ptr) -> unknown @ 233:69
+		CALL ^printLF %0 *1	; expects function() -> unknown @ 233:80
 		FORp $p &SOME_CONSTS:0 @.l7	; }
 	.e6:	PEEK $a &forgetMe 	; a = global forgetMe
 		MOVf $f #23.3 	; f = 23.3
@@ -174,11 +174,11 @@ showoff:	FUNC	; signature func showoff() -> void
 		iTOf %0 $a #1.0	; f = itof(a) / 100.0
 		DIVf $f %0 #100.0
 		MOVi %1 $a 	; printInt(a)
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
-		CALL ^printLF %0 *1	; expects function() -> unknown
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 242:12
+		CALL ^printLF %0 *1	; expects function() -> unknown @ 242:22
 		MOVf %1 $f 	; printFloat(f)
-		CALL ^printFloat %0 *2	; expects function(float) -> unknown
-		CALL ^printLF %0 *1	; expects function() -> unknown
+		CALL ^printFloat %0 *2	; expects function(float) -> unknown @ 243:14
+		CALL ^printLF %0 *1	; expects function() -> unknown @ 243:24
 		POKE &initedArray:2 &futureArray:4 	; global initedArray[2] = &global futureArray[4]
 		NEQi #1 #1 @.f8	; if (1 == 1) 
 		! EQUi #DEBUG #0 @.a9	; assert((pointer)global initedArray[2] == &global futureArray[4])
@@ -196,19 +196,19 @@ showoff:	FUNC	; signature func showoff() -> void
 	.e10:	POKE &aFuncPointer &showoff 	; global aFuncPointer = showoff
 		PEEK %0 &aFuncPointer 	; if (global aFuncPointer == nullfunc) global aFuncPointer()
 		NEQp %0 &NULL @.f12
-		PEEK %1 &aFuncPointer 	; expects function() -> unknown
+		PEEK %1 &aFuncPointer 	; expects function() -> unknown @ 253:59
 		CALL %1 %0 *1
 	.f12:	RETU   	; }
 
 	GLOB *1
-defineMeLaterPlease:	DATi #0	; signature global defineMeLaterPlease : int
-futureArray:	GLOB *10	; signature array futureArray[10] : unknown
+defineMeLaterPlease:	DATi #0	; signature global defineMeLaterPlease : int @ 266:31
+futureArray:	GLOB *10	; signature array futureArray[10] : unknown @ 267:29
 	GLOB *1
-myrand_seed:	DATi #2463534242	; signature global myrand_seed : int
+myrand_seed:	DATi #2463534242	; signature global myrand_seed : int @ 269:36
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-myrand:	FUNC	; signature func myrand() -> int
+myrand:	FUNC	; signature func myrand() -> int @ 270:17
 ;-----------------------------------------------------------------------------
 		PEEK $y &myrand_seed 	; y = global myrand_seed
 		SHLi %0 $y #13	; y = y ^ (y << 13)
@@ -220,26 +220,26 @@ myrand:	FUNC	; signature func myrand() -> int
 		POKE &myrand_seed $y 	; global myrand_seed = y
 		RETU   	; }
 
-anInt:	! DEFi #4	; signature const anInt : int
-; signature extern native print() -> unknown
+anInt:	! DEFi #4	; signature const anInt : int @ 280:20
+; signature extern native print() -> unknown @ 282:20
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 283:15
 	$myFloat:	LOCf
 ;-----------------------------------------------------------------------------
 		MOVp %1 #WELCOME 	; print(WELCOME)
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 286:16
 		MOVf $myFloat #1000.0 	; myFloat = 1000.0
 		! SHLi <B> #1 #anInt	; printInt(ftoi(myFloat * (1.0 / itof(1 << anInt))))
 		! iTOf <B> <B> #1.0
 		! DIVf <B> #1.0 <B>
 		fTOi %1 $myFloat <B>
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
-		CALL ^printLF %0 *1	; expects function() -> unknown
-		CALL &showoff %0 *1	; expects showoff() -> void
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 288:52
+		CALL ^printLF %0 *1	; expects function() -> unknown @ 288:63
+		CALL &showoff %0 *1	; expects showoff() -> void @ 289:11
 		MOVp %1 &.s_Bye4d4 	; print("Bye!\n")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 290:17
 		RETU   	; }
 
 .s_string4d2:	CNST *8

--- a/tests/impala/golden/MLMoogFilter.gazl
+++ b/tests/impala/golden/MLMoogFilter.gazl
@@ -1,36 +1,36 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-; signature extern native sin() -> unknown
-; signature extern native cos() -> unknown
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
-BATCH_SIZE:	! DEFi #64	; signature const BATCH_SIZE : int
-rq:	! DEFf #0.1	; signature const rq : float
-f:	! DEFf #0.01	; signature const f : float
+; signature extern native sin() -> unknown @ 1:18
+; signature extern native cos() -> unknown @ 2:18
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 3:40
+BATCH_SIZE:	! DEFi #64	; signature const BATCH_SIZE : int @ 4:26
+rq:	! DEFf #0.1	; signature const rq : float @ 6:21
+f:	! DEFf #0.01	; signature const f : float @ 7:21
 	TEMP *1
-_ldxz:	DATf #0.0	; signature temporary _ldxz : float
+_ldxz:	DATf #0.0	; signature temporary _ldxz : float @ 9:22
 	TEMP *1
-_ld0z:	DATf #0.0	; signature temporary _ld0z : float
+_ld0z:	DATf #0.0	; signature temporary _ld0z : float @ 10:22
 	TEMP *1
-_ld1z:	DATf #0.0	; signature temporary _ld1z : float
+_ld1z:	DATf #0.0	; signature temporary _ld1z : float @ 11:22
 	TEMP *1
-_ld2z:	DATf #0.0	; signature temporary _ld2z : float
+_ld2z:	DATf #0.0	; signature temporary _ld2z : float @ 12:22
 	TEMP *1
-_ld3z:	DATf #0.0	; signature temporary _ld3z : float
+_ld3z:	DATf #0.0	; signature temporary _ld3z : float @ 13:22
 	TEMP *1
-_rdxz:	DATf #0.0	; signature temporary _rdxz : float
+_rdxz:	DATf #0.0	; signature temporary _rdxz : float @ 14:22
 	TEMP *1
-_rd0z:	DATf #0.0	; signature temporary _rd0z : float
+_rd0z:	DATf #0.0	; signature temporary _rd0z : float @ 15:22
 	TEMP *1
-_rd1z:	DATf #0.0	; signature temporary _rd1z : float
+_rd1z:	DATf #0.0	; signature temporary _rd1z : float @ 16:22
 	TEMP *1
-_rd2z:	DATf #0.0	; signature temporary _rd2z : float
+_rd2z:	DATf #0.0	; signature temporary _rd2z : float @ 17:22
 	TEMP *1
-_rd3z:	DATf #0.0	; signature temporary _rd3z : float
+_rd3z:	DATf #0.0	; signature temporary _rd3z : float @ 18:22
 
 ;-----------------------------------------------------------------------------
 	$hasSoundOut:	OUTi
-filter:	FUNC	; signature func filter(int hasSoundIn, ptr left, ptr right) -> int
+filter:	FUNC	; signature func filter(int hasSoundIn, ptr left, ptr right) -> int @ 20:17
 	$hasSoundIn:	INPi
 	$left:	INPp
 	$right:	INPp
@@ -69,11 +69,11 @@ filter:	FUNC	; signature func filter(int hasSoundIn, ptr left, ptr right) -> int
 		! MULf <A> #f #PI	; fpi = f * PI
 		MOVf $fpi <A> 
 		MOVf %1 $fpi 	; k = ((float) sin(fpi)) / ((float) cos(fpi) + (float) sin(fpi))
-		CALL ^sin %0 *2	; expects function(float) -> unknown
+		CALL ^sin %0 *2	; expects function(float) -> unknown @ 32:23
 		MOVf %2 $fpi 
-		CALL ^cos %1 *2	; expects function(float) -> unknown
+		CALL ^cos %1 *2	; expects function(float) -> unknown @ 32:45
 		MOVf %3 $fpi 
-		CALL ^sin %2 *2	; expects function(float) -> unknown
+		CALL ^sin %2 *2	; expects function(float) -> unknown @ 32:63
 		ADDf %1 %1 %2
 		DIVf $k %0 %1
 		MULf %0 $r $k	; g0 = r / (1.0 + r * k * k * k * k)
@@ -139,4 +139,4 @@ filter:	FUNC	; signature func filter(int hasSoundIn, ptr left, ptr right) -> int
 		RETU   	; }
 
 	! MULi <A> #BATCH_SIZE #2
-audioBuffers:	TEMP *<A>	; signature array audioBuffers[<A>] : unknown
+audioBuffers:	TEMP *<A>	; signature array audioBuffers[<A>] : unknown @ 72:45

--- a/tests/impala/golden/ModTest_code.gazl
+++ b/tests/impala/golden/ModTest_code.gazl
@@ -1,33 +1,33 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_XORHIG4d2 &.s_XORHIG4d2:53 &.s_XORHIG4d2:53
 	DATA &.s_XORHIG4d2:53 &.s_XORHIG4d2:53 &.s_SUB16B4d3
 	DATA &.s_SUB16B4d3:53 &.s_SUB16B4d3:53
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-positions:	GLOB *2	; signature array positions[2] : unknown
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+positions:	GLOB *2	; signature array positions[2] : unknown @ 81:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 82:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 83:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
+instance:	DATi #0	; signature global instance : int @ 88:1
 	GLOB *1
-xorMask:	DATi #0	; signature global xorMask : int
+xorMask:	DATi #0	; signature global xorMask : int @ 88:19
 	GLOB *1
-subTerm:	DATi #0	; signature global subTerm : int
+subTerm:	DATi #0	; signature global subTerm : int @ 89:19
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 113:17
 	$x:	LOCi
 	$y:	LOCi
 ;-----------------------------------------------------------------------------
@@ -63,7 +63,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-operate1:	FUNC	; signature func operate1() -> int
+operate1:	FUNC	; signature func operate1() -> int @ 144:19
 	$l:	LOCi
 	$x:	LOCi
 ;-----------------------------------------------------------------------------
@@ -89,7 +89,7 @@ operate1:	FUNC	; signature func operate1() -> int
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-operate2:	FUNC	; signature func operate2() -> int
+operate2:	FUNC	; signature func operate2() -> int @ 164:19
 	$x:	LOCi
 ;-----------------------------------------------------------------------------
 		PEEK %0 &params:OPERATOR_2_PARAM_INDEX 	; switch ((int) global params[OPERATOR_2_PARAM_INDEX] == 0 to OPERATOR_2_COUNT) 

--- a/tests/impala/golden/Priyome.gazl
+++ b/tests/impala/golden/Priyome.gazl
@@ -1,83 +1,83 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-DEBUG:	! DEFi #0	; signature const DEBUG : int
+FALSE:	! DEFi #0	; signature const FALSE : int @ 2:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 3:1
+DEBUG:	! DEFi #0	; signature const DEBUG : int @ 5:1
 	! ADDi <A> #8 #2
-STRIDE:	! DEFi <A>	; signature const STRIDE : int
+STRIDE:	! DEFi <A>	; signature const STRIDE : int @ 6:1
 	! ADDi <A> #8 #4
 	! MULi <A> <A> #STRIDE
-BOARD_SIZE:	! DEFi <A>	; signature const BOARD_SIZE : int
+BOARD_SIZE:	! DEFi <A>	; signature const BOARD_SIZE : int @ 7:1
 	! MULi <A> #STRIDE #2
-RANK_1:	! DEFi <A>	; signature const RANK_1 : int
+RANK_1:	! DEFi <A>	; signature const RANK_1 : int @ 8:1
 	! MULi <A> #STRIDE #3
-RANK_2:	! DEFi <A>	; signature const RANK_2 : int
+RANK_2:	! DEFi <A>	; signature const RANK_2 : int @ 9:1
 	! MULi <A> #STRIDE #4
-RANK_3:	! DEFi <A>	; signature const RANK_3 : int
+RANK_3:	! DEFi <A>	; signature const RANK_3 : int @ 10:1
 	! MULi <A> #STRIDE #5
-RANK_4:	! DEFi <A>	; signature const RANK_4 : int
+RANK_4:	! DEFi <A>	; signature const RANK_4 : int @ 11:1
 	! MULi <A> #STRIDE #6
-RANK_5:	! DEFi <A>	; signature const RANK_5 : int
+RANK_5:	! DEFi <A>	; signature const RANK_5 : int @ 12:1
 	! MULi <A> #STRIDE #7
-RANK_6:	! DEFi <A>	; signature const RANK_6 : int
+RANK_6:	! DEFi <A>	; signature const RANK_6 : int @ 13:1
 	! MULi <A> #STRIDE #8
-RANK_7:	! DEFi <A>	; signature const RANK_7 : int
+RANK_7:	! DEFi <A>	; signature const RANK_7 : int @ 14:1
 	! MULi <A> #STRIDE #9
-RANK_8:	! DEFi <A>	; signature const RANK_8 : int
-OFFBOARD:	! DEFi #-1	; signature const OFFBOARD : int
-EMPTY:	! DEFi #0	; signature const EMPTY : int
-PAWN:	! DEFi #1	; signature const PAWN : int
-ROOK:	! DEFi #2	; signature const ROOK : int
-KNIGHT:	! DEFi #3	; signature const KNIGHT : int
-BISHOP:	! DEFi #4	; signature const BISHOP : int
-QUEEN:	! DEFi #5	; signature const QUEEN : int
-KING:	! DEFi #6	; signature const KING : int
-BLACK:	! DEFi #8	; signature const BLACK : int
-WHITE:	! DEFi #16	; signature const WHITE : int
-PIECE_MASK:	! DEFi #7	; signature const PIECE_MASK : int
+RANK_8:	! DEFi <A>	; signature const RANK_8 : int @ 16:1
+OFFBOARD:	! DEFi #-1	; signature const OFFBOARD : int @ 17:1
+EMPTY:	! DEFi #0	; signature const EMPTY : int @ 18:1
+PAWN:	! DEFi #1	; signature const PAWN : int @ 19:1
+ROOK:	! DEFi #2	; signature const ROOK : int @ 20:1
+KNIGHT:	! DEFi #3	; signature const KNIGHT : int @ 21:1
+BISHOP:	! DEFi #4	; signature const BISHOP : int @ 22:1
+QUEEN:	! DEFi #5	; signature const QUEEN : int @ 23:1
+KING:	! DEFi #6	; signature const KING : int @ 24:1
+BLACK:	! DEFi #8	; signature const BLACK : int @ 25:1
+WHITE:	! DEFi #16	; signature const WHITE : int @ 26:1
+PIECE_MASK:	! DEFi #7	; signature const PIECE_MASK : int @ 27:1
 	! IORi <A> #BLACK #WHITE
-COLOR_MASK:	! DEFi <A>	; signature const COLOR_MASK : int
+COLOR_MASK:	! DEFi <A>	; signature const COLOR_MASK : int @ 28:1
 	! XORi <A> #BLACK #WHITE
-COLOR_SWITCH_XOR:	! DEFi <A>	; signature const COLOR_SWITCH_XOR : int
-MOVED_MASK:	! DEFi #32	; signature const MOVED_MASK : int
+COLOR_SWITCH_XOR:	! DEFi <A>	; signature const COLOR_SWITCH_XOR : int @ 29:1
+MOVED_MASK:	! DEFi #32	; signature const MOVED_MASK : int @ 30:1
 	! IORi <A> #PIECE_MASK #MOVED_MASK
-PIECE_AND_MOVED_MASK:	! DEFi <A>	; signature const PIECE_AND_MOVED_MASK : int
-MAX_PIECE_AND_MOVED_VALUE:	! DEFi #64	; signature const MAX_PIECE_AND_MOVED_VALUE : int
-MIN_DEPTH:	! DEFi #4	; signature const MIN_DEPTH : int
-MAX_DEPTH:	! DEFi #16	; signature const MAX_DEPTH : int
-QUIESCENCE_DEPTH:	! DEFi #8	; signature const QUIESCENCE_DEPTH : int
-TO_SHIFT:	! DEFi #8	; signature const TO_SHIFT : int
-SCORE_SHIFT:	! DEFi #16	; signature const SCORE_SHIFT : int
-MOVE_MASK:	! DEFi #0x0000FFFF	; signature const MOVE_MASK : int
-FROM_MASK:	! DEFi #0x000000FF	; signature const FROM_MASK : int
-TO_MASK:	! DEFi #0x0000FF00	; signature const TO_MASK : int
+PIECE_AND_MOVED_MASK:	! DEFi <A>	; signature const PIECE_AND_MOVED_MASK : int @ 31:1
+MAX_PIECE_AND_MOVED_VALUE:	! DEFi #64	; signature const MAX_PIECE_AND_MOVED_VALUE : int @ 33:1
+MIN_DEPTH:	! DEFi #4	; signature const MIN_DEPTH : int @ 34:1
+MAX_DEPTH:	! DEFi #16	; signature const MAX_DEPTH : int @ 35:1
+QUIESCENCE_DEPTH:	! DEFi #8	; signature const QUIESCENCE_DEPTH : int @ 36:1
+TO_SHIFT:	! DEFi #8	; signature const TO_SHIFT : int @ 37:1
+SCORE_SHIFT:	! DEFi #16	; signature const SCORE_SHIFT : int @ 38:1
+MOVE_MASK:	! DEFi #0x0000FFFF	; signature const MOVE_MASK : int @ 39:1
+FROM_MASK:	! DEFi #0x000000FF	; signature const FROM_MASK : int @ 40:1
+TO_MASK:	! DEFi #0x0000FF00	; signature const TO_MASK : int @ 41:1
 	! XORi <A> #MOVE_MASK #-1
-SCORE_MASK:	! DEFi <A>	; signature const SCORE_MASK : int
-CHECKMATE:	! DEFi #0xFFFF	; signature const CHECKMATE : int
-STALEMATE:	! DEFi #0xFFFE	; signature const STALEMATE : int
-IN_CHECK:	! DEFi #0xFFFD	; signature const IN_CHECK : int
-VALID_MOVE:	! DEFi #0xFFFC	; signature const VALID_MOVE : int
-INVALID_MOVE:	! DEFi #-1	; signature const INVALID_MOVE : int
-MAX_SCORE:	! DEFi #10000	; signature const MAX_SCORE : int
+SCORE_MASK:	! DEFi <A>	; signature const SCORE_MASK : int @ 42:1
+CHECKMATE:	! DEFi #0xFFFF	; signature const CHECKMATE : int @ 43:1
+STALEMATE:	! DEFi #0xFFFE	; signature const STALEMATE : int @ 44:1
+IN_CHECK:	! DEFi #0xFFFD	; signature const IN_CHECK : int @ 45:1
+VALID_MOVE:	! DEFi #0xFFFC	; signature const VALID_MOVE : int @ 46:1
+INVALID_MOVE:	! DEFi #-1	; signature const INVALID_MOVE : int @ 47:1
+MAX_SCORE:	! DEFi #10000	; signature const MAX_SCORE : int @ 48:1
 	! SUBi <A> #0 #MAX_SCORE
-MIN_SCORE:	! DEFi <A>	; signature const MIN_SCORE : int
-PAWN_VALUE:	! DEFi #100	; signature const PAWN_VALUE : int
+MIN_SCORE:	! DEFi <A>	; signature const MIN_SCORE : int @ 49:1
+PAWN_VALUE:	! DEFi #100	; signature const PAWN_VALUE : int @ 50:1
 	! MULi <A> #9 #PAWN_VALUE
-QUEEN_VALUE:	! DEFi <A>	; signature const QUEEN_VALUE : int
+QUEEN_VALUE:	! DEFi <A>	; signature const QUEEN_VALUE : int @ 51:1
 	! SUBi <A> #QUEEN_VALUE #PAWN_VALUE
-PROMOTION_SCORE:	! DEFi <A>	; signature const PROMOTION_SCORE : int
+PROMOTION_SCORE:	! DEFi <A>	; signature const PROMOTION_SCORE : int @ 52:1
 	! SUBi <A> #MAX_SCORE #MAX_DEPTH
-CAPTURE_KING_MIN_SCORE:	! DEFi <A>	; signature const CAPTURE_KING_MIN_SCORE : int
+CAPTURE_KING_MIN_SCORE:	! DEFi <A>	; signature const CAPTURE_KING_MIN_SCORE : int @ 53:1
 	! DIVi <A> #PAWN_VALUE #10
-RANDOM_AMOUNT:	! DEFi <A>	; signature const RANDOM_AMOUNT : int
+RANDOM_AMOUNT:	! DEFi <A>	; signature const RANDOM_AMOUNT : int @ 54:1
 	! DIVi <A> #PAWN_VALUE #10
-PAWN_ADVANCE_SCORE:	! DEFi <A>	; signature const PAWN_ADVANCE_SCORE : int
+PAWN_ADVANCE_SCORE:	! DEFi <A>	; signature const PAWN_ADVANCE_SCORE : int @ 55:1
 	! DIVi <A> #PAWN_VALUE #2
-CASTLING_SCORE:	! DEFi <A>	; signature const CASTLING_SCORE : int
-CASTLING_MASK:	! DEFi #0x80	; signature const CASTLING_MASK : int
-HISTORY_SIZE:	! DEFi #256	; signature const HISTORY_SIZE : int
-DIRS:	CNST *8	; signature array DIRS[8] : unknown
+CASTLING_SCORE:	! DEFi <A>	; signature const CASTLING_SCORE : int @ 56:1
+CASTLING_MASK:	! DEFi #0x80	; signature const CASTLING_MASK : int @ 57:1
+HISTORY_SIZE:	! DEFi #256	; signature const HISTORY_SIZE : int @ 59:1
+DIRS:	CNST *8	; signature array DIRS[8] : unknown @ 59:24
 	! ADDi <A> #STRIDE #1
 	DATA #STRIDE
 	DATA <A>
@@ -93,7 +93,7 @@ DIRS:	CNST *8	; signature array DIRS[8] : unknown
 	! SUBi <A> #STRIDE #1
 	DATA #-1
 	DATA <A>
-KNIGHT_MOVES:	CNST *8	; signature array KNIGHT_MOVES[8] : unknown
+KNIGHT_MOVES:	CNST *8	; signature array KNIGHT_MOVES[8] : unknown @ 60:32
 	! MULi <A> #STRIDE #2
 	! ADDi <A> <A> #1
 	! ADDi <B> #2 #STRIDE
@@ -117,7 +117,7 @@ KNIGHT_MOVES:	CNST *8	; signature array KNIGHT_MOVES[8] : unknown
 	! SUBi <B> <B> #1
 	DATA <A>
 	DATA <B>
-PIECE_VALUES:	CNST *7	; signature array PIECE_VALUES[7] : unknown
+PIECE_VALUES:	CNST *7	; signature array PIECE_VALUES[7] : unknown @ 61:32
 	! MULi <B> #5 #PAWN_VALUE
 	DATA #0 #PAWN_VALUE
 	! MULi <A> #3 #PAWN_VALUE
@@ -127,12 +127,12 @@ PIECE_VALUES:	CNST *7	; signature array PIECE_VALUES[7] : unknown
 	DATA <B>
 	DATA #QUEEN_VALUE #MAX_SCORE
 	! ADDi <B> #8 #4
-RANK_VALUES:	CNST *<B>	; signature array RANK_VALUES[<B>] : unknown
+RANK_VALUES:	CNST *<B>	; signature array RANK_VALUES[<B>] : unknown @ 62:34
 	DATA #0 #0 #0 #30 #50 #60 #60 #50 #30 #0 #0 #0
-MAX_TARGET_SQUARES:	! DEFi #32	; signature const MAX_TARGET_SQUARES : int
-MAX_MOVES:	! DEFi #256	; signature const MAX_MOVES : int
-MAX_CAPTURES:	! DEFi #32	; signature const MAX_CAPTURES : int
-INIT_BOARD:	CNST *BOARD_SIZE	; signature array INIT_BOARD[BOARD_SIZE] : unknown
+MAX_TARGET_SQUARES:	! DEFi #32	; signature const MAX_TARGET_SQUARES : int @ 65:1
+MAX_MOVES:	! DEFi #256	; signature const MAX_MOVES : int @ 66:1
+MAX_CAPTURES:	! DEFi #32	; signature const MAX_CAPTURES : int @ 69:1
+INIT_BOARD:	CNST *BOARD_SIZE	; signature array INIT_BOARD[BOARD_SIZE] : unknown @ 69:39
 	DATA #OFFBOARD #OFFBOARD #OFFBOARD #OFFBOARD #OFFBOARD
 	DATA #OFFBOARD #OFFBOARD #OFFBOARD #OFFBOARD #OFFBOARD
 	DATA #OFFBOARD #OFFBOARD #OFFBOARD #OFFBOARD #OFFBOARD
@@ -220,45 +220,45 @@ INIT_BOARD:	CNST *BOARD_SIZE	; signature array INIT_BOARD[BOARD_SIZE] : unknown
 	DATi #32
 	DATs PRNBQK  prnbqk
 	DATi #32 #0
-PIECE_CHARS:	! DEFp &.s_PRNBQK4d2	; signature const PIECE_CHARS : ptr
-PIECE_NAMES:	CNST *8	; signature array PIECE_NAMES[8] : unknown
+PIECE_CHARS:	! DEFp &.s_PRNBQK4d2	; signature const PIECE_CHARS : ptr @ 84:47
+PIECE_NAMES:	CNST *8	; signature array PIECE_NAMES[8] : unknown @ 85:31
 	DATA &.s_PRNBQK4d2:16 &.s_pawn4d2 &.s_rook4d3
 	DATA &.s_knight4d4 &.s_bishop4d5 &.s_queen4d6 &.s_king4d7
-board:	GLOB *BOARD_SIZE	; signature array board[BOARD_SIZE] : unknown
-nextPiece:	GLOB *BOARD_SIZE	; signature array nextPiece[BOARD_SIZE] : unknown
-prevPiece:	GLOB *BOARD_SIZE	; signature array prevPiece[BOARD_SIZE] : unknown
+board:	GLOB *BOARD_SIZE	; signature array board[BOARD_SIZE] : unknown @ 87:31
+nextPiece:	GLOB *BOARD_SIZE	; signature array nextPiece[BOARD_SIZE] : unknown @ 88:35
+prevPiece:	GLOB *BOARD_SIZE	; signature array prevPiece[BOARD_SIZE] : unknown @ 89:35
 	GLOB *1
-xCapture:	DATi #0	; signature global xCapture : int
+xCapture:	DATi #0	; signature global xCapture : int @ 90:20
 	GLOB *1
-turnColor:	DATi #0	; signature global turnColor : int
+turnColor:	DATi #0	; signature global turnColor : int @ 91:21
 	GLOB *1
-boardHash:	DATi #0	; signature global boardHash : int
+boardHash:	DATi #0	; signature global boardHash : int @ 92:21
 	! MULi <B> #64 #1024
-HASH_TABLE_SIZE:	! DEFi <B>	; signature const HASH_TABLE_SIZE : int
+HASH_TABLE_SIZE:	! DEFi <B>	; signature const HASH_TABLE_SIZE : int @ 110:1
 	! XORi <B> #0 #-1
-HASH_MASK:	! DEFi <B>	; signature const HASH_MASK : int
+HASH_MASK:	! DEFi <B>	; signature const HASH_MASK : int @ 112:1
 	! MULi <B> #BOARD_SIZE #64
-pieceKeys:	GLOB *<B>	; signature array pieceKeys[<B>] : unknown
-xCaptureKeys:	GLOB *256	; signature array xCaptureKeys[256] : unknown
+pieceKeys:	GLOB *<B>	; signature array pieceKeys[<B>] : unknown @ 112:40
+xCaptureKeys:	GLOB *256	; signature array xCaptureKeys[256] : unknown @ 113:31
 	! ADDi <B> #WHITE #1
-colorKeys:	GLOB *<B>	; signature array colorKeys[<B>] : unknown
-hashTable:	GLOB *HASH_TABLE_SIZE	; signature array hashTable[HASH_TABLE_SIZE] : unknown
+colorKeys:	GLOB *<B>	; signature array colorKeys[<B>] : unknown @ 114:34
+hashTable:	GLOB *HASH_TABLE_SIZE	; signature array hashTable[HASH_TABLE_SIZE] : unknown @ 115:40
 	GLOB *1
-evalCounter:	DATi #0	; signature global evalCounter : int
+evalCounter:	DATi #0	; signature global evalCounter : int @ 116:27
 	! MULi <B> #HISTORY_SIZE #4
-history:	GLOB *<B>	; signature array history[<B>] : unknown
+history:	GLOB *<B>	; signature array history[<B>] : unknown @ 117:39
 	GLOB *1
-historyCount:	DATi #0	; signature global historyCount : int
+historyCount:	DATi #0	; signature global historyCount : int @ 118:28
 	GLOB *1
-minEvals:	DATi #10000	; signature global minEvals : int
+minEvals:	DATi #10000	; signature global minEvals : int @ 119:28
 	GLOB *1
-randPX:	DATi #123456789	; signature global randPX : int
+randPX:	DATi #123456789	; signature global randPX : int @ 121:30
 	GLOB *1
-randPY:	DATi #362436069	; signature global randPY : int
+randPY:	DATi #362436069	; signature global randPY : int @ 122:30
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-nextRandom:	FUNC	; signature func nextRandom() -> int
+nextRandom:	FUNC	; signature func nextRandom() -> int @ 124:21
 	$x:	LOCi
 	$t:	LOCi
 ;-----------------------------------------------------------------------------
@@ -279,30 +279,30 @@ nextRandom:	FUNC	; signature func nextRandom() -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-initGlobals:	FUNC	; signature func initGlobals() -> void
+initGlobals:	FUNC	; signature func initGlobals() -> void @ 139:22
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
 		MOVi $i #0 	; for (i = 0 to 64 * BOARD_SIZE) 
 		! MULi <B> #64 #BOARD_SIZE
 		GEQi #0 <B> @.e0
-	.l1:	CALL &nextRandom %0 *1	; expects nextRandom() -> int
+	.l1:	CALL &nextRandom %0 *1	; expects nextRandom() -> int @ 148:37
 		POKE &pieceKeys $i %0
 		FORi $i <B> @.l1	; }
 	.e0:	MOVi $i #0 	; for (i = 0 to 256) 
 		GEQi #0 #256 @.e2
-	.l3:	CALL &nextRandom %0 *1	; expects nextRandom() -> int
+	.l3:	CALL &nextRandom %0 *1	; expects nextRandom() -> int @ 151:40
 		POKE &xCaptureKeys $i %0
 		FORi $i #256 @.l3	; }
-	.e2:	CALL &nextRandom %0 *1	; expects nextRandom() -> int
+	.e2:	CALL &nextRandom %0 *1	; expects nextRandom() -> int @ 153:40
 		POKE &colorKeys:WHITE %0 
-		CALL &nextRandom %0 *1	; expects nextRandom() -> int
+		CALL &nextRandom %0 *1	; expects nextRandom() -> int @ 154:40
 		POKE &colorKeys:BLACK %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-isOnBoard:	FUNC	; signature func isOnBoard(int square) -> int
+isOnBoard:	FUNC	; signature func isOnBoard(int square) -> int @ 157:20
 	$square:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $b #FALSE 	; b = FALSE
@@ -316,7 +316,7 @@ isOnBoard:	FUNC	; signature func isOnBoard(int square) -> int
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-isValidColor:	FUNC	; signature func isValidColor(int color) -> int
+isValidColor:	FUNC	; signature func isValidColor(int color) -> int @ 166:23
 	$color:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $b #FALSE 	; b = FALSE
@@ -328,18 +328,18 @@ isValidColor:	FUNC	; signature func isValidColor(int color) -> int
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-isValidMove:	FUNC	; signature func isValidMove(int move) -> int
+isValidMove:	FUNC	; signature func isValidMove(int move) -> int @ 175:22
 	$move:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $b #FALSE 	; b = FALSE
 		ANDi %0 $move #MOVE_MASK	; if ((move & MOVE_MASK) == move && (int) isOnBoard(move & FROM_MASK) != FALSE && (int) isOnBoard((move & TO_MASK) >> TO_SHIFT) != FALSE) 
 		NEQi %0 $move @.f1
 		ANDi %1 $move #FROM_MASK
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 179:70
 		EQUi %0 #FALSE @.f1
 		ANDi %1 $move #TO_MASK
 		SHRi %1 %1 #TO_SHIFT
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 179:128
 		EQUi %0 #FALSE @.f1
 		MOVi $b #TRUE 	; b = TRUE
 	.f1:	RETU   	; }
@@ -347,7 +347,7 @@ isValidMove:	FUNC	; signature func isValidMove(int move) -> int
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-isValidPiece:	FUNC	; signature func isValidPiece(int piece) -> int
+isValidPiece:	FUNC	; signature func isValidPiece(int piece) -> int @ 184:23
 	$piece:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $b #FALSE 	; b = FALSE
@@ -358,7 +358,7 @@ isValidPiece:	FUNC	; signature func isValidPiece(int piece) -> int
 		ANDi %0 $piece #PIECE_MASK
 		GRTi %0 #6 @.f1
 		ANDi %1 $piece #COLOR_MASK
-		CALL &isValidColor %0 *2	; expects isValidColor(int) -> int
+		CALL &isValidColor %0 *2	; expects isValidColor(int) -> int @ 189:46
 		EQUi %0 #FALSE @.f1
 		MOVi $b #TRUE 	; b = TRUE
 	.f1:	RETU   	; }
@@ -366,12 +366,12 @@ isValidPiece:	FUNC	; signature func isValidPiece(int piece) -> int
 
 ;-----------------------------------------------------------------------------
 	$f:	OUTi
-moveFrom:	FUNC	; signature func moveFrom(int move) -> int
+moveFrom:	FUNC	; signature func moveFrom(int move) -> int @ 194:19
 	$move:	INPi
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isValidMove(move) != FALSE)
 		MOVi %1 $move 
-		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int
+		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int @ 197:33
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisV4d2 
 		CALL ^assertFail %0 *1
@@ -381,12 +381,12 @@ moveFrom:	FUNC	; signature func moveFrom(int move) -> int
 
 ;-----------------------------------------------------------------------------
 	$t:	OUTi
-moveTo:	FUNC	; signature func moveTo(int move) -> int
+moveTo:	FUNC	; signature func moveTo(int move) -> int @ 201:17
 	$move:	INPi
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isValidMove(move) != FALSE)
 		MOVi %1 $move 
-		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int
+		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int @ 204:33
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisV4d2 
 		CALL ^assertFail %0 *1
@@ -396,7 +396,7 @@ moveTo:	FUNC	; signature func moveTo(int move) -> int
 
 ;-----------------------------------------------------------------------------
 	$m:	OUTi
-makeMove:	FUNC	; signature func makeMove(int fromCol, int fromRow, int toCol, int toRow) -> int
+makeMove:	FUNC	; signature func makeMove(int fromCol, int fromRow, int toCol, int toRow) -> int @ 208:19
 	$fromCol:	INPi
 	$fromRow:	INPi
 	$toCol:	INPi
@@ -417,7 +417,7 @@ makeMove:	FUNC	; signature func makeMove(int fromCol, int fromRow, int toCol, in
 
 ;-----------------------------------------------------------------------------
 	$c:	OUTi
-switchColor:	FUNC	; signature func switchColor(int color) -> int
+switchColor:	FUNC	; signature func switchColor(int color) -> int @ 214:22
 	$color:	INPi
 ;-----------------------------------------------------------------------------
 		XORi $c $color #COLOR_SWITCH_XOR	; c = (color ^ COLOR_SWITCH_XOR)
@@ -426,7 +426,7 @@ switchColor:	FUNC	; signature func switchColor(int color) -> int
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-checkInvariant:	FUNC	; signature func checkInvariant() -> int
+checkInvariant:	FUNC	; signature func checkInvariant() -> int @ 220:25
 	! IORi <B> #BLACK #WHITE
 	! ADDi <B> <B> #1
 	! IORi <B> #BLACK #WHITE
@@ -441,7 +441,7 @@ checkInvariant:	FUNC	; signature func checkInvariant() -> int
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isValidColor(global turnColor) != FALSE)
 		PEEK %1 &turnColor 
-		CALL &isValidColor %0 *2	; expects isValidColor(int) -> int
+		CALL &isValidColor %0 *2	; expects isValidColor(int) -> int @ 225:46
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisV4d3 
 		CALL ^assertFail %0 *1
@@ -459,7 +459,7 @@ checkInvariant:	FUNC	; signature func checkInvariant() -> int
 		PEEK %1 &xCapture 
 		! XORi <B> #128 #-1
 		ANDi %1 %1 <B>
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 229:50
 		NEQi %0 #FALSE @.a4
 		MOVp %1 &.a_intisO4d5 
 		CALL ^assertFail %0 *1
@@ -540,7 +540,7 @@ checkInvariant:	FUNC	; signature func checkInvariant() -> int
 	.a19:	NOOP
 		! EQUi #DEBUG #0 @.a20	; assert((int) isValidPiece(p) != FALSE)
 		MOVi %1 $p 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 249:33
 		NEQi %0 #FALSE @.a20
 		MOVp %1 &.a_intisV4db 
 		CALL ^assertFail %0 *1
@@ -550,7 +550,7 @@ checkInvariant:	FUNC	; signature func checkInvariant() -> int
 		SETL $counts $color %0
 		GOTO @.l17  	; }
 	.e18:	MOVi %1 $color 	; color = (int) switchColor(color)
-		CALL &switchColor %0 *2	; expects switchColor(int) -> int
+		CALL &switchColor %0 *2	; expects switchColor(int) -> int @ 253:35
 		MOVi $color %0 
 		NEQi $color #BLACK @.l16	; } while (color != BLACK)
 		MOVi $h #0 	; h = 0
@@ -568,7 +568,7 @@ checkInvariant:	FUNC	; signature func checkInvariant() -> int
 	.a23:	LEQi $p #EMPTY @.f25	; if (p > EMPTY) 
 		! EQUi #DEBUG #0 @.a26	; assert((int) isValidPiece(p) != FALSE)
 		MOVi %1 $p 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 262:33
 		NEQi %0 #FALSE @.a26
 		MOVp %1 &.a_intisV4db 
 		CALL ^assertFail %0 *1
@@ -611,7 +611,7 @@ checkInvariant:	FUNC	; signature func checkInvariant() -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-putPiece:	FUNC	; signature func putPiece(int square, int piece) -> void
+putPiece:	FUNC	; signature func putPiece(int square, int piece) -> void @ 276:19
 	$square:	INPi
 	$piece:	INPi
 	$c:	LOCi
@@ -619,14 +619,14 @@ putPiece:	FUNC	; signature func putPiece(int square, int piece) -> void
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(square) != FALSE)
 		MOVi %1 $square 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 279:33
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e1 
 		CALL ^assertFail %0 *1
 	.a0:	NOOP
 		! EQUi #DEBUG #0 @.a1	; assert((int) isValidPiece(piece) != FALSE)
 		MOVi %1 $piece 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 280:35
 		NEQi %0 #FALSE @.a1
 		MOVp %1 &.a_intisV4e2 
 		CALL ^assertFail %0 *1
@@ -655,7 +655,7 @@ putPiece:	FUNC	; signature func putPiece(int square, int piece) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-liftPiece:	FUNC	; signature func liftPiece(int square) -> void
+liftPiece:	FUNC	; signature func liftPiece(int square) -> void @ 293:20
 	$square:	INPi
 	$piece:	LOCi
 	$n:	LOCi
@@ -663,7 +663,7 @@ liftPiece:	FUNC	; signature func liftPiece(int square) -> void
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(square) != FALSE)
 		MOVi %1 $square 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 296:33
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e1 
 		CALL ^assertFail %0 *1
@@ -689,7 +689,7 @@ liftPiece:	FUNC	; signature func liftPiece(int square) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-movePiece:	FUNC	; signature func movePiece(int frm, int t, int newPiece) -> void
+movePiece:	FUNC	; signature func movePiece(int frm, int t, int newPiece) -> void @ 308:20
 	$frm:	INPi
 	$t:	INPi
 	$newPiece:	INPi
@@ -699,21 +699,21 @@ movePiece:	FUNC	; signature func movePiece(int frm, int t, int newPiece) -> void
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(frm) != FALSE)
 		MOVi %1 $frm 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 311:30
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e5 
 		CALL ^assertFail %0 *1
 	.a0:	NOOP
 		! EQUi #DEBUG #0 @.a1	; assert((int) isOnBoard(t) != FALSE)
 		MOVi %1 $t 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 312:28
 		NEQi %0 #FALSE @.a1
 		MOVp %1 &.a_intisO4e6 
 		CALL ^assertFail %0 *1
 	.a1:	NOOP
 		! EQUi #DEBUG #0 @.a2	; assert((int) isValidPiece(newPiece) != FALSE)
 		MOVi %1 $newPiece 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 313:38
 		NEQi %0 #FALSE @.a2
 		MOVp %1 &.a_intisV4e7 
 		CALL ^assertFail %0 *1
@@ -732,7 +732,7 @@ movePiece:	FUNC	; signature func movePiece(int frm, int t, int newPiece) -> void
 		PEEK $oldPiece &board $frm	; oldPiece = (int) global board[frm]
 		! EQUi #DEBUG #0 @.a5	; assert((int) isValidPiece(oldPiece) != FALSE)
 		MOVi %1 $oldPiece 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 319:38
 		NEQi %0 #FALSE @.a5
 		MOVp %1 &.a_intisV4ea 
 		CALL ^assertFail %0 *1
@@ -759,7 +759,7 @@ movePiece:	FUNC	; signature func movePiece(int frm, int t, int newPiece) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-restart:	FUNC	; signature func restart() -> void
+restart:	FUNC	; signature func restart() -> void @ 330:18
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
 		POKE &prevPiece:WHITE #WHITE 	; global nextPiece[WHITE] = (int) global prevPiece[WHITE] = WHITE
@@ -778,7 +778,7 @@ restart:	FUNC	; signature func restart() -> void
 		LEQi %1 #EMPTY @.f4
 		MOVi %1 $i 	; putPiece(i, (int) global INIT_BOARD[i])
 		PEEK %2 &INIT_BOARD $i
-		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void
+		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void @ 341:43
 	.f4:	NOOP
 	.e3:	FORi $i #BOARD_SIZE @.l1	; }
 	.e0:	MOVi $i #0 	; for (i = 0 to HASH_TABLE_SIZE) 
@@ -789,7 +789,7 @@ restart:	FUNC	; signature func restart() -> void
 		POKE &xCapture #0 	; global xCapture = 0
 		POKE &historyCount #0 	; global historyCount = 0
 		! EQUi #DEBUG #0 @.a7	; assert((int) checkInvariant() != FALSE)
-		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int
+		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int @ 350:32
 		NEQi %0 #FALSE @.a7
 		MOVp %1 &.a_intche4eb 
 		CALL ^assertFail %0 *1
@@ -798,7 +798,7 @@ restart:	FUNC	; signature func restart() -> void
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-squareCapturesCastlingKing:	FUNC	; signature func squareCapturesCastlingKing(int square) -> int
+squareCapturesCastlingKing:	FUNC	; signature func squareCapturesCastlingKing(int square) -> int @ 353:37
 	$square:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $b #FALSE 	; b = FALSE
@@ -816,12 +816,12 @@ squareCapturesCastlingKing:	FUNC	; signature func squareCapturesCastlingKing(int
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-squareCapturesKing:	FUNC	; signature func squareCapturesKing(int square) -> int
+squareCapturesKing:	FUNC	; signature func squareCapturesKing(int square) -> int @ 369:29
 	$square:	INPi
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(square) != FALSE)
 		MOVi %1 $square 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 372:33
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e1 
 		CALL ^assertFail %0 *1
@@ -830,7 +830,7 @@ squareCapturesKing:	FUNC	; signature func squareCapturesKing(int square) -> int
 		ANDi %0 %0 #PIECE_MASK
 		EQUi %0 #KING @.t1
 		MOVi %1 $square 
-		CALL &squareCapturesCastlingKing %0 *2	; expects squareCapturesCastlingKing(int) -> int
+		CALL &squareCapturesCastlingKing %0 *2	; expects squareCapturesCastlingKing(int) -> int @ 375:100
 		EQUi %0 #FALSE @.f2
 	.t1:	MOVi $b #TRUE 	; b = TRUE
 	.f2:	RETU   	; }
@@ -838,7 +838,7 @@ squareCapturesKing:	FUNC	; signature func squareCapturesKing(int square) -> int
 
 ;-----------------------------------------------------------------------------
 	$score:	OUTi
-doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured, int oldXCapture) -> int
+doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured, int oldXCapture) -> int @ 394:17
 	$frm:	INPi
 	$t:	INPi
 	$oldPiece:	INPi
@@ -848,21 +848,21 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(frm) != FALSE)
 		MOVi %1 $frm 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 398:30
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e5 
 		CALL ^assertFail %0 *1
 	.a0:	NOOP
 		! EQUi #DEBUG #0 @.a1	; assert((int) isOnBoard(t) != FALSE)
 		MOVi %1 $t 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 399:28
 		NEQi %0 #FALSE @.a1
 		MOVp %1 &.a_intisO4e6 
 		CALL ^assertFail %0 *1
 	.a1:	NOOP
 		! EQUi #DEBUG #0 @.a2	; assert((int) isValidPiece(oldPiece) != FALSE)
 		MOVi %1 $oldPiece 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 400:38
 		NEQi %0 #FALSE @.a2
 		MOVp %1 &.a_intisV4ea 
 		CALL ^assertFail %0 *1
@@ -870,7 +870,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		! EQUi #DEBUG #0 @.a3	; assert(captured == EMPTY || (int) isValidPiece(captured) != FALSE)
 		EQUi $captured #EMPTY @.a3
 		MOVi %1 $captured 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 401:59
 		NEQi %0 #FALSE @.a3
 		MOVp %1 &.a_captur4ec 
 		CALL ^assertFail %0 *1
@@ -881,12 +881,12 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		CALL ^assertFail %0 *1
 	.a5:	NOOP
 		! EQUi #DEBUG #0 @.a6	; assert((int) checkInvariant() != FALSE)
-		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int
+		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int @ 404:32
 		NEQi %0 #FALSE @.a6
 		MOVp %1 &.a_intche4eb 
 		CALL ^assertFail %0 *1
 	.a6:	MOVi $newPiece $oldPiece 	; newPiece = oldPiece
-		CALL &nextRandom %0 *1	; expects nextRandom() -> int
+		CALL &nextRandom %0 *1	; expects nextRandom() -> int @ 407:30
 		ANDi %0 %0 #7
 		SUBi $score %0 #4
 		POKE &xCapture #0 	; global xCapture = 0
@@ -905,7 +905,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		ADDi %2 #RANK_1 #4
 		! IORi <B> #ROOK #WHITE
 		IORi %3 <B> #MOVED_MASK
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 417:66
 		! ADDi <B> #RANK_1 #4	; global xCapture = (RANK_1 + 4) | CASTLING_MASK
 		! IORi <B> <B> #CASTLING_MASK
 		POKE &xCapture <B> 
@@ -917,7 +917,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		ADDi %2 #RANK_1 #6
 		! IORi <B> #ROOK #WHITE
 		IORi %3 <B> #MOVED_MASK
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 426:66
 		! ADDi <B> #RANK_1 #6	; global xCapture = (RANK_1 + 6) | CASTLING_MASK
 		! IORi <B> <B> #CASTLING_MASK
 		POKE &xCapture <B> 
@@ -944,7 +944,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		ADDi %2 #RANK_8 #4
 		! IORi <A> #ROOK #BLACK
 		IORi %3 <A> #MOVED_MASK
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 444:66
 		! ADDi <A> #RANK_8 #4	; global xCapture = (RANK_8 + 4) | CASTLING_MASK
 		! IORi <A> <A> #CASTLING_MASK
 		POKE &xCapture <A> 
@@ -956,7 +956,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		ADDi %2 #RANK_8 #6
 		! IORi <A> #ROOK #BLACK
 		IORi %3 <A> #MOVED_MASK
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 453:66
 		! ADDi <A> #RANK_8 #6	; global xCapture = (RANK_8 + 6) | CASTLING_MASK
 		! IORi <A> <A> #CASTLING_MASK
 		POKE &xCapture <A> 
@@ -981,7 +981,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		MOVp %1 &.a_intglo4ed 
 		CALL ^assertFail %0 *1
 	.a14:	SUBi %1 $t #STRIDE	; liftPiece(t - STRIDE)
-		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void
+		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void @ 470:26
 		ADDi %0 $score #PAWN_ADVANCE_SCORE	; score = score + PAWN_ADVANCE_SCORE + PAWN_VALUE
 		ADDi $score %0 #PAWN_VALUE
 		GOTO @.e8  	; } else if (t >= RANK_8) 
@@ -1006,7 +1006,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		MOVp %1 &.a_intglo4ee 
 		CALL ^assertFail %0 *1
 	.a19:	ADDi %1 $t #STRIDE	; liftPiece(t + STRIDE)
-		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void
+		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void @ 491:26
 		ADDi %0 $score #PAWN_ADVANCE_SCORE	; score = score + PAWN_ADVANCE_SCORE + PAWN_VALUE
 		ADDi $score %0 #PAWN_VALUE
 		GOTO @.e8  	; } else if (t < RANK_2) 
@@ -1041,11 +1041,11 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		SUBi $score %0 %1
 	.e8:	LEQi $captured #EMPTY @.f25	; if (captured > EMPTY) 
 		MOVi %1 $t 	; liftPiece(t)
-		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void
+		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void @ 533:15
 	.f25:	MOVi %1 $frm 	; movePiece(frm, t, newPiece | MOVED_MASK)
 		MOVi %2 $t 
 		IORi %3 $newPiece #MOVED_MASK
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 535:42
 		! IORi <B> #PIECE_MASK #COLOR_MASK	; switch ((captured & (PIECE_MASK | COLOR_MASK)) == 0 to MAX_PIECE_AND_MOVED_VALUE) 
 		ANDi %0 $captured <B>
 		SWCH %0 *MAX_PIECE_AND_MOVED_VALUE @.s26
@@ -1071,10 +1071,10 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		PEEK %1 &RANK_VALUES %1
 		ADDi $score %0 %1
 	.e27:	PEEK %1 &turnColor 	; global turnColor = (int) switchColor(global turnColor)
-		CALL &switchColor %0 *2	; expects switchColor(int) -> int
+		CALL &switchColor %0 *2	; expects switchColor(int) -> int @ 558:56
 		POKE &turnColor %0 
 		! EQUi #DEBUG #0 @.a28	; assert((int) checkInvariant() != FALSE)
-		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int
+		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int @ 560:32
 		NEQi %0 #FALSE @.a28
 		MOVp %1 &.a_intche4eb 
 		CALL ^assertFail %0 *1
@@ -1083,7 +1083,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captured, int oldXCapture) -> void
+undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captured, int oldXCapture) -> void @ 565:19
 	$frm:	INPi
 	$t:	INPi
 	$oldPiece:	INPi
@@ -1092,21 +1092,21 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(frm) != FALSE)
 		MOVi %1 $frm 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 567:30
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e5 
 		CALL ^assertFail %0 *1
 	.a0:	NOOP
 		! EQUi #DEBUG #0 @.a1	; assert((int) isOnBoard(t) != FALSE)
 		MOVi %1 $t 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 568:28
 		NEQi %0 #FALSE @.a1
 		MOVp %1 &.a_intisO4e6 
 		CALL ^assertFail %0 *1
 	.a1:	NOOP
 		! EQUi #DEBUG #0 @.a2	; assert((int) isValidPiece(oldPiece) != FALSE)
 		MOVi %1 $oldPiece 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 569:38
 		NEQi %0 #FALSE @.a2
 		MOVp %1 &.a_intisV4ea 
 		CALL ^assertFail %0 *1
@@ -1114,7 +1114,7 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 		! EQUi #DEBUG #0 @.a3	; assert(captured == EMPTY || (int) isValidPiece(captured) != FALSE)
 		EQUi $captured #EMPTY @.a3
 		MOVi %1 $captured 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 570:59
 		NEQi %0 #FALSE @.a3
 		MOVp %1 &.a_captur4ec 
 		CALL ^assertFail %0 *1
@@ -1125,20 +1125,20 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 		CALL ^assertFail %0 *1
 	.a5:	NOOP
 		! EQUi #DEBUG #0 @.a6	; assert((int) checkInvariant() != FALSE)
-		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int
+		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int @ 573:32
 		NEQi %0 #FALSE @.a6
 		MOVp %1 &.a_intche4eb 
 		CALL ^assertFail %0 *1
 	.a6:	POKE &xCapture $oldXCapture 	; global xCapture = oldXCapture
 		MOVi %1 $frm 	; putPiece(frm, oldPiece)
 		MOVi %2 $oldPiece 
-		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void
+		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void @ 576:25
 		MOVi %1 $t 	; liftPiece(t)
-		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void
+		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void @ 577:14
 		LEQi $captured #EMPTY @.f7	; if (captured > EMPTY) 
 		MOVi %1 $t 	; putPiece(t, captured)
 		MOVi %2 $captured 
-		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void
+		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void @ 579:24
 	.f7:	SWCH $oldPiece *MAX_PIECE_AND_MOVED_VALUE @.s8	; switch (oldPiece == 0 to MAX_PIECE_AND_MOVED_VALUE) 
 		! IORi <B> #KING #WHITE	; case KING | WHITE
 	.s8#<B>:	NOOP
@@ -1153,14 +1153,14 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 	.s10#<B>:	ADDi %1 #RANK_1 #4	; movePiece(RANK_1 + 4, RANK_1 + 1, ROOK | WHITE)
 		ADDi %2 #RANK_1 #1
 		IORi %3 #ROOK #WHITE
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 589:53
 		GOTO @.e9  	; }
 		! ADDi <B> #RANK_1 #7	; case RANK_1 + 7
 		! SUBi <B> <B> <A>
 	.s10#<B>:	ADDi %1 #RANK_1 #6	; movePiece(RANK_1 + 6, RANK_1 + 8, ROOK | WHITE)
 		ADDi %2 #RANK_1 #8
 		IORi %3 #ROOK #WHITE
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 596:53
 	.s10:	NOOP
 	.e11:	GOTO @.e9  	; }
 		! IORi <A> #KING #BLACK	; case KING | BLACK
@@ -1176,14 +1176,14 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 	.s12#<A>:	ADDi %1 #RANK_8 #4	; movePiece(RANK_8 + 4, RANK_8 + 1, ROOK | BLACK)
 		ADDi %2 #RANK_8 #1
 		IORi %3 #ROOK #BLACK
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 607:53
 		GOTO @.e9  	; }
 		! ADDi <A> #RANK_8 #7	; case RANK_8 + 7
 		! SUBi <A> <A> <B>
 	.s12#<A>:	ADDi %1 #RANK_8 #6	; movePiece(RANK_8 + 6, RANK_8 + 8, ROOK | BLACK)
 		ADDi %2 #RANK_8 #8
 		IORi %3 #ROOK #BLACK
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 614:53
 	.s12:	NOOP
 	.e13:	GOTO @.e9  	; }
 		! IORi <B> #PAWN #WHITE	; case PAWN | WHITE | MOVED_MASK
@@ -1192,7 +1192,7 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 		SUBi %1 $t #STRIDE	; putPiece(t - STRIDE, PAWN | BLACK | MOVED_MASK)
 		! IORi <B> #PAWN #BLACK
 		IORi %2 <B> #MOVED_MASK
-		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void
+		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void @ 624:52
 		GOTO @.e9  	; }
 		! IORi <B> #PAWN #BLACK	; case PAWN | BLACK | MOVED_MASK
 		! IORi <B> <B> #MOVED_MASK
@@ -1200,14 +1200,14 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 		ADDi %1 $t #STRIDE	; putPiece(t + STRIDE, PAWN | WHITE | MOVED_MASK)
 		! IORi <B> #PAWN #WHITE
 		IORi %2 <B> #MOVED_MASK
-		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void
+		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void @ 633:52
 	.f15:	NOOP
 	.s8:	NOOP
 	.e9:	PEEK %1 &turnColor 	; global turnColor = (int) switchColor(global turnColor)
-		CALL &switchColor %0 *2	; expects switchColor(int) -> int
+		CALL &switchColor %0 *2	; expects switchColor(int) -> int @ 638:56
 		POKE &turnColor %0 
 		! EQUi #DEBUG #0 @.a16	; assert((int) checkInvariant() != FALSE)
-		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int
+		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int @ 640:32
 		NEQi %0 #FALSE @.a16
 		MOVp %1 &.a_intche4eb 
 		CALL ^assertFail %0 *1
@@ -1216,7 +1216,7 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 
 ;-----------------------------------------------------------------------------
 	$newToCount:	OUTi
-traceRBQ:	FUNC	; signature func traceRBQ(int color, int frm, int toCount, ptr tos, int start, int step) -> int
+traceRBQ:	FUNC	; signature func traceRBQ(int color, int frm, int toCount, ptr tos, int start, int step) -> int @ 643:19
 	$color:	INPi
 	$frm:	INPi
 	$toCount:	INPi
@@ -1230,13 +1230,13 @@ traceRBQ:	FUNC	; signature func traceRBQ(int color, int frm, int toCount, ptr to
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(frm) != FALSE)
 		MOVi %1 $frm 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 647:30
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e5 
 		CALL ^assertFail %0 *1
 	.a0:	MOVi $newToCount $toCount 	; newToCount = toCount
 		MOVi %1 $color 	; cx = (int) switchColor(color)
-		CALL &switchColor %0 *2	; expects switchColor(int) -> int
+		CALL &switchColor %0 *2	; expects switchColor(int) -> int @ 652:31
 		MOVi $cx %0 
 		MOVi $d $start 	; d = start
 	.l1:	GEQi $d #8 @.e2	; while (d < 8) 
@@ -1260,7 +1260,7 @@ traceRBQ:	FUNC	; signature func traceRBQ(int color, int frm, int toCount, ptr to
 
 ;-----------------------------------------------------------------------------
 	$toCount:	OUTi
-listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
+listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int @ 670:20
 	$color:	INPi
 	$frm:	INPi
 	$tos:	INPp
@@ -1272,7 +1272,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(frm) != FALSE)
 		MOVi %1 $frm 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 674:30
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e5 
 		CALL ^assertFail %0 *1
@@ -1298,7 +1298,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 		POKE $tos $toCount %0
 		ADDi $toCount $toCount #1	; toCount = toCount + 1
 	.f4:	MOVi %1 $color 	; cx = (int) switchColor(color)
-		CALL &switchColor %0 *2	; expects switchColor(int) -> int
+		CALL &switchColor %0 *2	; expects switchColor(int) -> int @ 691:33
 		MOVi $cx %0 
 		SUBi $t $t #1	; t = t - 1
 		PEEK %0 &board $t	; if (((int) global board[t] & COLOR_MASK) == cx || global xCapture == t || (int) squareCapturesCastlingKing(t) != FALSE) 
@@ -1307,7 +1307,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 		PEEK %0 &xCapture 
 		EQUi %0 $t @.t7
 		MOVi %1 $t 
-		CALL &squareCapturesCastlingKing %0 *2	; expects squareCapturesCastlingKing(int) -> int
+		CALL &squareCapturesCastlingKing %0 *2	; expects squareCapturesCastlingKing(int) -> int @ 693:114
 		EQUi %0 #FALSE @.f8
 	.t7:	POKE $tos $toCount $t	; tos[toCount] = t
 		ADDi $toCount $toCount #1	; toCount = toCount + 1
@@ -1318,7 +1318,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 		PEEK %0 &xCapture 
 		EQUi %0 $t @.t9
 		MOVi %1 $t 
-		CALL &squareCapturesCastlingKing %0 *2	; expects squareCapturesCastlingKing(int) -> int
+		CALL &squareCapturesCastlingKing %0 *2	; expects squareCapturesCastlingKing(int) -> int @ 698:114
 		EQUi %0 #FALSE @.e2
 	.t9:	POKE $tos $toCount $t	; tos[toCount] = t
 		ADDi $toCount $toCount #1	; toCount = toCount + 1
@@ -1329,7 +1329,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 		MOVp %4 $tos 
 		MOVi %5 #0 
 		MOVi %6 #2 
-		CALL &traceRBQ %0 *7	; expects traceRBQ(int, int, int, ptr, int, int) -> int
+		CALL &traceRBQ %0 *7	; expects traceRBQ(int, int, int, ptr, int, int) -> int @ 704:70
 		MOVi $toCount %0 
 		GOTO @.e2  
 	.s1#BISHOP:	MOVi %1 $color 	; toCount = (int) traceRBQ(color, frm, toCount, tos, 1, 2)
@@ -1338,7 +1338,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 		MOVp %4 $tos 
 		MOVi %5 #1 
 		MOVi %6 #2 
-		CALL &traceRBQ %0 *7	; expects traceRBQ(int, int, int, ptr, int, int) -> int
+		CALL &traceRBQ %0 *7	; expects traceRBQ(int, int, int, ptr, int, int) -> int @ 705:72
 		MOVi $toCount %0 
 		GOTO @.e2  
 	.s1#QUEEN:	MOVi %1 $color 	; toCount = (int) traceRBQ(color, frm, toCount, tos, 0, 1)
@@ -1347,7 +1347,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 		MOVp %4 $tos 
 		MOVi %5 #0 
 		MOVi %6 #1 
-		CALL &traceRBQ %0 *7	; expects traceRBQ(int, int, int, ptr, int, int) -> int
+		CALL &traceRBQ %0 *7	; expects traceRBQ(int, int, int, ptr, int, int) -> int @ 706:71
 		MOVi $toCount %0 
 		GOTO @.e2  
 	.s1#KING:	MOVi $d #0 	; for (d = 0 to 8) 
@@ -1422,7 +1422,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-canCaptureKing:	FUNC	; signature func canCaptureKing(int color) -> int
+canCaptureKing:	FUNC	; signature func canCaptureKing(int color) -> int @ 757:25
 	$color:	INPi
 	$tos:	LOCA *MAX_TARGET_SQUARES
 	$frm:	LOCi
@@ -1431,7 +1431,7 @@ canCaptureKing:	FUNC	; signature func canCaptureKing(int color) -> int
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isValidColor(color) != FALSE)
 		MOVi %1 $color 
-		CALL &isValidColor %0 *2	; expects isValidColor(int) -> int
+		CALL &isValidColor %0 *2	; expects isValidColor(int) -> int @ 761:35
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisV4f1 
 		CALL ^assertFail %0 *1
@@ -1441,12 +1441,12 @@ canCaptureKing:	FUNC	; signature func canCaptureKing(int color) -> int
 		MOVi %1 $color 	; toCount = (int) listMoves(color, frm, tos)
 		MOVi %2 $frm 
 		ADRL %3 $tos *0
-		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int
+		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int @ 765:45
 		MOVi $toCount %0 
 		MOVi $i #0 	; for (i = 0 to toCount) 
 		GEQi #0 $toCount @.e3
 	.l4:	GETL %1 $tos $i	; if ((int) squareCapturesKing(tos[i]) != FALSE) 
-		CALL &squareCapturesKing %0 *2	; expects squareCapturesKing(int) -> int
+		CALL &squareCapturesKing %0 *2	; expects squareCapturesKing(int) -> int @ 767:41
 		EQUi %0 #FALSE @.f5
 		MOVi $b #TRUE 	; b = TRUE
 		GOTO @returnNow  	; goto returnNow
@@ -1456,11 +1456,11 @@ canCaptureKing:	FUNC	; signature func canCaptureKing(int color) -> int
 	.e2:	NOOP
 	returnNow:	RETU   	; }
 
-; signature extern func search() -> unknown
+; signature extern func search() -> unknown @ 777:23
 
 ;-----------------------------------------------------------------------------
 	$bestMove:	OUTi
-findBestMove:	FUNC	; signature func findBestMove(int lowestScore, int alpha, int beta, int depth, int score, int movesCount, ptr moves) -> int
+findBestMove:	FUNC	; signature func findBestMove(int lowestScore, int alpha, int beta, int depth, int score, int movesCount, ptr moves) -> int @ 779:23
 	$lowestScore:	INPi
 	$alpha:	INPi
 	$beta:	INPi
@@ -1489,10 +1489,10 @@ findBestMove:	FUNC	; signature func findBestMove(int lowestScore, int alpha, int
 		GEQi $myAlpha $beta @.e2
 		PEEK $move $moves $i	; move = (int) moves[i]
 		MOVi %1 $move 	; frm = (int) moveFrom(move)
-		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int
+		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int @ 790:29
 		MOVi $frm %0 
 		MOVi %1 $move 	; t = (int) moveTo(move)
-		CALL &moveTo %0 *2	; expects moveTo(int) -> int
+		CALL &moveTo %0 *2	; expects moveTo(int) -> int @ 791:25
 		MOVi $t %0 
 		PEEK $oldPiece &board $frm	; oldPiece = (int) global board[frm]
 		PEEK $captured &board $t	; captured = (int) global board[t]
@@ -1502,7 +1502,7 @@ findBestMove:	FUNC	; signature func findBestMove(int lowestScore, int alpha, int
 		MOVi %3 $oldPiece 
 		MOVi %4 $captured 
 		MOVi %5 $oldXCapture 
-		CALL &doMove %0 *6	; expects doMove(int, int, int, int, int) -> int
+		CALL &doMove %0 *6	; expects doMove(int, int, int, int, int) -> int @ 795:68
 		MOVi $moveScore %0 
 		ADDi $s $score $moveScore	; s = score + moveScore
 		LEQi $depth #0 @.f3	; if (depth > 0) 
@@ -1514,7 +1514,7 @@ findBestMove:	FUNC	; signature func findBestMove(int lowestScore, int alpha, int
 		SUBi %3 $depth #1
 		SUBi %4 #0 $s
 		MOVi %5 $capturesOnly 
-		CALL &search %0 *6	; expects search(int, int, int, int, int) -> unknown
+		CALL &search %0 *6	; expects search(int, int, int, int, int) -> unknown @ 803:69
 		SHRi %0 %0 #SCORE_SHIFT
 		SUBi $s #0 %0
 	.f3:	GEQi $bestScore $s @.f5	; if (bestScore < s) 
@@ -1527,7 +1527,7 @@ findBestMove:	FUNC	; signature func findBestMove(int lowestScore, int alpha, int
 		MOVi %3 $oldPiece 
 		MOVi %4 $captured 
 		MOVi %5 $oldXCapture 
-		CALL &undoMove %0 *6	; expects undoMove(int, int, int, int, int) -> void
+		CALL &undoMove %0 *6	; expects undoMove(int, int, int, int, int) -> void @ 813:52
 		ADDi $i $i #1	; i = i + 1
 		GOTO @.l0  	; }
 	.e2:	SHLi %0 $bestScore #SCORE_SHIFT	; bestMove = bestMove | (bestScore << SCORE_SHIFT)
@@ -1537,7 +1537,7 @@ findBestMove:	FUNC	; signature func findBestMove(int lowestScore, int alpha, int
 
 ;-----------------------------------------------------------------------------
 	$bestMove:	OUTi
-searchCaptures:	FUNC	; signature func searchCaptures(int alpha, int beta, int depth, int score, int firstMove) -> int
+searchCaptures:	FUNC	; signature func searchCaptures(int alpha, int beta, int depth, int score, int firstMove) -> int @ 819:25
 	$alpha:	INPi
 	$beta:	INPi
 	$depth:	INPi
@@ -1561,7 +1561,7 @@ searchCaptures:	FUNC	; signature func searchCaptures(int alpha, int beta, int de
 		! EQUi #DEBUG #0 @.a1	; assert(firstMove == 0 || (int) isValidMove(firstMove) != FALSE)
 		EQUi $firstMove #0 @.a1
 		MOVi %1 $firstMove 
-		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int
+		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int @ 824:56
 		NEQi %0 #FALSE @.a1
 		MOVp %1 &.a_firstM4f3 
 		CALL ^assertFail %0 *1
@@ -1579,7 +1579,7 @@ searchCaptures:	FUNC	; signature func searchCaptures(int alpha, int beta, int de
 		PEEK %1 &turnColor 	; toCount = (int) listMoves(global turnColor, frm, tos)
 		MOVi %2 $frm 
 		ADRL %3 $tos *0
-		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int
+		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int @ 837:57
 		MOVi $toCount %0 
 		MOVi $i #0 	; for (i = 0 to toCount) 
 		GEQi #0 $toCount @.e8
@@ -1587,7 +1587,7 @@ searchCaptures:	FUNC	; signature func searchCaptures(int alpha, int beta, int de
 		SHLi %0 $t #TO_SHIFT	; move = frm | (t << TO_SHIFT)
 		IORi $move $frm %0
 		MOVi %1 $t 	; if ((int) squareCapturesKing(t) != FALSE) 
-		CALL &squareCapturesKing %0 *2	; expects squareCapturesKing(int) -> int
+		CALL &squareCapturesKing %0 *2	; expects squareCapturesKing(int) -> int @ 842:37
 		EQUi %0 #FALSE @.f10
 		ADDi %0 #CAPTURE_KING_MIN_SCORE $depth	; bestMove = ((CAPTURE_KING_MIN_SCORE + depth) << SCORE_SHIFT) | move
 		SHLi %0 %0 #SCORE_SHIFT
@@ -1620,7 +1620,7 @@ searchCaptures:	FUNC	; signature func searchCaptures(int alpha, int beta, int de
 		MOVi %5 $score 
 		MOVi %6 $capturesCount 
 		ADRL %7 $moves *0
-		CALL &findBestMove %0 *8	; expects findBestMove(int, int, int, int, int, int, ptr) -> int
+		CALL &findBestMove %0 *8	; expects findBestMove(int, int, int, int, int, int, ptr) -> int @ 862:90
 		MOVi $bestMove %0 
 	.e5:	NOOP
 	returnNow:	RETU   	; }
@@ -1628,7 +1628,7 @@ searchCaptures:	FUNC	; signature func searchCaptures(int alpha, int beta, int de
 
 ;-----------------------------------------------------------------------------
 	$bestMove:	OUTi
-searchAll:	FUNC	; signature func searchAll(int alpha, int beta, int depth, int score, int firstMove) -> int
+searchAll:	FUNC	; signature func searchAll(int alpha, int beta, int depth, int score, int firstMove) -> int @ 867:20
 	$alpha:	INPi
 	$beta:	INPi
 	$depth:	INPi
@@ -1652,7 +1652,7 @@ searchAll:	FUNC	; signature func searchAll(int alpha, int beta, int depth, int s
 		! EQUi #DEBUG #0 @.a1	; assert(firstMove == 0 || (int) isValidMove(firstMove) != FALSE)
 		EQUi $firstMove #0 @.a1
 		MOVi %1 $firstMove 
-		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int
+		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int @ 873:56
 		NEQi %0 #FALSE @.a1
 		MOVp %1 &.a_firstM4f3 
 		CALL ^assertFail %0 *1
@@ -1670,7 +1670,7 @@ searchAll:	FUNC	; signature func searchAll(int alpha, int beta, int depth, int s
 		PEEK %1 &turnColor 	; toCount = (int) listMoves(global turnColor, frm, tos)
 		MOVi %2 $frm 
 		ADRL %3 $tos *0
-		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int
+		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int @ 891:57
 		MOVi $toCount %0 
 		MOVi $i #0 	; for (i = 0 to toCount) 
 		GEQi #0 $toCount @.e7
@@ -1678,7 +1678,7 @@ searchAll:	FUNC	; signature func searchAll(int alpha, int beta, int depth, int s
 		SHLi %0 $t #TO_SHIFT	; move = frm | (t << TO_SHIFT)
 		IORi $move $frm %0
 		MOVi %1 $t 	; if ((int) squareCapturesKing(t) != FALSE) 
-		CALL &squareCapturesKing %0 *2	; expects squareCapturesKing(int) -> int
+		CALL &squareCapturesKing %0 *2	; expects squareCapturesKing(int) -> int @ 896:37
 		EQUi %0 #FALSE @.f9
 		ADDi %0 #CAPTURE_KING_MIN_SCORE $depth	; bestMove = ((CAPTURE_KING_MIN_SCORE + depth) << SCORE_SHIFT) | move
 		SHLi %0 %0 #SCORE_SHIFT
@@ -1728,7 +1728,7 @@ searchAll:	FUNC	; signature func searchAll(int alpha, int beta, int depth, int s
 		MOVi %5 $score 
 		MOVi %6 $movesCount 
 		ADRL %7 $moves *0
-		CALL &findBestMove %0 *8	; expects findBestMove(int, int, int, int, int, int, ptr) -> int
+		CALL &findBestMove %0 *8	; expects findBestMove(int, int, int, int, int, int, ptr) -> int @ 929:95
 		MOVi $bestMove %0 
 	.e4:	NOOP
 	returnNow:	RETU   	; }
@@ -1736,7 +1736,7 @@ searchAll:	FUNC	; signature func searchAll(int alpha, int beta, int depth, int s
 
 ;-----------------------------------------------------------------------------
 	$result:	OUTi
-search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, int capturesOnly) -> int
+search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, int capturesOnly) -> int @ 934:17
 	$alpha:	INPi
 	$beta:	INPi
 	$depth:	INPi
@@ -1757,7 +1757,7 @@ search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, 
 		CALL ^assertFail %0 *1
 	.a0:	NOOP
 		! EQUi #DEBUG #0 @.a1	; assert((int) checkInvariant() != FALSE)
-		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int
+		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int @ 939:32
 		NEQi %0 #FALSE @.a1
 		MOVp %1 &.a_intche4eb 
 		CALL ^assertFail %0 *1
@@ -1789,7 +1789,7 @@ search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, 
 		MOVi %3 $depth 
 		MOVi %4 $score 
 		MOVi %5 $firstMove 
-		CALL &searchCaptures %0 *6	; expects searchCaptures(int, int, int, int, int) -> int
+		CALL &searchCaptures %0 *6	; expects searchCaptures(int, int, int, int, int) -> int @ 969:70
 		MOVi $best %0 
 		MOVi $result $best 	; result = best
 		GOTO @.e5  	; } else 
@@ -1798,7 +1798,7 @@ search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, 
 		MOVi %3 $depth 
 		MOVi %4 $score 
 		MOVi %5 $firstMove 
-		CALL &searchAll %0 *6	; expects searchAll(int, int, int, int, int) -> int
+		CALL &searchAll %0 *6	; expects searchAll(int, int, int, int, int) -> int @ 975:65
 		MOVi $best %0 
 		MOVi $result $best 	; result = best
 		SHRi $s $result #SCORE_SHIFT	; s = result >> SCORE_SHIFT
@@ -1812,8 +1812,8 @@ search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, 
 		SUBi %0 #0 %0
 		NEQi $s %0 @.f8
 		PEEK %2 &turnColor 	; if ((int) canCaptureKing((int) switchColor(global turnColor)) != FALSE) 
-		CALL &switchColor %1 *2	; expects switchColor(int) -> int
-		CALL &canCaptureKing %0 *2	; expects canCaptureKing(int) -> int
+		CALL &switchColor %1 *2	; expects switchColor(int) -> int @ 992:64
+		CALL &canCaptureKing %0 *2	; expects canCaptureKing(int) -> int @ 992:66
 		EQUi %0 #FALSE @.f9
 		ANDi %0 $result #SCORE_MASK	; result = (result & SCORE_MASK) | CHECKMATE
 		IORi $result %0 #CHECKMATE
@@ -1827,7 +1827,7 @@ search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, 
 		EQUi $bestMove #0 @.f11	; if (bestMove != 0) 
 		! EQUi #DEBUG #0 @.a12	; assert((int) isValidMove(bestMove) != FALSE)
 		MOVi %1 $bestMove 
-		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int
+		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int @ 1002:38
 		NEQi %0 #FALSE @.a12
 		MOVp %1 &.a_intisV4f6 
 		CALL ^assertFail %0 *1
@@ -1846,7 +1846,7 @@ search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, 
 
 ;-----------------------------------------------------------------------------
 	$status:	OUTi
-executeMove:	FUNC	; signature func executeMove(int move) -> int
+executeMove:	FUNC	; signature func executeMove(int move) -> int @ 1015:22
 	$move:	INPi
 	$tos:	LOCA *MAX_TARGET_SQUARES
 	$frm:	LOCi
@@ -1859,7 +1859,7 @@ executeMove:	FUNC	; signature func executeMove(int move) -> int
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isValidMove(move) != FALSE)
 		MOVi %1 $move 
-		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int
+		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int @ 1019:33
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisV4d2 
 		CALL ^assertFail %0 *1
@@ -1879,7 +1879,7 @@ executeMove:	FUNC	; signature func executeMove(int move) -> int
 	.a3:	PEEK %1 &turnColor 	; toCount = (int) listMoves(global turnColor, frm, tos)
 		MOVi %2 $frm 
 		ADRL %3 $tos *0
-		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int
+		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int @ 1024:56
 		MOVi $toCount %0 
 		! EQUi #DEBUG #0 @.a5	; assert(toCount <= MAX_TARGET_SQUARES)
 		LEQi $toCount #MAX_TARGET_SQUARES @.a5
@@ -1899,13 +1899,13 @@ executeMove:	FUNC	; signature func executeMove(int move) -> int
 		MOVi %3 $oldPiece 
 		MOVi %4 $captured 
 		MOVi %5 $oldXCapture 
-		CALL &doMove %0 *6	; expects doMove(int, int, int, int, int) -> int
+		CALL &doMove %0 *6	; expects doMove(int, int, int, int, int) -> int @ 1032:52
 		MOVi %1 #MIN_SCORE 	; switch (((int) search(MIN_SCORE, MAX_SCORE, 1, 0, FALSE) & MOVE_MASK) == IN_CHECK to (CHECKMATE + 1)) 
 		MOVi %2 #MAX_SCORE 
 		MOVi %3 #1 
 		MOVi %4 #0 
 		MOVi %5 #FALSE 
-		CALL &search %0 *6	; expects search(int, int, int, int, int) -> int
+		CALL &search %0 *6	; expects search(int, int, int, int, int) -> int @ 1034:62
 		! ADDi <B> #CHECKMATE #1
 		! SUBi <B> <B> #IN_CHECK
 		ANDi %0 %0 #MOVE_MASK
@@ -1928,7 +1928,7 @@ executeMove:	FUNC	; signature func executeMove(int move) -> int
 		MOVi %3 $oldPiece 
 		MOVi %4 $captured 
 		MOVi %5 $oldXCapture 
-		CALL &undoMove %0 *6	; expects undoMove(int, int, int, int, int) -> void
+		CALL &undoMove %0 *6	; expects undoMove(int, int, int, int, int) -> void @ 1039:56
 		MOVi $status #IN_CHECK 	; status = IN_CHECK
 		GOTO @returnNow  	; goto returnNow
 	.e10:	NOOP
@@ -1938,14 +1938,14 @@ executeMove:	FUNC	; signature func executeMove(int move) -> int
 	.e2:	MOVi $status #INVALID_MOVE 	; status = INVALID_MOVE
 	returnNow:	RETU   	; }
 
-; signature extern native print() -> unknown
-; signature extern native printInt() -> unknown
-; signature extern native printLF() -> unknown
-; signature extern native input() -> unknown
+; signature extern native print() -> unknown @ 1053:20
+; signature extern native printInt() -> unknown @ 1054:23
+; signature extern native printLF() -> unknown @ 1055:22
+; signature extern native input() -> unknown @ 1056:20
 
 ;-----------------------------------------------------------------------------
 	$move:	OUTi
-getComputerMove:	FUNC	; signature func getComputerMove() -> int
+getComputerMove:	FUNC	; signature func getComputerMove() -> int @ 1061:26
 	$d:	LOCi
 	$m:	LOCi
 	$printedThinking:	LOCi
@@ -1962,21 +1962,21 @@ getComputerMove:	FUNC	; signature func getComputerMove() -> int
 		LEQi %0 #1000000 @.f3
 		NEQi $printedThinking #FALSE @.f4	; if (printedThinking == FALSE) 
 		MOVp %1 &.s_Thinki4d8 	; print("Thinking...")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1072:25
 		MOVi $printedThinking #TRUE 	; printedThinking = TRUE
 	.f4:	MOVp %1 &.s_Thinki4d8:10 	; print(".")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1075:14
 	.f3:	MOVi %1 #MIN_SCORE 	; m = (int) search(MIN_SCORE, MAX_SCORE, d, 0, FALSE)
 		MOVi %2 #MAX_SCORE 
 		MOVi %3 $d 
 		MOVi %4 #0 
 		MOVi %5 #FALSE 
-		CALL &search %0 *6	; expects search(int, int, int, int, int) -> int
+		CALL &search %0 *6	; expects search(int, int, int, int, int) -> int @ 1077:54
 		MOVi $m %0 
 		ADDi $d $d #1	; d = d + 1
 		GOTO @.l0  	; }
 	.e2:	EQUi $printedThinking #FALSE @.f5	; if (printedThinking != FALSE) 
-		CALL ^printLF %0 *1	; expects function() -> unknown
+		CALL ^printLF %0 *1	; expects function() -> unknown @ 1081:12
 	.f5:	NOOP
 		! EQUi #DEBUG #0 @.a6	; assert((m & MOVE_MASK) == CHECKMATE || (m & MOVE_MASK) == STALEMATE || (int) isValidMove(m & MOVE_MASK) != FALSE)
 		ANDi %0 $m #MOVE_MASK
@@ -1984,25 +1984,25 @@ getComputerMove:	FUNC	; signature func getComputerMove() -> int
 		ANDi %0 $m #MOVE_MASK
 		EQUi %0 #STALEMATE @.a6
 		ANDi %1 $m #MOVE_MASK
-		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int
+		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int @ 1083:106
 		NEQi %0 #FALSE @.a6
 		MOVp %1 &.a_mMOVEM4f8 
 		CALL ^assertFail %0 *1
 	.a6:	ANDi $move $m #MOVE_MASK	; move = (m & MOVE_MASK)
 		RETU   	; }
 
-LET_COMPUTER_PLAY:	! DEFi #-1	; signature const LET_COMPUTER_PLAY : int
-TAKE_BACK:	! DEFi #-2	; signature const TAKE_BACK : int
-NEW_GAME:	! DEFi #-3	; signature const NEW_GAME : int
-QUIT:	! DEFi #-4	; signature const QUIT : int
-SYNTAX_ERROR:	! DEFi #-5	; signature const SYNTAX_ERROR : int
-MATE:	! DEFi #-6	; signature const MATE : int
-SET_MAXIMUM_LEVEL:	! DEFi #-93	; signature const SET_MAXIMUM_LEVEL : int
-SET_MINIMUM_LEVEL:	! DEFi #-101	; signature const SET_MINIMUM_LEVEL : int
+LET_COMPUTER_PLAY:	! DEFi #-1	; signature const LET_COMPUTER_PLAY : int @ 1088:1
+TAKE_BACK:	! DEFi #-2	; signature const TAKE_BACK : int @ 1089:1
+NEW_GAME:	! DEFi #-3	; signature const NEW_GAME : int @ 1090:1
+QUIT:	! DEFi #-4	; signature const QUIT : int @ 1091:1
+SYNTAX_ERROR:	! DEFi #-5	; signature const SYNTAX_ERROR : int @ 1092:1
+MATE:	! DEFi #-6	; signature const MATE : int @ 1093:1
+SET_MAXIMUM_LEVEL:	! DEFi #-93	; signature const SET_MAXIMUM_LEVEL : int @ 1094:1
+SET_MINIMUM_LEVEL:	! DEFi #-101	; signature const SET_MINIMUM_LEVEL : int @ 1096:1
 
 ;-----------------------------------------------------------------------------
 	$d:	OUTi
-strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int
+strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int @ 1096:17
 	$s0:	INPp
 	$s1:	INPp
 	$a:	LOCp
@@ -2024,7 +2024,7 @@ strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int
 
 ;-----------------------------------------------------------------------------
 	$d:	OUTi
-strncmp:	FUNC	; signature func strncmp(ptr s0, ptr s1, int n) -> int
+strncmp:	FUNC	; signature func strncmp(ptr s0, ptr s1, int n) -> int @ 1108:18
 	$s0:	INPp
 	$s1:	INPp
 	$n:	INPi
@@ -2054,7 +2054,7 @@ strncmp:	FUNC	; signature func strncmp(ptr s0, ptr s1, int n) -> int
 
 ;-----------------------------------------------------------------------------
 	$u:	OUTi
-toupper:	FUNC	; signature func toupper(int c) -> int
+toupper:	FUNC	; signature func toupper(int c) -> int @ 1128:18
 	$c:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $u $c 	; u = c
@@ -2067,7 +2067,7 @@ toupper:	FUNC	; signature func toupper(int c) -> int
 
 ;-----------------------------------------------------------------------------
 	$result:	OUTi
-getUserMove:	FUNC	; signature func getUserMove() -> int
+getUserMove:	FUNC	; signature func getUserMove() -> int @ 1137:22
 	$level:	LOCi
 	$s:	LOCA *256
 	$l:	LOCi
@@ -2079,10 +2079,10 @@ getUserMove:	FUNC	; signature func getUserMove() -> int
 ;-----------------------------------------------------------------------------
 	.l0:	MOVi $result #SYNTAX_ERROR 	; result = SYNTAX_ERROR
 		MOVp %1 &.s_4d9 	; print(">")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1143:13
 		MOVi %1 #1023 	; l = (int) input(1023, s)
 		ADRL %2 $s *0
-		CALL ^input %0 *3	; expects function(int, ptr) -> unknown
+		CALL ^input %0 *3	; expects function(int, ptr) -> unknown @ 1144:27
 		MOVi $l %0 
 		LEQi $l #0 @.f2	; if (l > 0 && (int) s[l - 1] == '\n') 
 		SUBi %0 $l #1
@@ -2092,26 +2092,26 @@ getUserMove:	FUNC	; signature func getUserMove() -> int
 		SETL $s %0 #0
 	.f2:	ADRL %1 $s *0	; if ((int) strcmp(s, "go") == 0) 
 		MOVp %2 &.s_go4da 
-		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int @ 1148:29
 		NEQi %0 #0 @.f3
 		MOVi $result #LET_COMPUTER_PLAY 	; result = LET_COMPUTER_PLAY
 		GOTO @.e4  	; } else if ((int) strcmp(s, "back") == 0) 
 	.f3:	ADRL %1 $s *0	; if ((int) strcmp(s, "back") == 0) 
 		MOVp %2 &.s_back4db 
-		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int @ 1150:38
 		NEQi %0 #0 @.f5
 		MOVi $result #TAKE_BACK 	; result = TAKE_BACK
 		GOTO @.e6  	; } else if ((int) strcmp(s, "new") == 0) 
 	.f5:	ADRL %1 $s *0	; if ((int) strcmp(s, "new") == 0) 
 		MOVp %2 &.s_new4dc 
-		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int @ 1152:37
 		NEQi %0 #0 @.f7
 		MOVi $result #NEW_GAME 	; result = NEW_GAME
 		GOTO @.e8  	; } else if ((int) strncmp(s, "level ", 6) == 0 && l == 7 && (level = (int) s[6] - '0') >= 1 && level <= 9) 
 	.f7:	ADRL %1 $s *0	; if ((int) strncmp(s, "level ", 6) == 0 && l == 7 && (level = (int) s[6] - '0') >= 1 && level <= 9) 
 		MOVp %2 &.s_level4dd 
 		MOVi %3 #6 
-		CALL &strncmp %0 *4	; expects strncmp(ptr, ptr, int) -> int
+		CALL &strncmp %0 *4	; expects strncmp(ptr, ptr, int) -> int @ 1154:44
 		NEQi %0 #0 @.f10
 		NEQi $l #7 @.f10
 		SUBi $level $s:6 #'0'
@@ -2122,19 +2122,19 @@ getUserMove:	FUNC	; signature func getUserMove() -> int
 		GOTO @.e11  	; } else if ((int) strcmp(s, "quit") == 0) 
 	.f10:	ADRL %1 $s *0	; if ((int) strcmp(s, "quit") == 0) 
 		MOVp %2 &.s_quit4de 
-		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int @ 1156:38
 		NEQi %0 #0 @.f12
 		MOVi $result #QUIT 	; result = QUIT
 		GOTO @.e13  	; } else 
 	.f12:	MOVE %1 $s:0 	; fromCol = ((int) toupper(s[0]) - 'A')
-		CALL &toupper %0 *2	; expects toupper(int) -> int
+		CALL &toupper %0 *2	; expects toupper(int) -> int @ 1159:35
 		SUBi $fromCol %0 #'A'
 		SUBi $fromRow $s:1 #'1'	; fromRow = ((int) s[1] - '1')
 		MOVi $i #2 	; i = 2
 		NEQi $s:2 #'-' @.f14	; if ((int) s[2] == '-') i = 3
 		MOVi $i #3 	; i = 3
 	.f14:	GETL %1 $s $i	; toCol = ((int) toupper(s[i]) - 'A')
-		CALL &toupper %0 *2	; expects toupper(int) -> int
+		CALL &toupper %0 *2	; expects toupper(int) -> int @ 1163:33
 		SUBi $toCol %0 #'A'
 		ADDi %0 $i #1	; toRow = ((int) s[i + 1] - '1')
 		GETL %0 $s %0
@@ -2151,11 +2151,11 @@ getUserMove:	FUNC	; signature func getUserMove() -> int
 		MOVi %2 $fromRow 
 		MOVi %3 $toCol 
 		MOVi %4 $toRow 
-		CALL &makeMove %0 *5	; expects makeMove(int, int, int, int) -> int
+		CALL &makeMove %0 *5	; expects makeMove(int, int, int, int) -> int @ 1167:60
 		MOVi $result %0 
 		GOTO @.e17  	; } else 
 	.f16:	MOVp %1 &.s_Enterm4df 	; print("Enter moves like 'd2d4' or:\n'level 1-9' to set computer level (default is 3).\n'go' to switch color and let the computer play.\n'back' to take back a step.\n'new' to start a new game.\n'quit' to exit.\n")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1169:217
 	.e17:	NOOP
 	.e13:	NOOP
 	.e11:	NOOP
@@ -2167,7 +2167,7 @@ getUserMove:	FUNC	; signature func getUserMove() -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-printBoard:	FUNC	; signature func printBoard(int frm, int t) -> void
+printBoard:	FUNC	; signature func printBoard(int frm, int t) -> void @ 1175:21
 	$frm:	INPi
 	$t:	INPi
 	$y:	LOCi
@@ -2180,16 +2180,16 @@ printBoard:	FUNC	; signature func printBoard(int frm, int t) -> void
 		MOVi $buffer:1 #0 	; buffer[1] = 0
 		MOVi $lastI #-1 	; lastI = -1
 		MOVp %1 &.s_ABCDEF4e0 	; print("    A B C D E F G H\n")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1180:32
 		MOVp %1 &.s_4e1 	; print("  +-----------------+\n")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1181:34
 		MOVi $y #0 	; for (y = 0 to 8) 
 		GEQi #0 #8 @.e0
 	.l1:	SUBi $buffer:0 #'8' $y	; buffer[0] = '8' - y
 		ADRL %1 $buffer *0	; print(buffer)
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1184:16
 		MOVp %1 &.s_4e2 	; print(" |")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1185:14
 		MOVi $x #0 	; for (x = 0 to 8) 
 		GEQi #0 #8 @.e2
 	.l3:	SUBi %0 #9 $y	; i = (9 - y) * STRIDE + (x + 1)
@@ -2209,7 +2209,7 @@ printBoard:	FUNC	; signature func printBoard(int frm, int t) -> void
 	.e9:	NOOP
 	.f7:	MOVi $buffer:0 $c 	; buffer[0] = c
 		ADRL %1 $buffer *0	; print(buffer)
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1195:17
 		PEEK %0 &board $i	; c = (int) global PIECE_CHARS[(int) global board[i] & (PIECE_MASK | BLACK)]
 		! IORi <B> #PIECE_MASK #BLACK
 		ANDi %0 %0 <B>
@@ -2221,7 +2221,7 @@ printBoard:	FUNC	; signature func printBoard(int frm, int t) -> void
 		MOVi $c #'.' 	; c = '.'
 	.f11:	MOVi $buffer:0 $c 	; buffer[0] = c
 		ADRL %1 $buffer *0	; print(buffer)
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1199:17
 		MOVi $lastI $i 	; lastI = i
 		FORi $x #8 @.l3	; }
 	.e2:	MOVi $c #' ' 	; c = ' '
@@ -2230,25 +2230,25 @@ printBoard:	FUNC	; signature func printBoard(int frm, int t) -> void
 	.t12:	MOVi $c #')' 	; c = ')'
 	.f13:	MOVi $buffer:0 $c 	; buffer[0] = c
 		ADRL %1 $buffer *0	; print(buffer)
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1205:16
 		MOVp %1 &.s_4e3 	; print("| ")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1206:14
 		SUBi $buffer:0 #'8' $y	; buffer[0] = '8' - y
 		ADRL %1 $buffer *0	; print(buffer)
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
-		CALL ^printLF %0 *1	; expects function() -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1208:16
+		CALL ^printLF %0 *1	; expects function() -> unknown @ 1209:12
 		MOVi $lastI #-1 	; lastI = -1
 		FORi $y #8 @.l1	; }
 	.e0:	MOVp %1 &.s_4e1 	; print("  +-----------------+\n")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1212:34
 		MOVp %1 &.s_ABCDEF4e4 	; print("    A B C D E F G H\n\n")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1213:34
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-registerMove:	FUNC	; signature func registerMove(int move, int piece, int captured, int xCapture) -> void
+registerMove:	FUNC	; signature func registerMove(int move, int piece, int captured, int xCapture) -> void @ 1216:23
 	$move:	INPi
 	$piece:	INPi
 	$captured:	INPi
@@ -2287,7 +2287,7 @@ registerMove:	FUNC	; signature func registerMove(int move, int piece, int captur
 
 ;-----------------------------------------------------------------------------
 	$move:	OUTi
-takeBackMove:	FUNC	; signature func takeBackMove() -> int
+takeBackMove:	FUNC	; signature func takeBackMove() -> int @ 1233:23
 	$i:	LOCi
 	$frm:	LOCi
 	$t:	LOCi
@@ -2302,10 +2302,10 @@ takeBackMove:	FUNC	; signature func takeBackMove() -> int
 		ADDi %0 $i #0	; move = (int) global history[i + 0]
 		PEEK $move &history %0
 		MOVi %1 $move 	; frm = (int) moveFrom(move)
-		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int
+		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int @ 1241:29
 		MOVi $frm %0 
 		MOVi %1 $move 	; t = (int) moveTo(move)
-		CALL &moveTo %0 *2	; expects moveTo(int) -> int
+		CALL &moveTo %0 *2	; expects moveTo(int) -> int @ 1242:25
 		MOVi $t %0 
 		MOVi %1 $frm 	; undoMove(frm, t, (int) global history[i + 1], (int) global history[i + 2], (int) global history[i + 3])
 		MOVi %2 $t 
@@ -2315,7 +2315,7 @@ takeBackMove:	FUNC	; signature func takeBackMove() -> int
 		PEEK %4 &history %4
 		ADDi %5 $i #3
 		PEEK %5 &history %5
-		CALL &undoMove %0 *6	; expects undoMove(int, int, int, int, int) -> void
+		CALL &undoMove %0 *6	; expects undoMove(int, int, int, int, int) -> void @ 1243:106
 		GOTO @.e1  	; } else 
 	.f0:	MOVi $move #0 	; move = 0
 	.e1:	RETU   	; }
@@ -2323,7 +2323,7 @@ takeBackMove:	FUNC	; signature func takeBackMove() -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-setLevel:	FUNC	; signature func setLevel(int level) -> void
+setLevel:	FUNC	; signature func setLevel(int level) -> void @ 1249:19
 	$level:	INPi
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
@@ -2339,7 +2339,7 @@ setLevel:	FUNC	; signature func setLevel(int level) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 1256:15
 	$lastFrom:	LOCi
 	$lastTo:	LOCi
 	$lastPiece:	LOCi
@@ -2353,13 +2353,13 @@ main:	FUNC	; signature func main() -> void
 	$p:	LOCp
 	$level:	LOCi
 ;-----------------------------------------------------------------------------
-		CALL &initGlobals %0 *1	; expects initGlobals() -> void
-		CALL &restart %0 *1	; expects restart() -> void
+		CALL &initGlobals %0 *1	; expects initGlobals() -> void @ 1260:15
+		CALL &restart %0 *1	; expects restart() -> void @ 1261:11
 		MOVi %1 #2 	; setLevel(2)
-		CALL &setLevel %0 *2	; expects setLevel(int) -> void
+		CALL &setLevel %0 *2	; expects setLevel(int) -> void @ 1262:13
 		MOVi %1 #0 	; printBoard(0, 0)
 		MOVi %2 #0 
-		CALL &printBoard %0 *3	; expects printBoard(int, int) -> void
+		CALL &printBoard %0 *3	; expects printBoard(int, int) -> void @ 1264:18
 		MOVi $isComputersTurn #FALSE 	; isComputersTurn = FALSE
 		MOVi $lastMove #0 	; lastMove = 0
 		MOVi $moveResult #0 	; moveResult = 0
@@ -2369,10 +2369,10 @@ main:	FUNC	; signature func main() -> void
 		NEQi %0 #WHITE @.f2
 		MOVp $p &.s_Whites4e6 	; p = "White's turn.\n"
 	.f2:	MOVp %1 $p 	; print(p)
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1273:13
 	.f1:	MOVp $action &.s_Lastmo4e7 	; action = "Last move:"
 		NEQi $isComputersTurn #FALSE @.f3	; if (isComputersTurn == FALSE) 
-		CALL &getUserMove %0 *1	; expects getUserMove() -> int
+		CALL &getUserMove %0 *1	; expects getUserMove() -> int @ 1278:35
 		MOVi $lastMove %0 
 		! ADDi <B> #LET_COMPUTER_PLAY #1	; switch (lastMove == NEW_GAME to LET_COMPUTER_PLAY + 1) 
 		! SUBi <B> <B> #NEW_GAME
@@ -2382,24 +2382,24 @@ main:	FUNC	; signature func main() -> void
 	.s4#<B>:	MOVi $isComputersTurn #TRUE 	; isComputersTurn = TRUE
 		GOTO @.e5  	; }
 		! SUBi <B> #TAKE_BACK #NEW_GAME	; case TAKE_BACK
-	.s4#<B>:	CALL &takeBackMove %0 *1	; expects takeBackMove() -> int
+	.s4#<B>:	CALL &takeBackMove %0 *1	; expects takeBackMove() -> int @ 1285:38
 		MOVi $lastMove %0 
 		LEQi $lastMove #0 @.f6	; if (lastMove > 0) 
 		MOVi %1 $lastMove 	; lastFrom = (int) moveFrom(lastMove)
-		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int
+		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int @ 1287:43
 		MOVi $lastFrom %0 
 		MOVi %1 $lastMove 	; lastTo = (int) moveTo(lastMove)
-		CALL &moveTo %0 *2	; expects moveTo(int) -> int
+		CALL &moveTo %0 *2	; expects moveTo(int) -> int @ 1288:39
 		MOVi $lastTo %0 
 		MOVi $lastMove #0 	; lastMove = 0
 		MOVp $action &.s_Tookba4e8 	; action = "Took back move:"
 		GOTO @.e5  	; } else 
 	.f6:	MOVp %1 &.s_Nomove4e9 	; print("No move to take back.\n")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1292:40
 		MOVi $lastMove #-1 	; lastMove = -1
 	.e7:	GOTO @.e5  	; }
 		! SUBi <B> #NEW_GAME #NEW_GAME	; case NEW_GAME
-	.s4#<B>:	CALL &restart %0 *1	; expects restart() -> void
+	.s4#<B>:	CALL &restart %0 *1	; expects restart() -> void @ 1298:16
 		MOVi $lastMove #0 	; lastMove = 0
 		MOVi $lastFrom #0 	; lastFrom = 0
 		MOVi $lastTo #0 	; lastTo = 0
@@ -2408,17 +2408,17 @@ main:	FUNC	; signature func main() -> void
 		GRTi $lastMove #SET_MAXIMUM_LEVEL @.f3
 		SUBi $level $lastMove #SET_MINIMUM_LEVEL	; level = lastMove - SET_MINIMUM_LEVEL
 		MOVi %1 $level 	; setLevel(level)
-		CALL &setLevel %0 *2	; expects setLevel(int) -> void
+		CALL &setLevel %0 *2	; expects setLevel(int) -> void @ 1307:23
 		MOVp %1 &.s_Setcom4ea 	; print("Set computer level to ")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1308:39
 		ADDi %1 $level #1	; printInt(level + 1)
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 1309:27
 		MOVp %1 &.s_Nomove4e9:20 	; print(".\n")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1310:20
 		MOVi $lastMove #-1 	; lastMove = -1
 	.e5:	NOOP
 	.f3:	EQUi $isComputersTurn #FALSE @.f10	; if (isComputersTurn != FALSE) 
-		CALL &getComputerMove %0 *1	; expects getComputerMove() -> int
+		CALL &getComputerMove %0 *1	; expects getComputerMove() -> int @ 1317:39
 		MOVi $lastMove %0 
 	.f10:	MOVi $moveResult #0 	; moveResult = 0
 		EQUi $lastMove #CHECKMATE @.t11	; if (lastMove == CHECKMATE || lastMove == STALEMATE) 
@@ -2428,16 +2428,16 @@ main:	FUNC	; signature func main() -> void
 		MOVi $lastMove #-1 	; lastMove = -1
 	.f12:	LEQi $lastMove #0 @.f13	; if (lastMove > 0) 
 		MOVi %1 $lastMove 	; lastFrom = (int) moveFrom(lastMove)
-		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int
+		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int @ 1327:40
 		MOVi $lastFrom %0 
 		MOVi %1 $lastMove 	; lastTo = (int) moveTo(lastMove)
-		CALL &moveTo %0 *2	; expects moveTo(int) -> int
+		CALL &moveTo %0 *2	; expects moveTo(int) -> int @ 1328:36
 		MOVi $lastTo %0 
 		PEEK $lastPiece &board $lastFrom	; lastPiece = (int) global board[lastFrom]
 		PEEK $lastCaptured &board $lastTo	; lastCaptured = (int) global board[lastTo]
 		PEEK $lastXCapture &xCapture 	; lastXCapture = global xCapture
 		MOVi %1 $lastMove 	; moveResult = (int) executeMove(lastMove)
-		CALL &executeMove %0 *2	; expects executeMove(int) -> int
+		CALL &executeMove %0 *2	; expects executeMove(int) -> int @ 1333:45
 		MOVi $moveResult %0 
 		! ADDi <B> #CHECKMATE #1	; switch (moveResult == VALID_MOVE to CHECKMATE + 1) 
 		! SUBi <B> <B> #VALID_MOVE
@@ -2452,7 +2452,7 @@ main:	FUNC	; signature func main() -> void
 		MOVi %2 $lastPiece 
 		MOVi %3 $lastCaptured 
 		MOVi %4 $lastXCapture 
-		CALL &registerMove %0 *5	; expects registerMove(int, int, int, int) -> void
+		CALL &registerMove %0 *5	; expects registerMove(int, int, int, int) -> void @ 1336:68
 		NEQi $moveResult #VALID_MOVE @.f16	; if (moveResult == VALID_MOVE) 
 		SUBi $isComputersTurn #TRUE $isComputersTurn	; isComputersTurn = TRUE - isComputersTurn
 		GOTO @.e15  	; } else 
@@ -2460,30 +2460,30 @@ main:	FUNC	; signature func main() -> void
 	.e17:	GOTO @.e15  	; }
 		! SUBi <B> #IN_CHECK #VALID_MOVE	; case IN_CHECK
 	.s14#<B>:	MOVp %1 &.s_Kingin4eb 	; print("King in check.\n")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1345:32
 		MOVi $lastMove #-1 	; lastMove = -1
 		GOTO @.e15  	; }
 	.s14:	NEQi $moveResult #INVALID_MOVE @.f13	; if (moveResult == INVALID_MOVE) 
 		MOVp %1 &.s_Invali4ec 	; print("Invalid move.\n")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1351:32
 		MOVi $lastMove #-1 	; lastMove = -1
 	.e15:	NOOP
 	.f13:	LSSi $lastMove #0 @.f19	; if (lastMove >= 0) 
-		CALL ^printLF %0 *1	; expects function() -> unknown
+		CALL ^printLF %0 *1	; expects function() -> unknown @ 1359:14
 		MOVi %1 $lastFrom 	; printBoard(lastFrom, lastTo)
 		MOVi %2 $lastTo 
-		CALL &printBoard %0 *3	; expects printBoard(int, int) -> void
+		CALL &printBoard %0 *3	; expects printBoard(int, int) -> void @ 1360:33
 		EQUi $lastFrom #0 @.f19	; if (lastFrom != 0 && lastTo != 0) 
 		EQUi $lastTo #0 @.f19
 		MOVp %1 $action 	; print(action)
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1362:19
 		MOVp %1 &.s_Setcom4ea:21 	; print(" ")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1363:16
 		ANDi %1 $lastPiece #PIECE_MASK	; print(global PIECE_NAMES[lastPiece & PIECE_MASK])
 		PEEK %1 &PIECE_NAMES %1
-		CALL ^print %0 *2	; expects function(unknown) -> unknown
+		CALL ^print %0 *2	; expects function(unknown) -> unknown @ 1364:55
 		MOVp %1 &.s_Setcom4ea:21 	; print(" ")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1365:16
 		MODi %0 $lastFrom #STRIDE	; buffer[0] = ('A' + (lastFrom % STRIDE - 1))
 		SUBi %0 %0 #1
 		ADDi $buffer:0 #'A' %0
@@ -2492,9 +2492,9 @@ main:	FUNC	; signature func main() -> void
 		ADDi $buffer:1 #'1' %0
 		MOVi $buffer:2 #0 	; buffer[2] = 0
 		ADRL %1 $buffer *0	; print(buffer)
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1369:19
 		MOVp %1 &.s_Setcom4ea:18 	; print(" to ")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1370:19
 		MODi %0 $lastTo #STRIDE	; buffer[0] = ('A' + (lastTo % STRIDE - 1))
 		SUBi %0 %0 #1
 		ADDi $buffer:0 #'A' %0
@@ -2502,21 +2502,21 @@ main:	FUNC	; signature func main() -> void
 		SUBi %0 %0 #2
 		ADDi $buffer:1 #'1' %0
 		ADRL %1 $buffer *0	; print(buffer)
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1373:19
 		MOVp %1 &.s_4ed 	; print(".\n\n")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1374:20
 	.f19:	NEQi $moveResult #CHECKMATE @.f22	; if (moveResult == CHECKMATE) 
 		MOVp $p &.s_Checkm4ee 	; p = "Checkmate! White wins.\n"
 		PEEK %0 &turnColor 	; if (global turnColor == WHITE) p = "Checkmate! Black wins.\n"
 		NEQi %0 #WHITE @.f23
 		MOVp $p &.s_Checkm4ef 	; p = "Checkmate! Black wins.\n"
 	.f23:	MOVp %1 $p 	; print(p)
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1381:13
 		MOVi $lastMove #MATE 	; lastMove = MATE
 		GOTO @.e24  	; } else if (moveResult == STALEMATE) 
 	.f22:	NEQi $moveResult #STALEMATE @.f25	; if (moveResult == STALEMATE) 
 		MOVp %1 &.s_Stalem4f0 	; print("Stalemate!\n")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 1384:26
 		MOVi $lastMove #MATE 	; lastMove = MATE
 	.f25:	NOOP
 	.e24:	NEQi $lastMove #QUIT @.l0	; } while (lastMove != QUIT)

--- a/tests/impala/golden/adventCode.gazl
+++ b/tests/impala/golden/adventCode.gazl
@@ -1,179 +1,179 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-; signature extern native output() -> unknown
-; signature extern native abort() -> unknown
-; signature extern native exit() -> unknown
-; signature extern native input() -> unknown
-; signature extern native inputEOF() -> unknown
-; signature extern native clock() -> unknown
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-GOTO2:	! DEFi #0	; signature const GOTO2 : int
-GOTO8:	! DEFi #1	; signature const GOTO8 : int
-GOTO2000:	! DEFi #2	; signature const GOTO2000 : int
-GOTO2009:	! DEFi #3	; signature const GOTO2009 : int
-GOTO2010:	! DEFi #4	; signature const GOTO2010 : int
-GOTO2011:	! DEFi #5	; signature const GOTO2011 : int
-GOTO2012:	! DEFi #6	; signature const GOTO2012 : int
-GOTO2600:	! DEFi #7	; signature const GOTO2600 : int
-GOTO2607:	! DEFi #8	; signature const GOTO2607 : int
-GOTO2630:	! DEFi #9	; signature const GOTO2630 : int
-GOTO2800:	! DEFi #10	; signature const GOTO2800 : int
-GOTO8000:	! DEFi #11	; signature const GOTO8000 : int
-GOTO18999:	! DEFi #12	; signature const GOTO18999 : int
-GOTO19000:	! DEFi #13	; signature const GOTO19000 : int
-CLSMAX:	! DEFi #12	; signature const CLSMAX : int
-HNTSIZ:	! DEFi #20	; signature const HNTSIZ : int
-LINSIZ:	! DEFi #12500	; signature const LINSIZ : int
-LOCSIZ:	! DEFi #185	; signature const LOCSIZ : int
-MESH:	! DEFi #123456789	; signature const MESH : int
-RTXSIZ:	! DEFi #277	; signature const RTXSIZ : int
-TRVSIZ:	! DEFi #885	; signature const TRVSIZ : int
-VRBSIZ:	! DEFi #35	; signature const VRBSIZ : int
-VRSION:	! DEFi #25	; signature const VRSION : int
-TRNSIZ:	! DEFi #5	; signature const TRNSIZ : int
-MAXTRS:	! DEFi #79	; signature const MAXTRS : int
-TABSIZ:	! DEFi #330	; signature const TABSIZ : int
-CHLOC:	! DEFi #114	; signature const CHLOC : int
-CHLOC2:	! DEFi #142	; signature const CHLOC2 : int
+; signature extern native output() -> unknown @ 9:21
+; signature extern native abort() -> unknown @ 10:20
+; signature extern native exit() -> unknown @ 11:19
+; signature extern native input() -> unknown @ 12:20
+; signature extern native inputEOF() -> unknown @ 13:23
+; signature extern native clock() -> unknown @ 14:20
+FALSE:	! DEFi #0	; signature const FALSE : int @ 16:20
+TRUE:	! DEFi #1	; signature const TRUE : int @ 17:19
+GOTO2:	! DEFi #0	; signature const GOTO2 : int @ 19:20
+GOTO8:	! DEFi #1	; signature const GOTO8 : int @ 20:20
+GOTO2000:	! DEFi #2	; signature const GOTO2000 : int @ 21:23
+GOTO2009:	! DEFi #3	; signature const GOTO2009 : int @ 22:23
+GOTO2010:	! DEFi #4	; signature const GOTO2010 : int @ 23:23
+GOTO2011:	! DEFi #5	; signature const GOTO2011 : int @ 24:23
+GOTO2012:	! DEFi #6	; signature const GOTO2012 : int @ 25:23
+GOTO2600:	! DEFi #7	; signature const GOTO2600 : int @ 26:23
+GOTO2607:	! DEFi #8	; signature const GOTO2607 : int @ 27:23
+GOTO2630:	! DEFi #9	; signature const GOTO2630 : int @ 28:23
+GOTO2800:	! DEFi #10	; signature const GOTO2800 : int @ 29:24
+GOTO8000:	! DEFi #11	; signature const GOTO8000 : int @ 30:24
+GOTO18999:	! DEFi #12	; signature const GOTO18999 : int @ 31:25
+GOTO19000:	! DEFi #13	; signature const GOTO19000 : int @ 32:25
+CLSMAX:	! DEFi #12	; signature const CLSMAX : int @ 34:22
+HNTSIZ:	! DEFi #20	; signature const HNTSIZ : int @ 35:22
+LINSIZ:	! DEFi #12500	; signature const LINSIZ : int @ 36:25
+LOCSIZ:	! DEFi #185	; signature const LOCSIZ : int @ 37:23
+MESH:	! DEFi #123456789	; signature const MESH : int @ 38:27
+RTXSIZ:	! DEFi #277	; signature const RTXSIZ : int @ 39:23
+TRVSIZ:	! DEFi #885	; signature const TRVSIZ : int @ 40:23
+VRBSIZ:	! DEFi #35	; signature const VRBSIZ : int @ 41:22
+VRSION:	! DEFi #25	; signature const VRSION : int @ 42:22
+TRNSIZ:	! DEFi #5	; signature const TRNSIZ : int @ 43:21
+MAXTRS:	! DEFi #79	; signature const MAXTRS : int @ 44:22
+TABSIZ:	! DEFi #330	; signature const TABSIZ : int @ 45:23
+CHLOC:	! DEFi #114	; signature const CHLOC : int @ 46:20
+CHLOC2:	! DEFi #142	; signature const CHLOC2 : int @ 47:21
 	! SHLi <A> #1 #11
-CONDS:	! DEFi <A>	; signature const CONDS : int
-DALTLC:	! DEFi #18	; signature const DALTLC : int
-ABB:	GLOB *186	; signature array ABB[186] : unknown
-ATLOC:	GLOB *186	; signature array ATLOC[186] : unknown
-DLOC:	GLOB *7	; signature array DLOC[7] : unknown
-FIXED:	GLOB *101	; signature array FIXED[101] : unknown
-LINK:	GLOB *201	; signature array LINK[201] : unknown
-PARMS:	GLOB *26	; signature array PARMS[26] : unknown
-PLACE:	GLOB *101	; signature array PLACE[101] : unknown
-INLINE:	GLOB *101	; signature array INLINE[101] : unknown
-MAP1:	GLOB *129	; signature array MAP1[129] : unknown
-MAP2:	GLOB *129	; signature array MAP2[129] : unknown
-DSEEN:	GLOB *7	; signature array DSEEN[7] : unknown
-HINTED:	GLOB *21	; signature array HINTED[21] : unknown
-HINTLC:	GLOB *21	; signature array HINTLC[21] : unknown
-ODLOC:	GLOB *7	; signature array ODLOC[7] : unknown
-TK:	GLOB *21	; signature array TK[21] : unknown
-PROP:	GLOB *101	; signature array PROP[101] : unknown
+CONDS:	! DEFi <A>	; signature const CONDS : int @ 48:28
+DALTLC:	! DEFi #18	; signature const DALTLC : int @ 49:22
+ABB:	GLOB *186	; signature array ABB[186] : unknown @ 51:22
+ATLOC:	GLOB *186	; signature array ATLOC[186] : unknown @ 52:24
+DLOC:	GLOB *7	; signature array DLOC[7] : unknown @ 53:21
+FIXED:	GLOB *101	; signature array FIXED[101] : unknown @ 54:24
+LINK:	GLOB *201	; signature array LINK[201] : unknown @ 55:23
+PARMS:	GLOB *26	; signature array PARMS[26] : unknown @ 56:23
+PLACE:	GLOB *101	; signature array PLACE[101] : unknown @ 57:24
+INLINE:	GLOB *101	; signature array INLINE[101] : unknown @ 59:25
+MAP1:	GLOB *129	; signature array MAP1[129] : unknown @ 60:23
+MAP2:	GLOB *129	; signature array MAP2[129] : unknown @ 61:23
+DSEEN:	GLOB *7	; signature array DSEEN[7] : unknown @ 63:22
+HINTED:	GLOB *21	; signature array HINTED[21] : unknown @ 64:24
+HINTLC:	GLOB *21	; signature array HINTLC[21] : unknown @ 65:24
+ODLOC:	GLOB *7	; signature array ODLOC[7] : unknown @ 66:22
+TK:	GLOB *21	; signature array TK[21] : unknown @ 67:20
+PROP:	GLOB *101	; signature array PROP[101] : unknown @ 68:23
 	GLOB *1
-BLKLIN:	DATi #TRUE	; signature global BLKLIN : int
+BLKLIN:	DATi #TRUE	; signature global BLKLIN : int @ 70:25
 	GLOB *1
-HOLDNG:	DATi #0	; signature global HOLDNG : int
+HOLDNG:	DATi #0	; signature global HOLDNG : int @ 71:22
 	GLOB *1
-ABBNUM:	DATi #5	; signature global ABBNUM : int
+ABBNUM:	DATi #5	; signature global ABBNUM : int @ 72:22
 	GLOB *1
-TRNDEX:	DATi #1	; signature global TRNDEX : int
+TRNDEX:	DATi #1	; signature global TRNDEX : int @ 73:22
 	GLOB *1
-TRNLUZ:	DATi #0	; signature global TRNLUZ : int
+TRNLUZ:	DATi #0	; signature global TRNLUZ : int @ 74:22
 	GLOB *1
-TURNS:	DATi #0	; signature global TURNS : int
+TURNS:	DATi #0	; signature global TURNS : int @ 75:21
 	GLOB *1
-CLOSNG:	DATi #FALSE	; signature global CLOSNG : int
+CLOSNG:	DATi #FALSE	; signature global CLOSNG : int @ 76:26
 	GLOB *1
-BONUS:	DATi #0	; signature global BONUS : int
+BONUS:	DATi #0	; signature global BONUS : int @ 77:21
 	GLOB *1
-NOVICE:	DATi #FALSE	; signature global NOVICE : int
+NOVICE:	DATi #FALSE	; signature global NOVICE : int @ 78:26
 	GLOB *1
-CLSHNT:	DATi #FALSE	; signature global CLSHNT : int
+CLSHNT:	DATi #FALSE	; signature global CLSHNT : int @ 79:26
 	GLOB *1
-CLOSED:	DATi #FALSE	; signature global CLOSED : int
+CLOSED:	DATi #FALSE	; signature global CLOSED : int @ 80:26
 	GLOB *1
-NUMDIE:	DATi #0	; signature global NUMDIE : int
+NUMDIE:	DATi #0	; signature global NUMDIE : int @ 81:22
 	GLOB *1
-SAVED:	DATi #0	; signature global SAVED : int
+SAVED:	DATi #0	; signature global SAVED : int @ 82:21
 	GLOB *1
-WZDARK:	DATi #FALSE	; signature global WZDARK : int
+WZDARK:	DATi #FALSE	; signature global WZDARK : int @ 83:26
 	GLOB *1
-LMWARN:	DATi #FALSE	; signature global LMWARN : int
+LMWARN:	DATi #FALSE	; signature global LMWARN : int @ 84:26
 	GLOB *1
-FOOBAR:	DATi #0	; signature global FOOBAR : int
+FOOBAR:	DATi #0	; signature global FOOBAR : int @ 85:22
 	GLOB *1
-CLOCK1:	DATi #30	; signature global CLOCK1 : int
+CLOCK1:	DATi #30	; signature global CLOCK1 : int @ 86:23
 	GLOB *1
-CLOCK2:	DATi #50	; signature global CLOCK2 : int
+CLOCK2:	DATi #50	; signature global CLOCK2 : int @ 87:23
 	GLOB *1
-DETAIL:	DATi #0	; signature global DETAIL : int
+DETAIL:	DATi #0	; signature global DETAIL : int @ 88:22
 	GLOB *1
-DKILL:	DATi #0	; signature global DKILL : int
+DKILL:	DATi #0	; signature global DKILL : int @ 89:21
 	GLOB *1
-IGO:	DATi #0	; signature global IGO : int
+IGO:	DATi #0	; signature global IGO : int @ 90:19
 	GLOB *1
-KNFLOC:	DATi #0	; signature global KNFLOC : int
+KNFLOC:	DATi #0	; signature global KNFLOC : int @ 91:22
 	GLOB *1
-IWEST:	DATi #0	; signature global IWEST : int
+IWEST:	DATi #0	; signature global IWEST : int @ 92:21
 	GLOB *1
-PANIC:	DATi #FALSE	; signature global PANIC : int
+PANIC:	DATi #FALSE	; signature global PANIC : int @ 93:25
 	GLOB *1
-gK:	DATi #0	; signature global gK : int
+gK:	DATi #0	; signature global gK : int @ 95:14
 	GLOB *1
-gOBJ:	DATi #0	; signature global gOBJ : int
+gOBJ:	DATi #0	; signature global gOBJ : int @ 96:16
 	GLOB *1
-gLOC:	DATi #0	; signature global gLOC : int
+gLOC:	DATi #0	; signature global gLOC : int @ 97:16
 	GLOB *1
-DFLAG:	DATi #0	; signature global DFLAG : int
+DFLAG:	DATi #0	; signature global DFLAG : int @ 99:17
 	GLOB *1
-LNLENG:	DATi #0	; signature global LNLENG : int
+LNLENG:	DATi #0	; signature global LNLENG : int @ 100:18
 	GLOB *1
-LNPOSN:	DATi #0	; signature global LNPOSN : int
+LNPOSN:	DATi #0	; signature global LNPOSN : int @ 101:18
 	GLOB *1
-VERB:	DATi #0	; signature global VERB : int
+VERB:	DATi #0	; signature global VERB : int @ 102:16
 	GLOB *1
-ZZWORD:	DATi #0	; signature global ZZWORD : int
+ZZWORD:	DATi #0	; signature global ZZWORD : int @ 103:18
 	GLOB *1
-SCORE:	DATi #0	; signature global SCORE : int
+SCORE:	DATi #0	; signature global SCORE : int @ 104:17
 	GLOB *1
-MAXDIE:	DATi #0	; signature global MAXDIE : int
+MAXDIE:	DATi #0	; signature global MAXDIE : int @ 105:18
 	GLOB *1
-MXSCOR:	DATi #0	; signature global MXSCOR : int
+MXSCOR:	DATi #0	; signature global MXSCOR : int @ 106:18
 	GLOB *1
-TALLY:	DATi #0	; signature global TALLY : int
+TALLY:	DATi #0	; signature global TALLY : int @ 107:17
 	GLOB *1
-THRESH:	DATi #0	; signature global THRESH : int
+THRESH:	DATi #0	; signature global THRESH : int @ 108:18
 	GLOB *1
-NEWLOC:	DATi #0	; signature global NEWLOC : int
+NEWLOC:	DATi #0	; signature global NEWLOC : int @ 109:18
 	GLOB *1
-LIMIT:	DATi #0	; signature global LIMIT : int
+LIMIT:	DATi #0	; signature global LIMIT : int @ 110:17
 	GLOB *1
-OLDLC2:	DATi #0	; signature global OLDLC2 : int
+OLDLC2:	DATi #0	; signature global OLDLC2 : int @ 111:18
 	GLOB *1
-OLDLOC:	DATi #0	; signature global OLDLOC : int
+OLDLOC:	DATi #0	; signature global OLDLOC : int @ 112:18
 	GLOB *1
-DTOTAL:	DATi #0	; signature global DTOTAL : int
+DTOTAL:	DATi #0	; signature global DTOTAL : int @ 113:18
 	GLOB *1
-SPK:	DATi #0	; signature global SPK : int
+SPK:	DATi #0	; signature global SPK : int @ 114:15
 	GLOB *1
-WD1:	DATi #0	; signature global WD1 : int
+WD1:	DATi #0	; signature global WD1 : int @ 115:15
 	GLOB *1
-WD1X:	DATi #0	; signature global WD1X : int
+WD1X:	DATi #0	; signature global WD1X : int @ 116:16
 	GLOB *1
-WD2:	DATi #0	; signature global WD2 : int
+WD2:	DATi #0	; signature global WD2 : int @ 117:15
 	GLOB *1
-WD2X:	DATi #0	; signature global WD2X : int
-LINUSE:	! DEFi #12482	; signature const LINUSE : int
-TRVS:	! DEFi #879	; signature const TRVS : int
-CLSSES:	! DEFi #10	; signature const CLSSES : int
-TRNVLS:	! DEFi #4	; signature const TRNVLS : int
-TABNDX:	! DEFi #326	; signature const TABNDX : int
-HNTMAX:	! DEFi #10	; signature const HNTMAX : int
-; signature extern array PTEXT[] : unknown
-; signature extern array RTEXT[] : unknown
-; signature extern array CTEXT[] : unknown
-; signature extern array STEXT[] : unknown
-; signature extern array LTEXT[] : unknown
-; signature extern array KEY[] : unknown
-; signature extern array LOCSND[] : unknown
-; signature extern array LINES[] : unknown
-; signature extern array CVAL[] : unknown
-; signature extern array TTEXT[] : unknown
-; signature extern array TRNVAL[] : unknown
-; signature extern array TRAVEL[] : unknown
-; signature extern array KTAB[] : unknown
-; signature extern array PLAC[] : unknown
-; signature extern array FIXD[] : unknown
-; signature extern array ACTSPK[] : unknown
-; signature extern array HINTS[] : unknown
-ATAB:	GLOB *331	; signature array ATAB[331] : unknown
+WD2X:	DATi #0	; signature global WD2X : int @ 118:16
+LINUSE:	! DEFi #12482	; signature const LINUSE : int @ 120:25
+TRVS:	! DEFi #879	; signature const TRVS : int @ 121:21
+CLSSES:	! DEFi #10	; signature const CLSSES : int @ 122:22
+TRNVLS:	! DEFi #4	; signature const TRNVLS : int @ 123:21
+TABNDX:	! DEFi #326	; signature const TABNDX : int @ 124:23
+HNTMAX:	! DEFi #10	; signature const HNTMAX : int @ 125:22
+; signature extern array PTEXT[] : unknown @ 127:19
+; signature extern array RTEXT[] : unknown @ 128:19
+; signature extern array CTEXT[] : unknown @ 129:19
+; signature extern array STEXT[] : unknown @ 130:19
+; signature extern array LTEXT[] : unknown @ 131:19
+; signature extern array KEY[] : unknown @ 132:17
+; signature extern array LOCSND[] : unknown @ 133:20
+; signature extern array LINES[] : unknown @ 134:19
+; signature extern array CVAL[] : unknown @ 135:18
+; signature extern array TTEXT[] : unknown @ 136:19
+; signature extern array TRNVAL[] : unknown @ 137:20
+; signature extern array TRAVEL[] : unknown @ 138:20
+; signature extern array KTAB[] : unknown @ 139:18
+; signature extern array PLAC[] : unknown @ 140:18
+; signature extern array FIXD[] : unknown @ 141:18
+; signature extern array ACTSPK[] : unknown @ 142:20
+; signature extern array HINTS[] : unknown @ 143:19
+ATAB:	GLOB *331	; signature array ATAB[331] : unknown @ 145:24
 	DATA #0 #576501649 #407342340 #358494005 #627590956
 	DATA #342272582 #375946497 #376088268 #325880787
 	DATA #527121725 #305669668 #575365029 #575505951
@@ -256,7 +256,7 @@ ATAB:	GLOB *331	; signature array ATAB[331] : unknown
 	DATA #540281369 #426091588 #644153937 #474943296
 	DATA #475114733 #645429828 #709109173 #741757328
 	DATA #557397993 #0 #0 #0 #0 #0
-COND:	GLOB *186	; signature array COND[186] : unknown
+COND:	GLOB *186	; signature array COND[186] : unknown @ 168:24
 	DATA #0 #5 #1 #5 #5 #1 #131089 #5 #1050625 #1 #1 #0 #0
 	DATA #4096 #0 #1048576 #0 #0 #0 #8192 #0 #0 #0 #0 #6 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #4 #0 #0 #0 #16400
@@ -274,116 +274,116 @@ COND:	GLOB *186	; signature array COND[186] : unknown
 	DATA #262161 #262161 #262161 #262161 #262161 #262161
 	DATA #262161 #1 #4 #4 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0
-OBJSND:	GLOB *101	; signature array OBJSND[101] : unknown
+OBJSND:	GLOB *101	; signature array OBJSND[101] : unknown @ 182:26
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #3 #0 #0 #2 #0 #0 #1 #2 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #6 #0 #0 #0 #0 #0 #0 #4 #0 #3 #0 #0
 	DATA #0 #0 #0 #0 #0 #1 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
-OBJTXT:	GLOB *101	; signature array OBJTXT[101] : unknown
+OBJTXT:	GLOB *101	; signature array OBJTXT[101] : unknown @ 191:26
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #1 #0 #0 #1 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #1 #0 #1 #0 #0 #0 #0 #0 #0 #0 #0 #1 #1 #1 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
-AXE:	! DEFi #28	; signature const AXE : int
-BATTER:	! DEFi #39	; signature const BATTER : int
-BEAR:	! DEFi #35	; signature const BEAR : int
-BIRD:	! DEFi #8	; signature const BIRD : int
-BLOOD:	! DEFi #44	; signature const BLOOD : int
-BOTTLE:	! DEFi #20	; signature const BOTTLE : int
-CAGE:	! DEFi #4	; signature const CAGE : int
-CAVITY:	! DEFi #43	; signature const CAVITY : int
-CHASM:	! DEFi #32	; signature const CHASM : int
-CLAM:	! DEFi #14	; signature const CLAM : int
-DOOR:	! DEFi #9	; signature const DOOR : int
-DRAGON:	! DEFi #31	; signature const DRAGON : int
-DWARF:	! DEFi #17	; signature const DWARF : int
-FISSUR:	! DEFi #12	; signature const FISSUR : int
-FOOD:	! DEFi #19	; signature const FOOD : int
-GRATE:	! DEFi #3	; signature const GRATE : int
-KEYS:	! DEFi #1	; signature const KEYS : int
-KNIFE:	! DEFi #18	; signature const KNIFE : int
-LAMP:	! DEFi #2	; signature const LAMP : int
-MAGZIN:	! DEFi #16	; signature const MAGZIN : int
-MESSAG:	! DEFi #36	; signature const MESSAG : int
-MIRROR:	! DEFi #23	; signature const MIRROR : int
-OGRE:	! DEFi #41	; signature const OGRE : int
-OIL:	! DEFi #22	; signature const OIL : int
-OYSTER:	! DEFi #15	; signature const OYSTER : int
-PILLOW:	! DEFi #10	; signature const PILLOW : int
-PLANT:	! DEFi #24	; signature const PLANT : int
-PLANT2:	! DEFi #25	; signature const PLANT2 : int
-RESER:	! DEFi #45	; signature const RESER : int
-ROD:	! DEFi #5	; signature const ROD : int
-ROD2:	! DEFi #6	; signature const ROD2 : int
-gSIGN:	! DEFi #49	; signature const gSIGN : int
-SNAKE:	! DEFi #11	; signature const SNAKE : int
-STEPS:	! DEFi #7	; signature const STEPS : int
-TROLL:	! DEFi #33	; signature const TROLL : int
-TROLL2:	! DEFi #34	; signature const TROLL2 : int
-URN:	! DEFi #42	; signature const URN : int
-VEND:	! DEFi #38	; signature const VEND : int
-VOLCAN:	! DEFi #37	; signature const VOLCAN : int
-WATER:	! DEFi #21	; signature const WATER : int
-AMBER:	! DEFi #67	; signature const AMBER : int
-CHAIN:	! DEFi #64	; signature const CHAIN : int
-CHEST:	! DEFi #55	; signature const CHEST : int
-COINS:	! DEFi #54	; signature const COINS : int
-EGGS:	! DEFi #56	; signature const EGGS : int
-EMRALD:	! DEFi #59	; signature const EMRALD : int
-JADE:	! DEFi #66	; signature const JADE : int
-NUGGET:	! DEFi #50	; signature const NUGGET : int
-PEARL:	! DEFi #61	; signature const PEARL : int
-PYRAM:	! DEFi #60	; signature const PYRAM : int
-RUBY:	! DEFi #65	; signature const RUBY : int
-RUG:	! DEFi #62	; signature const RUG : int
-SAPPH:	! DEFi #68	; signature const SAPPH : int
-TRIDNT:	! DEFi #57	; signature const TRIDNT : int
-VASE:	! DEFi #58	; signature const VASE : int
-BACK:	! DEFi #8	; signature const BACK : int
-CAVE:	! DEFi #67	; signature const CAVE : int
-DPRSSN:	! DEFi #63	; signature const DPRSSN : int
-ENTER:	! DEFi #3	; signature const ENTER : int
-ENTRNC:	! DEFi #64	; signature const ENTRNC : int
-LOOK:	! DEFi #57	; signature const LOOK : int
-NUL:	! DEFi #21	; signature const NUL : int
-STREAM:	! DEFi #14	; signature const STREAM : int
-FIND:	! DEFi #19	; signature const FIND : int
-INVENT:	! DEFi #20	; signature const INVENT : int
-LOCK:	! DEFi #6	; signature const LOCK : int
-SAY:	! DEFi #3	; signature const SAY : int
-THROW:	! DEFi #17	; signature const THROW : int
-; signature extern func score() -> unknown
+AXE:	! DEFi #28	; signature const AXE : int @ 200:19
+BATTER:	! DEFi #39	; signature const BATTER : int @ 201:22
+BEAR:	! DEFi #35	; signature const BEAR : int @ 202:20
+BIRD:	! DEFi #8	; signature const BIRD : int @ 203:19
+BLOOD:	! DEFi #44	; signature const BLOOD : int @ 204:21
+BOTTLE:	! DEFi #20	; signature const BOTTLE : int @ 205:22
+CAGE:	! DEFi #4	; signature const CAGE : int @ 206:19
+CAVITY:	! DEFi #43	; signature const CAVITY : int @ 207:22
+CHASM:	! DEFi #32	; signature const CHASM : int @ 208:21
+CLAM:	! DEFi #14	; signature const CLAM : int @ 209:20
+DOOR:	! DEFi #9	; signature const DOOR : int @ 210:19
+DRAGON:	! DEFi #31	; signature const DRAGON : int @ 211:22
+DWARF:	! DEFi #17	; signature const DWARF : int @ 212:21
+FISSUR:	! DEFi #12	; signature const FISSUR : int @ 213:22
+FOOD:	! DEFi #19	; signature const FOOD : int @ 214:20
+GRATE:	! DEFi #3	; signature const GRATE : int @ 215:20
+KEYS:	! DEFi #1	; signature const KEYS : int @ 216:19
+KNIFE:	! DEFi #18	; signature const KNIFE : int @ 217:21
+LAMP:	! DEFi #2	; signature const LAMP : int @ 218:19
+MAGZIN:	! DEFi #16	; signature const MAGZIN : int @ 219:22
+MESSAG:	! DEFi #36	; signature const MESSAG : int @ 220:22
+MIRROR:	! DEFi #23	; signature const MIRROR : int @ 221:22
+OGRE:	! DEFi #41	; signature const OGRE : int @ 222:20
+OIL:	! DEFi #22	; signature const OIL : int @ 223:19
+OYSTER:	! DEFi #15	; signature const OYSTER : int @ 224:22
+PILLOW:	! DEFi #10	; signature const PILLOW : int @ 225:22
+PLANT:	! DEFi #24	; signature const PLANT : int @ 226:21
+PLANT2:	! DEFi #25	; signature const PLANT2 : int @ 227:22
+RESER:	! DEFi #45	; signature const RESER : int @ 228:21
+ROD:	! DEFi #5	; signature const ROD : int @ 229:18
+ROD2:	! DEFi #6	; signature const ROD2 : int @ 230:19
+gSIGN:	! DEFi #49	; signature const gSIGN : int @ 231:21
+SNAKE:	! DEFi #11	; signature const SNAKE : int @ 232:21
+STEPS:	! DEFi #7	; signature const STEPS : int @ 233:20
+TROLL:	! DEFi #33	; signature const TROLL : int @ 234:21
+TROLL2:	! DEFi #34	; signature const TROLL2 : int @ 235:22
+URN:	! DEFi #42	; signature const URN : int @ 236:19
+VEND:	! DEFi #38	; signature const VEND : int @ 237:20
+VOLCAN:	! DEFi #37	; signature const VOLCAN : int @ 238:22
+WATER:	! DEFi #21	; signature const WATER : int @ 239:21
+AMBER:	! DEFi #67	; signature const AMBER : int @ 240:21
+CHAIN:	! DEFi #64	; signature const CHAIN : int @ 241:21
+CHEST:	! DEFi #55	; signature const CHEST : int @ 242:21
+COINS:	! DEFi #54	; signature const COINS : int @ 243:21
+EGGS:	! DEFi #56	; signature const EGGS : int @ 244:20
+EMRALD:	! DEFi #59	; signature const EMRALD : int @ 245:22
+JADE:	! DEFi #66	; signature const JADE : int @ 246:20
+NUGGET:	! DEFi #50	; signature const NUGGET : int @ 247:22
+PEARL:	! DEFi #61	; signature const PEARL : int @ 248:21
+PYRAM:	! DEFi #60	; signature const PYRAM : int @ 249:21
+RUBY:	! DEFi #65	; signature const RUBY : int @ 250:20
+RUG:	! DEFi #62	; signature const RUG : int @ 251:19
+SAPPH:	! DEFi #68	; signature const SAPPH : int @ 252:21
+TRIDNT:	! DEFi #57	; signature const TRIDNT : int @ 253:22
+VASE:	! DEFi #58	; signature const VASE : int @ 254:20
+BACK:	! DEFi #8	; signature const BACK : int @ 255:19
+CAVE:	! DEFi #67	; signature const CAVE : int @ 256:20
+DPRSSN:	! DEFi #63	; signature const DPRSSN : int @ 257:22
+ENTER:	! DEFi #3	; signature const ENTER : int @ 258:20
+ENTRNC:	! DEFi #64	; signature const ENTRNC : int @ 259:22
+LOOK:	! DEFi #57	; signature const LOOK : int @ 260:20
+NUL:	! DEFi #21	; signature const NUL : int @ 261:19
+STREAM:	! DEFi #14	; signature const STREAM : int @ 262:22
+FIND:	! DEFi #19	; signature const FIND : int @ 263:20
+INVENT:	! DEFi #20	; signature const INVENT : int @ 264:22
+LOCK:	! DEFi #6	; signature const LOCK : int @ 265:19
+SAY:	! DEFi #3	; signature const SAY : int @ 266:18
+THROW:	! DEFi #17	; signature const THROW : int @ 267:21
+; signature extern func score() -> unknown @ 269:22
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fBUG:	FUNC	; signature func fBUG(int NUM) -> void
+fBUG:	FUNC	; signature func fBUG(int NUM) -> void @ 271:15
 	$NUM:	INPi
 	$numString:	LOCA *3
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_Fatale4d2 	; output("Fatal error ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 299:24
 		DIVi %0 $NUM #10	; numString[0] = '0' + NUM / 10
 		ADDi $numString:0 #'0' %0
 		MODi %0 $NUM #10	; numString[1] = '0' + NUM % 10
 		ADDi $numString:1 #'0' %0
 		MOVi $numString:2 #0 	; numString[2] = 0
 		ADRL %1 $numString *0	; output(numString)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 303:19
 		MOVp %1 &.s_Seesou4d3 	; output(".  See source code for interpretation.\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 304:52
+		CALL ^abort %0 *1	; expects function() -> unknown @ 305:9
 		RETU   	; }
 
 	GLOB *1
-fRAN_R:	DATi #0	; signature global fRAN_R : int
+fRAN_R:	DATi #0	; signature global fRAN_R : int @ 308:22
 
 ;-----------------------------------------------------------------------------
 	$RAN:	OUTi
-fRAN:	FUNC	; signature func fRAN(int RANGE) -> int
+fRAN:	FUNC	; signature func fRAN(int RANGE) -> int @ 310:15
 	$RANGE:	INPi
 	$D:	LOCi
 	$T:	LOCi
@@ -393,7 +393,7 @@ fRAN:	FUNC	; signature func fRAN(int RANGE) -> int
 		EQUi %0 #0 @.f0
 		GEQi $RANGE #0 @.f1
 	.f0:	MOVi $D #1999 	; D=1999
-		CALL ^clock %0 *1	; expects function() -> unknown
+		CALL ^clock %0 *1	; expects function() -> unknown @ 328:18
 		ANDi $T %0 #0x7FFFFFFF
 	.f1:	MOVi $T #1 	; for (T=1 to D+1) global fRAN_R=((global fRAN_R*1093+221587)%1048576)
 		ADDi %0 $D #1
@@ -410,13 +410,13 @@ fRAN:	FUNC	; signature func fRAN(int RANGE) -> int
 		RETU   	; }
 
 	! MULi <A> #7 #2
-fMPINIT_RUNS:	CNST *<A>	; signature array fMPINIT_RUNS[<A>] : unknown
+fMPINIT_RUNS:	CNST *<A>	; signature array fMPINIT_RUNS[<A>] : unknown @ 348:36
 	DATA #32 #34 #39 #46 #65 #90 #97 #122 #37 #37 #48 #57 #0
 	DATA #126
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fMPINIT:	FUNC	; signature func fMPINIT() -> void
+fMPINIT:	FUNC	; signature func fMPINIT() -> void @ 350:18
 	$FIRST:	LOCi
 	$I:	LOCi
 	$J:	LOCi
@@ -471,25 +471,25 @@ fMPINIT:	FUNC	; signature func fMPINIT() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fMAPLIN:	FUNC	; signature func fMAPLIN(int FIL) -> void
+fMAPLIN:	FUNC	; signature func fMAPLIN(int FIL) -> void @ 380:18
 	$FIL:	INPi
 	$I:	LOCi
 	$VAL:	LOCi
 ;-----------------------------------------------------------------------------
 		PEEK %0 &MAP2:1 	; if((int)global MAP2[1] == 0)fMPINIT()
 		NEQi %0 #0 @.l1
-		CALL &fMPINIT %0 *1	; expects fMPINIT() -> void
+		CALL &fMPINIT %0 *1	; expects fMPINIT() -> void @ 412:39
 	.l1:	NEQi $FIL #FALSE @.f2	; if(FIL==FALSE) 
 		MOVi %1 #99 	; input(99, global INLINE+1)
 		ADDp %2 &INLINE #1
-		CALL ^input %0 *3	; expects function(int, ptr) -> unknown
-		CALL ^inputEOF %0 *1	; expects function() -> unknown
+		CALL ^input %0 *3	; expects function(int, ptr) -> unknown @ 416:30
+		CALL ^inputEOF %0 *1	; expects function() -> unknown @ 417:24
 		EQUi %0 #FALSE @.e4
 		MOVi %1 #1 	; score(1)
-		CALL &score %0 *2	; expects score(int) -> unknown
+		CALL &score %0 *2	; expects score(int) -> unknown @ 417:42
 		GOTO @.e4  	; } else 
 	.f2:	MOVi %1 #-1 	; fBUG(-1)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 419:12
 	.e4:	POKE &LNLENG #0 	; global LNLENG=0
 		MOVi $I #1 	; for (I=1 to 100+1) 
 		! ADDi <A> #100 #1
@@ -513,11 +513,11 @@ fMAPLIN:	FUNC	; signature func fMAPLIN(int FIL) -> void
 	.f9:	RETU   	; }
 
 	GLOB *1
-fGETTXT_SPLITTING:	DATi #-1	; signature global fGETTXT_SPLITTING : int
+fGETTXT_SPLITTING:	DATi #-1	; signature global fGETTXT_SPLITTING : int @ 437:34
 
 ;-----------------------------------------------------------------------------
 	$GETTXT:	OUTi
-fGETTXT:	FUNC	; signature func fGETTXT(int SKIP, int ONEWRD, int UPPER, int HASH) -> int
+fGETTXT:	FUNC	; signature func fGETTXT(int SKIP, int ONEWRD, int UPPER, int HASH) -> int @ 439:18
 	$SKIP:	INPi
 	$ONEWRD:	INPi
 	$UPPER:	INPi
@@ -591,7 +591,7 @@ fGETTXT:	FUNC	; signature func fGETTXT(int SKIP, int ONEWRD, int UPPER, int HASH
 
 ;-----------------------------------------------------------------------------
 	$MAKEWD:	OUTi
-fMAKEWD:	FUNC	; signature func fMAKEWD(int LETTRS) -> int
+fMAKEWD:	FUNC	; signature func fMAKEWD(int LETTRS) -> int @ 486:18
 	$LETTRS:	INPi
 	$I:	LOCi
 	$L:	LOCi
@@ -621,7 +621,7 @@ fMAKEWD:	FUNC	; signature func fMAKEWD(int LETTRS) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fSHFTXT:	FUNC	; signature func fSHFTXT(int FROM, int DELTA) -> void
+fSHFTXT:	FUNC	; signature func fSHFTXT(int FROM, int DELTA) -> void @ 510:18
 	$FROM:	INPi
 	$DELTA:	INPi
 	$I:	LOCi
@@ -652,7 +652,7 @@ fSHFTXT:	FUNC	; signature func fSHFTXT(int FROM, int DELTA) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fPUTTXT:	FUNC	; signature func fPUTTXT(int WORD, ptr sTATE, int CASE, int HASH) -> void
+fPUTTXT:	FUNC	; signature func fPUTTXT(int WORD, ptr sTATE, int CASE, int HASH) -> void @ 528:18
 	$WORD:	INPi
 	$sTATE:	INPp
 	$CASE:	INPi
@@ -702,7 +702,7 @@ fPUTTXT:	FUNC	; signature func fPUTTXT(int WORD, ptr sTATE, int CASE, int HASH) 
 		GOTO @.e8  	; } else 
 	.f7:	PEEK %1 &LNPOSN 	; fSHFTXT(global LNPOSN,1)
 		MOVi %2 #1 
-		CALL &fSHFTXT %0 *3	; expects fSHFTXT(int, int) -> void
+		CALL &fSHFTXT %0 *3	; expects fSHFTXT(int, int) -> void @ 555:28
 		PEEK %0 $sTATE 	; (*sTATE)=(int)(*sTATE)+BYTE
 		ADDi %0 %0 $BYTE
 		POKE $sTATE %0 
@@ -731,18 +731,18 @@ fPUTTXT:	FUNC	; signature func fPUTTXT(int WORD, ptr sTATE, int CASE, int HASH) 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fTYPE:	FUNC	; signature func fTYPE() -> void
+fTYPE:	FUNC	; signature func fTYPE() -> void @ 569:16
 	$I:	LOCi
 	$VAL:	LOCi
 ;-----------------------------------------------------------------------------
 		PEEK %1 &LNLENG 	; if(!(global LNLENG != 0)) 
 		NEQi %1 #0 @.f0
 		MOVp %1 &.s_Seesou4d3:38 	; output("\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 577:15
 		GOTO @return  	; goto return
 	.f0:	PEEK %0 &MAP2:1 	; if((int)global MAP2[1] == 0)fMPINIT()
 		NEQi %0 #0 @.f1
-		CALL &fMPINIT %0 *1	; expects fMPINIT() -> void
+		CALL &fMPINIT %0 *1	; expects fMPINIT() -> void @ 580:39
 	.f1:	MOVi $I #1 	; for (I=1 to global LNLENG+1) 
 		PEEK %0 &LNLENG 
 		ADDi %0 %0 #1
@@ -756,27 +756,27 @@ fTYPE:	FUNC	; signature func fTYPE() -> void
 		ADDi %0 %0 #1
 		POKE &INLINE %0 #0
 		ADDp %1 &INLINE #1	; output(global INLINE+1)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 586:25
 		MOVp %1 &.s_Seesou4d3:38 	; output("\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 586:39
 	return:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fTYPE0:	FUNC	; signature func fTYPE0() -> void
+fTYPE0:	FUNC	; signature func fTYPE0() -> void @ 590:17
 	$TEMP:	LOCi
 ;-----------------------------------------------------------------------------
 		PEEK $TEMP &LNLENG 	; TEMP=global LNLENG
 		POKE &LNLENG #0 	; global LNLENG=0
-		CALL &fTYPE %0 *1	; expects fTYPE() -> void
+		CALL &fTYPE %0 *1	; expects fTYPE() -> void @ 598:9
 		POKE &LNLENG $TEMP 	; global LNLENG=TEMP
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fSPEAK:	FUNC	; signature func fSPEAK(int N) -> void
+fSPEAK:	FUNC	; signature func fSPEAK(int N) -> void @ 602:17
 	$N:	INPi
 	$BLANK:	LOCi
 	$CASE:	LOCi
@@ -808,7 +808,7 @@ fSPEAK:	FUNC	; signature func fSPEAK(int N) -> void
 		ADRL %3 $STATE *0
 		MOVi %4 #2 
 		MOVi %5 $I 
-		CALL &fPUTTXT %1 *5	; expects fPUTTXT(int, ptr, int, int) -> void
+		CALL &fPUTTXT %1 *5	; expects fPUTTXT(int, ptr, int, int) -> void @ 620:38
 		FORi $I %0 @.l2	; } /* end loop */
 	.e1:	POKE &LNPOSN #0 	; global LNPOSN=0
 	L30:	PEEK %0 &LNPOSN 	; L30:
@@ -845,7 +845,7 @@ fSPEAK:	FUNC	; signature func fSPEAK(int N) -> void
 	.f12:	PEEK %1 &LNPOSN 	; fSHFTXT(global LNPOSN+2,PRMTYP-2)
 		ADDi %1 %1 #2
 		SUBi %2 $PRMTYP #2
-		CALL &fSHFTXT %0 *3	; expects fSHFTXT(int, int) -> void
+		CALL &fSHFTXT %0 *3	; expects fSHFTXT(int, int) -> void @ 646:35
 		PEEK %0 &LNPOSN 	; global LNPOSN=global LNPOSN+PRMTYP
 		ADDi %0 %0 $PRMTYP
 		POKE &LNPOSN %0 
@@ -881,7 +881,7 @@ fSPEAK:	FUNC	; signature func fSPEAK(int N) -> void
 	L320:	PEEK %1 &LNPOSN 	; L320:
 		ADDi %1 %1 #2
 		MOVi %2 #-1 
-		CALL &fSHFTXT %0 *3	; expects fSHFTXT(int, int) -> void
+		CALL &fSHFTXT %0 *3	; expects fSHFTXT(int, int) -> void @ 666:29
 		PEEK %0 &LNPOSN 	; global INLINE[global LNPOSN]=55
 		POKE &INLINE %0 #55
 		PEEK %0 &PARMS $NPARMS	; if((int)global PARMS[NPARMS] == 1)fSHFTXT(global LNPOSN+1,-1)
@@ -889,12 +889,12 @@ fSPEAK:	FUNC	; signature func fSPEAK(int N) -> void
 		PEEK %1 &LNPOSN 	; fSHFTXT(global LNPOSN+1,-1)
 		ADDi %1 %1 #1
 		MOVi %2 #-1 
-		CALL &fSHFTXT %0 *3	; expects fSHFTXT(int, int) -> void
+		CALL &fSHFTXT %0 *3	; expects fSHFTXT(int, int) -> void @ 668:63
 		GOTO @L395  	; goto L395
 	L340:	PEEK %1 &LNPOSN 	; L340:
 		ADDi %1 %1 #2
 		MOVi %2 #-2 
-		CALL &fSHFTXT %0 *3	; expects fSHFTXT(int, int) -> void
+		CALL &fSHFTXT %0 *3	; expects fSHFTXT(int, int) -> void @ 672:29
 		MOVi $STATE #0 	; STATE=0
 		MOVi $CASE #2 	; CASE=2
 	L345:	PEEK %0 &PARMS $NPARMS	; L345:
@@ -908,14 +908,14 @@ fSPEAK:	FUNC	; signature func fSPEAK(int N) -> void
 		ADRL %2 $STATE *0
 		MOVi %3 $CASE 
 		MOVi %4 #0 
-		CALL &fPUTTXT %0 *5	; expects fPUTTXT(int, ptr, int, int) -> void
+		CALL &fPUTTXT %0 *5	; expects fPUTTXT(int, ptr, int, int) -> void @ 678:45
 		ADDi $NPARMS $NPARMS #1	; NPARMS=NPARMS+1
 		GOTO @L345  	; goto L345
 	L360:	PEEK $PRMTYP &PARMS $NPARMS	; L360:
 		PEEK %1 &LNPOSN 	; fSHFTXT(global LNPOSN+2,PRMTYP-2)
 		ADDi %1 %1 #2
 		SUBi %2 $PRMTYP #2
-		CALL &fSHFTXT %0 *3	; expects fSHFTXT(int, int) -> void
+		CALL &fSHFTXT %0 *3	; expects fSHFTXT(int, int) -> void @ 684:35
 		NEQi $PRMTYP #0 @.f21	; if(PRMTYP == 0) goto L395
 		GOTO @L395  	; goto L395
 	.f21:	MOVi $I #1 	; for (I=1 to PRMTYP+1) 
@@ -931,7 +931,7 @@ fSPEAK:	FUNC	; signature func fSPEAK(int N) -> void
 	L380:	PEEK %1 &LNPOSN 	; L380:
 		ADDi %1 %1 #2
 		MOVi %2 #-2 
-		CALL &fSHFTXT %0 *3	; expects fSHFTXT(int, int) -> void
+		CALL &fSHFTXT %0 *3	; expects fSHFTXT(int, int) -> void @ 693:29
 		MOVi $STATE #0 	; STATE=0
 		MOVi $CASE #-1 	; CASE= -1
 		NEQi $PRMTYP #31 @.f24	; if(PRMTYP == 31)CASE=1
@@ -943,13 +943,13 @@ fSPEAK:	FUNC	; signature func fSPEAK(int N) -> void
 		ADRL %2 $STATE *0
 		MOVi %3 $CASE 
 		MOVi %4 #0 
-		CALL &fPUTTXT %0 *5	; expects fPUTTXT(int, ptr, int, int) -> void
+		CALL &fPUTTXT %0 *5	; expects fPUTTXT(int, ptr, int, int) -> void @ 699:45
 		ADDi %1 $NPARMS #1	; fPUTTXT(global PARMS[NPARMS+1],&STATE,CASE,0)
 		PEEK %1 &PARMS %1
 		ADRL %2 $STATE *0
 		MOVi %3 $CASE 
 		MOVi %4 #0 
-		CALL &fPUTTXT %0 *5	; expects fPUTTXT(int, ptr, int, int) -> void
+		CALL &fPUTTXT %0 *5	; expects fPUTTXT(int, ptr, int, int) -> void @ 700:47
 		NEQi $PRMTYP #13 @.f27	; if(PRMTYP == 13 && (int)global INLINE[I] >= 37 && (int)global INLINE[I] <= 62)global INLINE[I]=(int)global INLINE[I]-26
 		PEEK %0 &INLINE $I
 		LSSi %0 #37 @.f27
@@ -961,9 +961,9 @@ fSPEAK:	FUNC	; signature func fSPEAK(int N) -> void
 	.f27:	ADDi $NPARMS $NPARMS #2	; NPARMS=NPARMS+2
 		GOTO @L32  	; goto L32
 	L40:	EQUi $BLANK #FALSE @.f28	; L40:
-		CALL &fTYPE0 %0 *1	; expects fTYPE0() -> void
+		CALL &fTYPE0 %0 *1	; expects fTYPE0() -> void @ 706:28
 	.f28:	MOVi $BLANK #FALSE 	; BLANK=FALSE
-		CALL &fTYPE %0 *1	; expects fTYPE() -> void
+		CALL &fTYPE %0 *1	; expects fTYPE() -> void @ 708:9
 		ADDi $K $L #1	; K=L+1
 		PEEK %0 &LINES $K	; if((int)global LINES[K] >= 0) goto L10
 		LSSi %0 #0 @.f29
@@ -974,7 +974,7 @@ fSPEAK:	FUNC	; signature func fSPEAK(int N) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fPSPEAK:	FUNC	; signature func fPSPEAK(int MSG, int SKIP) -> void
+fPSPEAK:	FUNC	; signature func fPSPEAK(int MSG, int SKIP) -> void @ 715:18
 	$MSG:	INPi
 	$SKIP:	INPi
 	$I:	LOCi
@@ -992,31 +992,31 @@ fPSPEAK:	FUNC	; signature func fPSPEAK(int MSG, int SKIP) -> void
 		GEQi %1 #0 @.l3
 		FORi $I %0 @.l2	; } /* end loop */
 	.f0:	MOVi %1 $M 	; fSPEAK(M)
-		CALL &fSPEAK %0 *2	; expects fSPEAK(int) -> void
+		CALL &fSPEAK %0 *2	; expects fSPEAK(int) -> void @ 728:11
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fRSPEAK:	FUNC	; signature func fRSPEAK(int I) -> void
+fRSPEAK:	FUNC	; signature func fRSPEAK(int I) -> void @ 731:18
 	$I:	INPi
 ;-----------------------------------------------------------------------------
 		EQUi $I #0 @.f0	; if(I != 0)fSPEAK(global RTEXT[I])
 		PEEK %1 &RTEXT $I	; fSPEAK(global RTEXT[I])
-		CALL &fSPEAK %0 *2	; expects fSPEAK(int) -> void
+		CALL &fSPEAK %0 *2	; expects fSPEAK(int) -> void @ 734:35
 	.f0:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fSETPRM:	FUNC	; signature func fSETPRM(int FIRST, int P1, int P2) -> void
+fSETPRM:	FUNC	; signature func fSETPRM(int FIRST, int P1, int P2) -> void @ 737:18
 	$FIRST:	INPi
 	$P1:	INPi
 	$P2:	INPi
 ;-----------------------------------------------------------------------------
 		LSSi $FIRST #25 @.f0	; if(FIRST >= 25)fBUG(29)
 		MOVi %1 #29 	; fBUG(29)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 741:25
 	.f0:	POKE &PARMS $FIRST $P1	; global PARMS[FIRST]=P1
 		ADDi %0 $FIRST #1	; global PARMS[FIRST + 1]=P2
 		POKE &PARMS %0 $P2
@@ -1025,7 +1025,7 @@ fSETPRM:	FUNC	; signature func fSETPRM(int FIRST, int P1, int P2) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fGETIN:	FUNC	; signature func fGETIN(ptr wORD1, ptr wORD1X, ptr wORD2, ptr wORD2X) -> void
+fGETIN:	FUNC	; signature func fGETIN(ptr wORD1, ptr wORD1X, ptr wORD2, ptr wORD2X) -> void @ 748:17
 	$wORD1:	INPp
 	$wORD1X:	INPp
 	$wORD2:	INPp
@@ -1035,14 +1035,14 @@ fGETIN:	FUNC	; signature func fGETIN(ptr wORD1, ptr wORD1X, ptr wORD2, ptr wORD2
 	L10:	NOOP
 	.l0:	PEEK %0 &BLKLIN 	; if(global BLKLIN != FALSE)fTYPE0()
 		EQUi %0 #FALSE @.f1
-		CALL &fTYPE0 %0 *1	; expects fTYPE0() -> void
+		CALL &fTYPE0 %0 *1	; expects fTYPE0() -> void @ 760:37
 	.f1:	MOVi %1 #FALSE 	; fMAPLIN(FALSE)
-		CALL &fMAPLIN %0 *2	; expects fMAPLIN(int) -> void
+		CALL &fMAPLIN %0 *2	; expects fMAPLIN(int) -> void @ 761:17
 		MOVi %1 #TRUE 	; (*wORD1)=fGETTXT(TRUE,TRUE,TRUE,0)
 		MOVi %2 #TRUE 
 		MOVi %3 #TRUE 
 		MOVi %4 #0 
-		CALL &fGETTXT %0 *5	; expects fGETTXT(int, int, int, int) -> int
+		CALL &fGETTXT %0 *5	; expects fGETTXT(int, int, int, int) -> int @ 762:37
 		POKE $wORD1 %0 
 		PEEK %0 &BLKLIN 	; } while (global BLKLIN != FALSE && (int)(*wORD1) < 0)
 		EQUi %0 #FALSE @.f2
@@ -1052,50 +1052,50 @@ fGETIN:	FUNC	; signature func fGETIN(ptr wORD1, ptr wORD1X, ptr wORD2, ptr wORD2
 		MOVi %2 #TRUE 
 		MOVi %3 #TRUE 
 		MOVi %4 #0 
-		CALL &fGETTXT %0 *5	; expects fGETTXT(int, int, int, int) -> int
+		CALL &fGETTXT %0 *5	; expects fGETTXT(int, int, int, int) -> int @ 764:38
 		POKE $wORD1X %0 
 	.l3:	MOVi %1 #FALSE 	; JUNK=(int)fGETTXT(FALSE,TRUE,TRUE,0)
 		MOVi %2 #TRUE 
 		MOVi %3 #TRUE 
 		MOVi %4 #0 
-		CALL &fGETTXT %0 *5	; expects fGETTXT(int, int, int, int) -> int
+		CALL &fGETTXT %0 *5	; expects fGETTXT(int, int, int, int) -> int @ 766:39
 		MOVi $JUNK %0 
 		GRTi $JUNK #0 @.l3	; } while (JUNK > 0)
 		MOVi %1 #TRUE 	; (*wORD2)=fGETTXT(TRUE,TRUE,TRUE,0)
 		MOVi %2 #TRUE 
 		MOVi %3 #TRUE 
 		MOVi %4 #0 
-		CALL &fGETTXT %0 *5	; expects fGETTXT(int, int, int, int) -> int
+		CALL &fGETTXT %0 *5	; expects fGETTXT(int, int, int, int) -> int @ 768:36
 		POKE $wORD2 %0 
 		MOVi %1 #FALSE 	; (*wORD2X)=fGETTXT(FALSE,TRUE,TRUE,0)
 		MOVi %2 #TRUE 
 		MOVi %3 #TRUE 
 		MOVi %4 #0 
-		CALL &fGETTXT %0 *5	; expects fGETTXT(int, int, int, int) -> int
+		CALL &fGETTXT %0 *5	; expects fGETTXT(int, int, int, int) -> int @ 769:38
 		POKE $wORD2X %0 
 	.l4:	MOVi %1 #FALSE 	; JUNK=(int)fGETTXT(FALSE,TRUE,TRUE,0)
 		MOVi %2 #TRUE 
 		MOVi %3 #TRUE 
 		MOVi %4 #0 
-		CALL &fGETTXT %0 *5	; expects fGETTXT(int, int, int, int) -> int
+		CALL &fGETTXT %0 *5	; expects fGETTXT(int, int, int, int) -> int @ 771:39
 		MOVi $JUNK %0 
 		GRTi $JUNK #0 @.l4	; } while (JUNK > 0)
 		MOVi %1 #TRUE 	; if((int)fGETTXT(TRUE,TRUE,TRUE,0) <= 0)goto return
 		MOVi %2 #TRUE 
 		MOVi %3 #TRUE 
 		MOVi %4 #0 
-		CALL &fGETTXT %0 *5	; expects fGETTXT(int, int, int, int) -> int
+		CALL &fGETTXT %0 *5	; expects fGETTXT(int, int, int, int) -> int @ 773:36
 		GRTi %0 #0 @.f5
 		GOTO @return  	; goto return
 	.f5:	MOVi %1 #53 	; fRSPEAK(53)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 774:13
 		GOTO @L10  	; goto L10
 	return:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$YES:	OUTi
-fYES:	FUNC	; signature func fYES(int X, int Y, int Z) -> int
+fYES:	FUNC	; signature func fYES(int X, int Y, int Z) -> int @ 779:15
 	$X:	INPi
 	$Y:	INPi
 	$Z:	INPi
@@ -1105,41 +1105,41 @@ fYES:	FUNC	; signature func fYES(int X, int Y, int Z) -> int
 	$JUNK3:	LOCi
 ;-----------------------------------------------------------------------------
 	L1:	MOVi %1 $X 	; L1:
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 787:12
 		ADRL %1 $REPLY *0	; fGETIN(&REPLY,&JUNK1,&JUNK2,&JUNK3)
 		ADRL %2 $JUNK1 *0
 		ADRL %3 $JUNK2 *0
 		ADRL %4 $JUNK3 *0
-		CALL &fGETIN %0 *5	; expects fGETIN(ptr, ptr, ptr, ptr) -> void
+		CALL &fGETIN %0 *5	; expects fGETIN(ptr, ptr, ptr, ptr) -> void @ 788:37
 		MOVi %1 #250519 	; if(REPLY == (int)fMAKEWD(250519) || REPLY == (int)fMAKEWD(25)) 
-		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int
+		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int @ 789:35
 		EQUi $REPLY %0 @.t0
 		MOVi %1 #25 
-		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int
+		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int @ 789:63
 		NEQi $REPLY %0 @.f1
 	.t0:	MOVi $YES #TRUE 	; YES=TRUE
 		MOVi %1 $Y 	; fRSPEAK(Y)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 791:13
 		GOTO @return  	; goto return
 	.f1:	MOVi %1 #1415 	; if(REPLY == (int)fMAKEWD(1415) || REPLY == (int)fMAKEWD(14)) 
-		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int
+		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int @ 794:33
 		EQUi $REPLY %0 @.t2
 		MOVi %1 #14 
-		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int
+		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int @ 794:61
 		NEQi $REPLY %0 @.f3
 	.t2:	MOVi $YES #FALSE 	; YES=FALSE
 		MOVi %1 $Z 	; fRSPEAK(Z)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 796:13
 		GOTO @return  	; goto return
 	.f3:	MOVi %1 #185 	; fRSPEAK(185)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 799:14
 		GOTO @L1  	; goto L1
 	return:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-score:	FUNC	; signature func score(int MODE) -> void
+score:	FUNC	; signature func score(int MODE) -> void @ 808:16
 	$MODE:	INPi
 	$I:	LOCi
 	$K:	LOCi
@@ -1286,7 +1286,7 @@ score:	FUNC	; signature func score(int MODE) -> void
 		PEEK %1 &TRNLUZ 
 		EQUi %1 #0 @.f24
 		MOVi %1 #242 	; fRSPEAK(242)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 897:85
 	.f24:	PEEK %0 &SCORE 	; if(global SCORE+global SAVED+1 >= global MXSCOR && global SAVED != 0)fRSPEAK(143)
 		PEEK %1 &SAVED 
 		ADDi %0 %0 %1
@@ -1296,17 +1296,17 @@ score:	FUNC	; signature func score(int MODE) -> void
 		PEEK %0 &SAVED 
 		EQUi %0 #0 @.f26
 		MOVi %1 #143 	; fRSPEAK(143)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 898:83
 	.f26:	MOVi %1 #1 	; fSETPRM(1,global SCORE,global MXSCOR)
 		PEEK %2 &SCORE 
 		PEEK %3 &MXSCOR 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 899:39
 		MOVi %1 #3 	; fSETPRM(3,global TURNS,global TURNS)
 		PEEK %2 &TURNS 
 		PEEK %3 &TURNS 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 900:38
 		MOVi %1 #262 	; fRSPEAK(262)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 901:14
 		MOVi $I #1 	; for (I=1 to CLSSES+1) 
 		! ADDi <A> #CLSSES #1
 		GEQi #1 <A> @.e27
@@ -1314,7 +1314,7 @@ score:	FUNC	; signature func score(int MODE) -> void
 		PEEK %1 &SCORE 
 		LSSi %0 %1 @.f29
 		PEEK %1 &CTEXT $I	; fSPEAK(global CTEXT[I])
-		CALL &fSPEAK %0 *2	; expects fSPEAK(int) -> void
+		CALL &fSPEAK %0 *2	; expects fSPEAK(int) -> void @ 904:27
 		POKE &SPK #264 	; global SPK=264
 		GEQi $I #CLSSES @.f30	; if(I < CLSSES) 
 		PEEK %0 &CVAL $I	; I=(int)global CVAL[I]+1-global SCORE
@@ -1324,24 +1324,24 @@ score:	FUNC	; signature func score(int MODE) -> void
 		MOVi %1 #1 	; fSETPRM(1,I,I)
 		MOVi %2 $I 
 		MOVi %3 $I 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 908:19
 		POKE &SPK #263 	; global SPK=263
 	.f30:	PEEK %1 &SPK 	; fRSPEAK(global SPK)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 911:23
 		MOVi %1 #0 	; exit(0)
-		CALL ^exit %0 *2	; expects function(int) -> unknown
+		CALL ^exit %0 *2	; expects function(int) -> unknown @ 912:11
 	.f29:	FORi $I <A> @.l28	; } /* end loop */
 	.e27:	POKE &SPK #265 	; global SPK=265
 		PEEK %1 &SPK 	; fRSPEAK(global SPK)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 916:21
 		MOVi %1 #0 	; exit(0)
-		CALL ^exit %0 *2	; expects function(int) -> unknown
+		CALL ^exit %0 *2	; expects function(int) -> unknown @ 917:9
 	return:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$VOCAB:	OUTi
-fVOCAB:	FUNC	; signature func fVOCAB(int ID, int INIT) -> int
+fVOCAB:	FUNC	; signature func fVOCAB(int ID, int INIT) -> int @ 924:17
 	$ID:	INPi
 	$INIT:	INPi
 	$HASH:	LOCi
@@ -1357,7 +1357,7 @@ fVOCAB:	FUNC	; signature func fVOCAB(int ID, int INIT) -> int
 		GEQi $INIT #0 @.f3	; if(INIT < 0) goto return
 		GOTO @return  	; goto return
 	.f3:	MOVi %1 #5 	; fBUG(5)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 940:11
 	.f2:	ADDi $HASH $HASH #7	; HASH=HASH+7
 		LSSi $INIT #0 @.f4	; if(!(INIT >= 0 && (int)global KTAB[I]/1000 != INIT)) 
 		PEEK %0 &KTAB $I
@@ -1373,13 +1373,13 @@ fVOCAB:	FUNC	; signature func fVOCAB(int ID, int INIT) -> int
 		GOTO @return  	; goto return
 	.f5:	FORi $I <A> @.l1	; } /* end loop */
 	.e0:	MOVi %1 #21 	; fBUG(21)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 951:10
 	return:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fCARRY:	FUNC	; signature func fCARRY(int OBJECT, int WHERE) -> void
+fCARRY:	FUNC	; signature func fCARRY(int OBJECT, int WHERE) -> void @ 955:17
 	$OBJECT:	INPi
 	$WHERE:	INPi
 	$TEMP:	LOCi
@@ -1409,7 +1409,7 @@ fCARRY:	FUNC	; signature func fCARRY(int OBJECT, int WHERE) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fDROP:	FUNC	; signature func fDROP(int OBJECT, int WHERE) -> void
+fDROP:	FUNC	; signature func fDROP(int OBJECT, int WHERE) -> void @ 979:16
 	$OBJECT:	INPi
 	$WHERE:	INPi
 ;-----------------------------------------------------------------------------
@@ -1432,7 +1432,7 @@ fDROP:	FUNC	; signature func fDROP(int OBJECT, int WHERE) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fMOVE:	FUNC	; signature func fMOVE(int OBJECT, int WHERE) -> void
+fMOVE:	FUNC	; signature func fMOVE(int OBJECT, int WHERE) -> void @ 995:16
 	$OBJECT:	INPi
 	$WHERE:	INPi
 	$FROM:	LOCi
@@ -1446,27 +1446,27 @@ fMOVE:	FUNC	; signature func fMOVE(int OBJECT, int WHERE) -> void
 		GRTi $FROM #300 @.f3
 		MOVi %1 $OBJECT 	; fCARRY(OBJECT,FROM)
 		MOVi %2 $FROM 
-		CALL &fCARRY %0 *3	; expects fCARRY(int, int) -> void
+		CALL &fCARRY %0 *3	; expects fCARRY(int, int) -> void @ 1007:48
 	.f3:	MOVi %1 $OBJECT 	; fDROP(OBJECT,WHERE)
 		MOVi %2 $WHERE 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1008:21
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fDSTROY:	FUNC	; signature func fDSTROY(int OBJECT) -> void
+fDSTROY:	FUNC	; signature func fDSTROY(int OBJECT) -> void @ 1011:18
 	$OBJECT:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi %1 $OBJECT 	; fMOVE(OBJECT,0)
 		MOVi %2 #0 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1014:17
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fJUGGLE:	FUNC	; signature func fJUGGLE(int OBJECT) -> void
+fJUGGLE:	FUNC	; signature func fJUGGLE(int OBJECT) -> void @ 1017:18
 	$OBJECT:	INPi
 	$I:	LOCi
 	$J:	LOCi
@@ -1475,30 +1475,30 @@ fJUGGLE:	FUNC	; signature func fJUGGLE(int OBJECT) -> void
 		PEEK $J &FIXED $OBJECT	; J=(int)global FIXED[OBJECT]
 		MOVi %1 $OBJECT 	; fMOVE(OBJECT,I)
 		MOVi %2 $I 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1025:17
 		ADDi %1 $OBJECT #100	; fMOVE(OBJECT+100,J)
 		MOVi %2 $J 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1026:21
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$PUT:	OUTi
-fPUT:	FUNC	; signature func fPUT(int OBJECT, int WHERE, int PVAL) -> int
+fPUT:	FUNC	; signature func fPUT(int OBJECT, int WHERE, int PVAL) -> int @ 1029:15
 	$OBJECT:	INPi
 	$WHERE:	INPi
 	$PVAL:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi %1 $OBJECT 	; fMOVE(OBJECT,WHERE)
 		MOVi %2 $WHERE 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1035:21
 		SUBi $PUT #-1 $PVAL	; PUT=(-1)-PVAL
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$ATDWRF:	OUTi
-fATDWRF:	FUNC	; signature func fATDWRF(int WHERE) -> int
+fATDWRF:	FUNC	; signature func fATDWRF(int WHERE) -> int @ 1039:18
 	$WHERE:	INPi
 	$I:	LOCi
 ;-----------------------------------------------------------------------------
@@ -1524,7 +1524,7 @@ fATDWRF:	FUNC	; signature func fATDWRF(int WHERE) -> int
 
 ;-----------------------------------------------------------------------------
 	$RNDVOC:	OUTi
-fRNDVOC:	FUNC	; signature func fRNDVOC(int CHAR, int FORCE) -> int
+fRNDVOC:	FUNC	; signature func fRNDVOC(int CHAR, int FORCE) -> int @ 1060:18
 	$CHAR:	INPi
 	$FORCE:	INPi
 	$DIV:	LOCi
@@ -1537,7 +1537,7 @@ fRNDVOC:	FUNC	; signature func fRNDVOC(int CHAR, int FORCE) -> int
 		! ADDi <A> #5 #1
 		GEQi #1 <A> @.f0
 	.l2:	MOVi %1 #26 	; J=11+(int)fRAN(26)
-		CALL &fRAN %0 *2	; expects fRAN(int) -> int
+		CALL &fRAN %0 *2	; expects fRAN(int) -> int @ 1072:22
 		ADDi $J #11 %0
 		NEQi $I #2 @.f3	; if(I == 2)J=CHAR
 		MOVi $J $CHAR 	; J=CHAR
@@ -1564,13 +1564,13 @@ fRNDVOC:	FUNC	; signature func fRNDVOC(int CHAR, int FORCE) -> int
 		GOTO @return  	; goto return
 	.f6:	FORi $I <A> @.l5	; } /* end loop */
 	.e4:	MOVi %1 #5 	; fBUG(5)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 1086:9
 	return:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-initialise:	FUNC	; signature func initialise() -> void
+initialise:	FUNC	; signature func initialise() -> void @ 1100:21
 	$I:	LOCi
 	$K:	LOCi
 ;-----------------------------------------------------------------------------
@@ -1607,10 +1607,10 @@ initialise:	FUNC	; signature func initialise() -> void
 		LEQi %0 #0 @.f9
 		ADDi %1 $K #100	; fDROP(K+100,global FIXD[K])
 		PEEK %2 &FIXD $K
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1129:31
 		MOVi %1 $K 	; fDROP(K,global PLAC[K])
 		PEEK %2 &PLAC $K
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1130:27
 	.f9:	FORi $I <A> @.l8	; } /* end loop */
 	.e7:	MOVi $I #1 	; for (I=1 to 100+1) 
 		! ADDi <A> #100 #1
@@ -1624,7 +1624,7 @@ initialise:	FUNC	; signature func initialise() -> void
 		GRTi %0 #0 @.f13
 		MOVi %1 $K 	; fDROP(K,global PLAC[K])
 		PEEK %2 &PLAC $K
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1137:82
 	.f13:	FORi $I <A> @.l11	; } /* end loop */
 	.e10:	POKE &TALLY #0 	; global TALLY=0
 		MOVi $I #50 	; for (I=50 to MAXTRS+1) 
@@ -1677,7 +1677,7 @@ initialise:	FUNC	; signature func initialise() -> void
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-TOTING:	FUNC	; signature func TOTING(int OBJ) -> int
+TOTING:	FUNC	; signature func TOTING(int OBJ) -> int @ 1218:17
 	$OBJ:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $r #FALSE 	; r = FALSE
@@ -1689,7 +1689,7 @@ TOTING:	FUNC	; signature func TOTING(int OBJ) -> int
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-AT:	FUNC	; signature func AT(int OBJ, int LOC) -> int
+AT:	FUNC	; signature func AT(int OBJ, int LOC) -> int @ 1219:13
 	$OBJ:	INPi
 	$LOC:	INPi
 ;-----------------------------------------------------------------------------
@@ -1704,16 +1704,16 @@ AT:	FUNC	; signature func AT(int OBJ, int LOC) -> int
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-HERE:	FUNC	; signature func HERE(int OBJ, int LOC) -> int
+HERE:	FUNC	; signature func HERE(int OBJ, int LOC) -> int @ 1220:15
 	$OBJ:	INPi
 	$LOC:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $r #FALSE 	; r = FALSE
 		MOVi %1 $OBJ 	; if (((int)AT(OBJ, LOC) | (int)TOTING(OBJ)) != FALSE) r = TRUE
 		MOVi %2 $LOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1220:83
 		MOVi %2 $OBJ 
-		CALL &TOTING %1 *2	; expects TOTING(int) -> int
+		CALL &TOTING %1 *2	; expects TOTING(int) -> int @ 1220:101
 		IORi %0 %0 %1
 		EQUi %0 #FALSE @.f0
 		MOVi $r #TRUE 	; r = TRUE
@@ -1722,7 +1722,7 @@ HERE:	FUNC	; signature func HERE(int OBJ, int LOC) -> int
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-LIQ2:	FUNC	; signature func LIQ2(int PBOTL) -> int
+LIQ2:	FUNC	; signature func LIQ2(int PBOTL) -> int @ 1221:15
 	$PBOTL:	INPi
 ;-----------------------------------------------------------------------------
 		SUBi %0 #1 $PBOTL	; r = ((1-(PBOTL))*WATER+((PBOTL)/2)*(WATER+OIL))
@@ -1736,7 +1736,7 @@ LIQ2:	FUNC	; signature func LIQ2(int PBOTL) -> int
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-LIQ:	FUNC	; signature func LIQ() -> int
+LIQ:	FUNC	; signature func LIQ() -> int @ 1222:14
 ;-----------------------------------------------------------------------------
 		PEEK %0 &PROP:BOTTLE 	; if ((int)global PROP[BOTTLE]<0) r = -1-(int)global PROP[BOTTLE]
 		GEQi %0 #0 @.f0
@@ -1745,14 +1745,14 @@ LIQ:	FUNC	; signature func LIQ() -> int
 		GOTO @.e1  
 	.f0:	PEEK $r &PROP:BOTTLE 	; r = (int)global PROP[BOTTLE]
 	.e1:	MOVi %1 $r 	; r = (int)LIQ2(r)
-		CALL &LIQ2 %0 *2	; expects LIQ2(int) -> int
+		CALL &LIQ2 %0 *2	; expects LIQ2(int) -> int @ 1222:148
 		MOVi $r %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-LIQLOC:	FUNC	; signature func LIQLOC(int LOC) -> int
+LIQLOC:	FUNC	; signature func LIQLOC(int LOC) -> int @ 1223:17
 	$LOC:	INPi
 ;-----------------------------------------------------------------------------
 		PEEK %1 &COND $LOC	; r = (int)LIQ2(((((int)global COND[LOC]/2*2)%8)-5)*(((int)global COND[LOC]/4)%2)+1)
@@ -1765,14 +1765,14 @@ LIQLOC:	FUNC	; signature func LIQLOC(int LOC) -> int
 		MODi %2 %2 #2
 		MULi %1 %1 %2
 		ADDi %1 %1 #1
-		CALL &LIQ2 %0 *2	; expects LIQ2(int) -> int
+		CALL &LIQ2 %0 *2	; expects LIQ2(int) -> int @ 1223:124
 		MOVi $r %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-CNDBIT:	FUNC	; signature func CNDBIT(int L, int N) -> int
+CNDBIT:	FUNC	; signature func CNDBIT(int L, int N) -> int @ 1224:17
 	$L:	INPi
 	$N:	INPi
 ;-----------------------------------------------------------------------------
@@ -1787,19 +1787,19 @@ CNDBIT:	FUNC	; signature func CNDBIT(int L, int N) -> int
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-DARK:	FUNC	; signature func DARK(int LOC) -> int
+DARK:	FUNC	; signature func DARK(int LOC) -> int @ 1225:15
 	$LOC:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $r #FALSE 	; r = FALSE
 		MOVi %1 $LOC 	; if (((int)CNDBIT(LOC,0) == FALSE) && ((int)global PROP[LAMP] == 0 || (int)HERE(LAMP, LOC) == FALSE)) r = TRUE
 		MOVi %2 #0 
-		CALL &CNDBIT %0 *3	; expects CNDBIT(int, int) -> int
+		CALL &CNDBIT %0 *3	; expects CNDBIT(int, int) -> int @ 1225:75
 		NEQi %0 #FALSE @.f2
 		PEEK %0 &PROP:LAMP 
 		EQUi %0 #0 @.t1
 		MOVi %1 #LAMP 
 		MOVi %2 $LOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1225:141
 		NEQi %0 #FALSE @.f2
 	.t1:	MOVi $r #TRUE 	; r = TRUE
 	.f2:	RETU   	; }
@@ -1807,7 +1807,7 @@ DARK:	FUNC	; signature func DARK(int LOC) -> int
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-GSTONE:	FUNC	; signature func GSTONE(int OBJ) -> int
+GSTONE:	FUNC	; signature func GSTONE(int OBJ) -> int @ 1226:17
 	$OBJ:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $r #FALSE 	; r = FALSE
@@ -1821,7 +1821,7 @@ GSTONE:	FUNC	; signature func GSTONE(int OBJ) -> int
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-FOREST:	FUNC	; signature func FOREST(int LOC) -> int
+FOREST:	FUNC	; signature func FOREST(int LOC) -> int @ 1227:17
 	$LOC:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $r #FALSE 	; r = FALSE
@@ -1833,13 +1833,13 @@ FOREST:	FUNC	; signature func FOREST(int LOC) -> int
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-OUTSID:	FUNC	; signature func OUTSID(int LOC) -> int
+OUTSID:	FUNC	; signature func OUTSID(int LOC) -> int @ 1235:17
 	$LOC:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $r #FALSE 	; r = FALSE
 		LEQi $LOC #8 @.t0	; if ((LOC) <= 8 || (int)FOREST(LOC) != FALSE || (LOC) == (int)global PLAC[SAPPH] || (LOC) == 180 || (LOC) == 182) r = TRUE
 		MOVi %1 $LOC 
-		CALL &FOREST %0 *2	; expects FOREST(int) -> int
+		CALL &FOREST %0 *2	; expects FOREST(int) -> int @ 1235:88
 		NEQi %0 #FALSE @.t0
 		PEEK %0 &PLAC:SAPPH 
 		EQUi $LOC %0 @.t0
@@ -1851,13 +1851,13 @@ OUTSID:	FUNC	; signature func OUTSID(int LOC) -> int
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-INDEEP:	FUNC	; signature func INDEEP(int LOC) -> int
+INDEEP:	FUNC	; signature func INDEEP(int LOC) -> int @ 1236:17
 	$LOC:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $r #FALSE 	; r = FALSE
 		LSSi $LOC #15 @.f1	; if ((LOC) >= 15 && (int)OUTSID(LOC) == FALSE && (LOC) != 179) r = TRUE
 		MOVi %1 $LOC 
-		CALL &OUTSID %0 *2	; expects OUTSID(int) -> int
+		CALL &OUTSID %0 *2	; expects OUTSID(int) -> int @ 1236:89
 		NEQi %0 #FALSE @.f1
 		EQUi $LOC #179 @.f1
 		MOVi $r #TRUE 	; r = TRUE
@@ -1866,7 +1866,7 @@ INDEEP:	FUNC	; signature func INDEEP(int LOC) -> int
 
 ;-----------------------------------------------------------------------------
 	$goValue:	OUTi
-discard:	FUNC	; signature func discard(int just_do_it) -> int
+discard:	FUNC	; signature func discard(int just_do_it) -> int @ 1242:18
 	$just_do_it:	INPi
 	$lK:	LOCi
 	$lLOC:	LOCi
@@ -1876,16 +1876,16 @@ discard:	FUNC	; signature func discard(int just_do_it) -> int
 		PEEK $lOBJ &gOBJ 	; lOBJ = global gOBJ
 		NEQi $just_do_it #FALSE @.f0	; if(just_do_it == FALSE) 
 		MOVi %1 #ROD2 	; if((int)TOTING(ROD2) != FALSE && lOBJ == ROD && (int)TOTING(ROD) == FALSE) 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1249:24
 		EQUi %0 #FALSE @.f2
 		NEQi $lOBJ #ROD @.f2
 		MOVi %1 #ROD 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1249:68
 		NEQi %0 #FALSE @.f2
 		MOVi $lOBJ #ROD2 	; lOBJ=ROD2
 		POKE &gOBJ $lOBJ 	; global gOBJ = lOBJ
 	.f2:	MOVi %1 $lOBJ 	; if((int)TOTING(lOBJ) == FALSE) 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1250:24
 		NEQi %0 #FALSE @.f3
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
@@ -1893,34 +1893,34 @@ discard:	FUNC	; signature func discard(int just_do_it) -> int
 	.f3:	NEQi $lOBJ #BIRD @.f6	; if(!(lOBJ != BIRD || (int)HERE(SNAKE, lLOC) == FALSE)) 
 		MOVi %1 #SNAKE 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1251:52
 		EQUi %0 #FALSE @.f6
 		MOVi %1 #30 	; fRSPEAK(30)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1252:15
 		PEEK %0 &CLOSED 	; if(global CLOSED != FALSE) 
 		EQUi %0 #FALSE @.f7
 		MOVi $goValue #GOTO19000 	; goValue = GOTO19000
 		GOTO @return  	; goto return
 	.f7:	MOVi %1 #SNAKE 	; fDSTROY(SNAKE)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 1254:18
 		POKE &PROP:SNAKE #1 	; global PROP[SNAKE]=1
 		GOTO @.e8  	; } else if(!(!((int)GSTONE(lOBJ) != FALSE && (int)AT(CAVITY, lLOC) != FALSE && (int)global PROP[CAVITY] != 0))) 
 	.f6:	MOVi %1 $lOBJ 	; if(!(!((int)GSTONE(lOBJ) != FALSE && (int)AT(CAVITY, lLOC) != FALSE && (int)global PROP[CAVITY] != 0))) 
-		CALL &GSTONE %0 *2	; expects GSTONE(int) -> int
+		CALL &GSTONE %0 *2	; expects GSTONE(int) -> int @ 1257:35
 		EQUi %0 #FALSE @.f10
 		MOVi %1 #CAVITY 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1257:69
 		EQUi %0 #FALSE @.f10
 		PEEK %0 &PROP:CAVITY 
 		EQUi %0 #0 @.f10
 		MOVi %1 #218 	; fRSPEAK(218)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1258:16
 		POKE &PROP $lOBJ #1	; global PROP[lOBJ]=1
 		POKE &PROP:CAVITY #0 	; global PROP[CAVITY]=0
 		MOVi %1 #RUG 	; if(!((int)HERE(RUG, lLOC) == FALSE || !((lOBJ == EMRALD && (int)global PROP[RUG] != 2) || (lOBJ == RUBY && (int)global PROP[RUG] == 2)))) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1261:30
 		EQUi %0 #FALSE @.e20
 		NEQi $lOBJ #EMRALD @.f12
 		PEEK %0 &PROP:RUG 
@@ -1930,13 +1930,13 @@ discard:	FUNC	; signature func discard(int just_do_it) -> int
 		NEQi %0 #2 @.e20
 	.t13:	POKE &SPK #219 	; global SPK=219
 		MOVi %1 #RUG 	; if((int)TOTING(RUG) != FALSE)global SPK=220
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1263:25
 		EQUi %0 #FALSE @.f16
 		POKE &SPK #220 	; global SPK=220
 	.f16:	NEQi $lOBJ #RUBY @.f17	; if(lOBJ == RUBY)global SPK=221
 		POKE &SPK #221 	; global SPK=221
 	.f17:	PEEK %1 &SPK 	; fRSPEAK(global SPK)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1265:24
 		PEEK %0 &SPK 	; if(!(global SPK == 220)) 
 		EQUi %0 #220 @.e20
 		PEEK %0 &PROP:RUG 	; lK=2-(int)global PROP[RUG]
@@ -1946,35 +1946,35 @@ discard:	FUNC	; signature func discard(int just_do_it) -> int
 		PEEK $lK &PLAC:SAPPH 	; lK=(int)global PLAC[SAPPH]
 	.f19:	ADDi %1 #RUG #100	; fMOVE(RUG+100,lK)
 		MOVi %2 $lK 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1270:23
 		GOTO @.e20  	; } else if(!(lOBJ != COINS || (int)HERE(VEND, lLOC) == FALSE)) 
 	.f10:	NEQi $lOBJ #COINS @.f22	; if(!(lOBJ != COINS || (int)HERE(VEND, lLOC) == FALSE)) 
 		MOVi %1 #VEND 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1273:54
 		EQUi %0 #FALSE @.f22
 		MOVi %1 #COINS 	; fDSTROY(COINS)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 1274:18
 		MOVi %1 #BATTER 	; fDROP(BATTER,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1275:22
 		MOVi %1 #BATTER 	; fPSPEAK(BATTER,0)
 		MOVi %2 #0 
-		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void
+		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void @ 1276:21
 		MOVi $goValue #GOTO2012 	; goValue = GOTO2012
 		GOTO @return  	; goto return
 		GOTO @.e23  	; } else if(!(lOBJ != BIRD || (int)AT(DRAGON, lLOC) == FALSE || (int)global PROP[DRAGON] != 0)) 
 	.f22:	NEQi $lOBJ #BIRD @.f25	; if(!(lOBJ != BIRD || (int)AT(DRAGON, lLOC) == FALSE || (int)global PROP[DRAGON] != 0)) 
 		MOVi %1 #DRAGON 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1278:53
 		EQUi %0 #FALSE @.f25
 		PEEK %0 &PROP:DRAGON 
 		NEQi %0 #0 @.f25
 		MOVi %1 #154 	; fRSPEAK(154)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1279:16
 		MOVi %1 #BIRD 	; fDSTROY(BIRD)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 1280:17
 		POKE &PROP:BIRD #0 	; global PROP[BIRD]=0
 		MOVi $goValue #GOTO2012 	; goValue = GOTO2012
 		GOTO @return  	; goto return
@@ -1982,42 +1982,42 @@ discard:	FUNC	; signature func discard(int just_do_it) -> int
 	.f25:	NEQi $lOBJ #BEAR @.f28	; if(!(lOBJ != BEAR || (int)AT(TROLL, lLOC) == FALSE)) 
 		MOVi %1 #TROLL 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1283:52
 		EQUi %0 #FALSE @.f28
 		MOVi %1 #163 	; fRSPEAK(163)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1284:16
 		MOVi %1 #TROLL 	; fMOVE(TROLL,0)
 		MOVi %2 #0 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1285:18
 		ADDi %1 #TROLL #100	; fMOVE(TROLL+100,0)
 		MOVi %2 #0 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1286:22
 		MOVi %1 #TROLL2 	; fMOVE(TROLL2,global PLAC[TROLL])
 		PEEK %2 &PLAC:TROLL 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1287:36
 		ADDi %1 #TROLL2 #100	; fMOVE(TROLL2+100,global FIXD[TROLL])
 		PEEK %2 &FIXD:TROLL 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1288:40
 		MOVi %1 #CHASM 	; fJUGGLE(CHASM)
-		CALL &fJUGGLE %0 *2	; expects fJUGGLE(int) -> void
+		CALL &fJUGGLE %0 *2	; expects fJUGGLE(int) -> void @ 1289:18
 		POKE &PROP:TROLL #2 	; global PROP[TROLL]=2
 		GOTO @.e29  	; } else if(!(lOBJ == VASE && lLOC != (int)global PLAC[PILLOW])) 
 	.f28:	NEQi $lOBJ #VASE @.f30	; if(!(lOBJ == VASE && lLOC != (int)global PLAC[PILLOW])) 
 		PEEK %0 &PLAC:PILLOW 
 		NEQi $lLOC %0 @.f31
 	.f30:	MOVi %1 #54 	; fRSPEAK(54)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1292:15
 		GOTO @.e32  	; } else 
 	.f31:	POKE &PROP:VASE #2 	; global PROP[VASE]=2
 		MOVi %1 #PILLOW 	; if((int)AT(PILLOW, lLOC) != FALSE)global PROP[VASE]=0
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1295:29
 		EQUi %0 #FALSE @.f33
 		POKE &PROP:VASE #0 	; global PROP[VASE]=0
 	.f33:	MOVi %1 #VASE 	; fPSPEAK(VASE,(int)global PROP[VASE]+1)
 		PEEK %2 &PROP:VASE 
 		ADDi %2 %2 #1
-		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void
+		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void @ 1296:42
 		PEEK %0 &PROP:VASE 	; if((int)global PROP[VASE] != 0)global FIXED[VASE]= -1
 		EQUi %0 #0 @.f0
 		POKE &FIXED:VASE #-1 	; global FIXED[VASE]= -1
@@ -2028,7 +2028,7 @@ discard:	FUNC	; signature func discard(int just_do_it) -> int
 	.e20:	NOOP
 	.e8:	NOOP
 	.e4:	NOOP
-	.f0:	CALL &LIQ %0 *1	; expects LIQ() -> int
+	.f0:	CALL &LIQ %0 *1	; expects LIQ() -> int @ 1301:15
 		MOVi $lK %0 
 		POKE &gK $lK 	; global gK = lK
 		NEQi $lK $lOBJ @.f35	; if(lK == lOBJ) 
@@ -2042,16 +2042,16 @@ discard:	FUNC	; signature func discard(int just_do_it) -> int
 		NEQi %0 #1 @.f39
 		MOVi %1 #BIRD 	; fDROP(BIRD,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1304:65
 	.f39:	MOVi %1 $lOBJ 	; fDROP(lOBJ,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1305:18
 		EQUi $lOBJ #BIRD @.f40	; if(lOBJ != BIRD) 
 		MOVi $goValue #GOTO2012 	; goValue = GOTO2012
 		GOTO @return  	; goto return
 	.f40:	POKE &PROP:BIRD #0 	; global PROP[BIRD]=0
 		MOVi %1 $lLOC 	; if((int)FOREST(lLOC) != FALSE)global PROP[BIRD]=2
-		CALL &FOREST %0 *2	; expects FOREST(int) -> int
+		CALL &FOREST %0 *2	; expects FOREST(int) -> int @ 1308:23
 		EQUi %0 #FALSE @.f41
 		POKE &PROP:BIRD #2 	; global PROP[BIRD]=2
 	.f41:	MOVi $goValue #GOTO2012 	; goValue = GOTO2012
@@ -2061,7 +2061,7 @@ discard:	FUNC	; signature func discard(int just_do_it) -> int
 
 ;-----------------------------------------------------------------------------
 	$goValue:	OUTi
-fill:	FUNC	; signature func fill(int OBJ) -> int
+fill:	FUNC	; signature func fill(int OBJ) -> int @ 1315:15
 	$OBJ:	INPi
 	$lK:	LOCi
 	$lLOC:	LOCi
@@ -2075,13 +2075,13 @@ fill:	FUNC	; signature func fill(int OBJ) -> int
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f2:	POKE &SPK #144 	; global SPK=144
-		CALL &LIQ %0 *1	; expects LIQ() -> int
+		CALL &LIQ %0 *1	; expects LIQ() -> int @ 1325:17
 		MOVi $lK %0 
 		POKE &gK $lK 	; global gK = lK
 		EQUi $lK #0 @.t3	; if(lK == 0 || (int)HERE(BOTTLE, lLOC) == FALSE) 
 		MOVi %1 #BOTTLE 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1326:42
 		NEQi %0 #FALSE @.f4
 	.t3:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
@@ -2101,23 +2101,23 @@ fill:	FUNC	; signature func fill(int OBJ) -> int
 	.f7:	NEQi $OBJ #0 @.f9	; if(OBJ == 0 && (int)HERE(BOTTLE, lLOC) == FALSE) 
 		MOVi %1 #BOTTLE 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1334:42
 		NEQi %0 #FALSE @.f9
 		MOVi $goValue #GOTO8000 	; goValue = GOTO8000
 		GOTO @return  	; goto return
 	.f9:	POKE &SPK #107 	; global SPK=107
 		MOVi %1 $lLOC 	; if((int)LIQLOC(lLOC) == 0)global SPK=106
-		CALL &LIQLOC %0 *2	; expects LIQLOC(int) -> int
+		CALL &LIQLOC %0 *2	; expects LIQLOC(int) -> int @ 1336:24
 		NEQi %0 #0 @.f10
 		POKE &SPK #106 	; global SPK=106
 	.f10:	MOVi %1 #URN 	; if((int)HERE(URN, lLOC) != FALSE && (int)global PROP[URN] != 0)global SPK=214
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1337:27
 		EQUi %0 #FALSE @.f12
 		PEEK %0 &PROP:URN 
 		EQUi %0 #0 @.f12
 		POKE &SPK #214 	; global SPK=214
-	.f12:	CALL &LIQ %0 *1	; expects LIQ() -> int
+	.f12:	CALL &LIQ %0 *1	; expects LIQ() -> int @ 1338:17
 		EQUi %0 #0 @.f13
 		POKE &SPK #105 	; global SPK=105
 	.f13:	PEEK %0 &SPK 	; if(global SPK != 107) 
@@ -2129,11 +2129,11 @@ fill:	FUNC	; signature func fill(int OBJ) -> int
 		DIVi %0 %0 #2
 		MULi %0 %0 #2
 		POKE &PROP:BOTTLE %0 
-		CALL &LIQ %0 *1	; expects LIQ() -> int
+		CALL &LIQ %0 *1	; expects LIQ() -> int @ 1341:16
 		MOVi $lK %0 
 		POKE &gK $lK 	; global gK = lK
 		MOVi %1 #BOTTLE 	; if((int)TOTING(BOTTLE) != FALSE)global PLACE[lK]= -1
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1342:26
 		EQUi %0 #FALSE @.f15
 		POKE &PLACE $lK #-1	; global PLACE[lK]= -1
 	.f15:	NEQi $lK #OIL @.f16	; if(lK == OIL)global SPK=108
@@ -2143,23 +2143,23 @@ fill:	FUNC	; signature func fill(int OBJ) -> int
 		GOTO @.e17  	; } else 
 	.f0:	POKE &SPK #29 	; global SPK=29
 		MOVi %1 $lLOC 	; if((int)LIQLOC(lLOC) == 0)global SPK=144
-		CALL &LIQLOC %0 *2	; expects LIQLOC(int) -> int
+		CALL &LIQLOC %0 *2	; expects LIQLOC(int) -> int @ 1347:24
 		NEQi %0 #0 @.f18
 		POKE &SPK #144 	; global SPK=144
 	.f18:	MOVi %1 $lLOC 	; if((int)LIQLOC(lLOC) == 0 || (int)TOTING(VASE) == FALSE) 
-		CALL &LIQLOC %0 *2	; expects LIQLOC(int) -> int
+		CALL &LIQLOC %0 *2	; expects LIQLOC(int) -> int @ 1348:24
 		EQUi %0 #0 @.t19
 		MOVi %1 #VASE 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1348:50
 		NEQi %0 #FALSE @.f20
 	.t19:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f20:	MOVi %1 #145 	; fRSPEAK(145)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1349:15
 		POKE &PROP:VASE #2 	; global PROP[VASE]=2
 		POKE &FIXED:VASE #-1 	; global FIXED[VASE]= -1
 		MOVi %1 #TRUE 	; goValue = (int)discard(TRUE)
-		CALL &discard %0 *2	; expects discard(int) -> int
+		CALL &discard %0 *2	; expects discard(int) -> int @ 1352:33
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 	.e17:	NOOP
@@ -2168,7 +2168,7 @@ fill:	FUNC	; signature func fill(int OBJ) -> int
 
 ;-----------------------------------------------------------------------------
 	$goValue:	OUTi
-carry:	FUNC	; signature func carry() -> int
+carry:	FUNC	; signature func carry() -> int @ 1361:16
 	$lK:	LOCi
 	$lLOC:	LOCi
 	$lOBJ:	LOCi
@@ -2177,7 +2177,7 @@ carry:	FUNC	; signature func carry() -> int
 		PEEK $lOBJ &gOBJ 	; lOBJ = global gOBJ
 		PEEK $lLOC &gLOC 	; lLOC = global gLOC
 		MOVi %1 $lOBJ 	; if((int)TOTING(lOBJ) != FALSE) 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1368:23
 		EQUi %0 #FALSE @.f0
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
@@ -2209,7 +2209,7 @@ carry:	FUNC	; signature func carry() -> int
 	.f12:	NEQi $lOBJ #MESSAG @.f13	; if(lOBJ == MESSAG) 
 		POKE &SPK #190 	; global SPK=190
 		MOVi %1 #MESSAG 	; fDSTROY(MESSAG)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 1380:18
 	.f13:	PEEK %0 &FIXED $lOBJ	; if((int)global FIXED[lOBJ] != 0) 
 		EQUi %0 #0 @.f14
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
@@ -2222,24 +2222,24 @@ carry:	FUNC	; signature func carry() -> int
 		POKE &gOBJ #BOTTLE 	; global gOBJ = BOTTLE
 		MOVi %1 #BOTTLE 	; if(!((int)HERE(BOTTLE, lLOC) != FALSE && (int)LIQ() == lK)) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1386:32
 		EQUi %0 #FALSE @.f17
-		CALL &LIQ %0 *1	; expects LIQ() -> int
+		CALL &LIQ %0 *1	; expects LIQ() -> int @ 1386:55
 		EQUi %0 $lK @.f16
 	.f17:	MOVi %1 #BOTTLE 	; if((int)TOTING(BOTTLE) != FALSE && (int)global PROP[BOTTLE] == 1) 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1387:27
 		EQUi %0 #FALSE @.f20
 		PEEK %0 &PROP:BOTTLE 
 		NEQi %0 #1 @.f20
 		MOVi %1 $lOBJ 	; goValue = (int)fill(lOBJ)
-		CALL &fill %0 *2	; expects fill(int) -> int
+		CALL &fill %0 *2	; expects fill(int) -> int @ 1387:97
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 	.f20:	PEEK %0 &PROP:BOTTLE 	; if((int)global PROP[BOTTLE] != 1)global SPK=105
 		EQUi %0 #1 @.f21
 		POKE &SPK #105 	; global SPK=105
 	.f21:	MOVi %1 #BOTTLE 	; if((int)TOTING(BOTTLE) == FALSE)global SPK=104
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1389:27
 		NEQi %0 #FALSE @.f22
 		POKE &SPK #104 	; global SPK=104
 	.f22:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
@@ -2259,15 +2259,15 @@ carry:	FUNC	; signature func carry() -> int
 		NEQi %0 #2 @.f26
 		POKE &SPK #238 	; global SPK=238
 		MOVi %1 #BIRD 	; fDSTROY(BIRD)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 1398:17
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f26:	MOVi %1 #CAGE 	; if((int)TOTING(CAGE) == FALSE)global SPK=27
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1401:24
 		NEQi %0 #FALSE @.f27
 		POKE &SPK #27 	; global SPK=27
 	.f27:	MOVi %1 #ROD 	; if((int)TOTING(ROD) != FALSE)global SPK=26
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1402:23
 		EQUi %0 #FALSE @.f28
 		POKE &SPK #26 	; global SPK=26
 	.f28:	PEEK %0 &SPK 	; if(global SPK/2 == 13) 
@@ -2287,18 +2287,18 @@ carry:	FUNC	; signature func carry() -> int
 		! ADDi <A> #BIRD #CAGE	; fCARRY(BIRD+CAGE-lOBJ,lLOC)
 		SUBi %1 <A> $lOBJ
 		MOVi %2 $lLOC 
-		CALL &fCARRY %0 *3	; expects fCARRY(int, int) -> void
+		CALL &fCARRY %0 *3	; expects fCARRY(int, int) -> void @ 1406:130
 	.f33:	MOVi %1 $lOBJ 	; fCARRY(lOBJ,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fCARRY %0 *3	; expects fCARRY(int, int) -> void
-		CALL &LIQ %0 *1	; expects LIQ() -> int
+		CALL &fCARRY %0 *3	; expects fCARRY(int, int) -> void @ 1407:19
+		CALL &LIQ %0 *1	; expects LIQ() -> int @ 1408:15
 		MOVi $lK %0 
 		POKE &gK $lK 	; global gK = lK
 		NEQi $lOBJ #BOTTLE @.f35	; if(lOBJ == BOTTLE && lK != 0)global PLACE[lK]= -1
 		EQUi $lK #0 @.f35
 		POKE &PLACE $lK #-1	; global PLACE[lK]= -1
 	.f35:	MOVi %1 $lOBJ 	; if((int)GSTONE(lOBJ) == FALSE || (int)global PROP[lOBJ] == 0) 
-		CALL &GSTONE %0 *2	; expects GSTONE(int) -> int
+		CALL &GSTONE %0 *2	; expects GSTONE(int) -> int @ 1410:23
 		EQUi %0 #FALSE @.t36
 		PEEK %0 &PROP $lOBJ
 		NEQi %0 #0 @.f37
@@ -2313,7 +2313,7 @@ carry:	FUNC	; signature func carry() -> int
 
 ;-----------------------------------------------------------------------------
 	$goValue:	OUTi
-attack:	FUNC	; signature func attack() -> int
+attack:	FUNC	; signature func attack() -> int @ 1421:17
 	$I:	LOCi
 	$lK:	LOCi
 	$lLOC:	LOCi
@@ -2322,7 +2322,7 @@ attack:	FUNC	; signature func attack() -> int
 		PEEK $lLOC &gLOC 	; lLOC = global gLOC
 		PEEK $lOBJ &gOBJ 	; lOBJ = global gOBJ
 		MOVi %1 $lLOC 	; I=(int)fATDWRF(lLOC)
-		CALL &fATDWRF %0 *2	; expects fATDWRF(int) -> int
+		CALL &fATDWRF %0 *2	; expects fATDWRF(int) -> int @ 1427:22
 		MOVi $I %0 
 		NEQi $lOBJ #0 @.f0	; if(lOBJ == 0) 
 		LEQi $I #0 @.f1	; if(I > 0) 
@@ -2330,14 +2330,14 @@ attack:	FUNC	; signature func attack() -> int
 		POKE &gOBJ #DWARF 	; global gOBJ = DWARF
 	.f1:	MOVi %1 #SNAKE 	; if((int)HERE(SNAKE, lLOC) != FALSE) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1430:29
 		EQUi %0 #FALSE @.f2
 		MULi %0 $lOBJ #100	; lOBJ=lOBJ*100+SNAKE
 		ADDi $lOBJ %0 #SNAKE
 		POKE &gOBJ $lOBJ 	; global gOBJ = lOBJ
 	.f2:	MOVi %1 #DRAGON 	; if((int)AT(DRAGON, lLOC) != FALSE && (int)global PROP[DRAGON] == 0) 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1431:28
 		EQUi %0 #FALSE @.f4
 		PEEK %0 &PROP:DRAGON 
 		NEQi %0 #0 @.f4
@@ -2346,21 +2346,21 @@ attack:	FUNC	; signature func attack() -> int
 		POKE &gOBJ $lOBJ 	; global gOBJ = lOBJ
 	.f4:	MOVi %1 #TROLL 	; if((int)AT(TROLL, lLOC) != FALSE) 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1432:27
 		EQUi %0 #FALSE @.f5
 		MULi %0 $lOBJ #100	; lOBJ=lOBJ*100+TROLL
 		ADDi $lOBJ %0 #TROLL
 		POKE &gOBJ $lOBJ 	; global gOBJ = lOBJ
 	.f5:	MOVi %1 #OGRE 	; if((int)AT(OGRE, lLOC) != FALSE) 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1433:26
 		EQUi %0 #FALSE @.f6
 		MULi %0 $lOBJ #100	; lOBJ=lOBJ*100+OGRE
 		ADDi $lOBJ %0 #OGRE
 		POKE &gOBJ $lOBJ 	; global gOBJ = lOBJ
 	.f6:	MOVi %1 #BEAR 	; if((int)HERE(BEAR, lLOC) != FALSE && (int)global PROP[BEAR] == 0) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1434:28
 		EQUi %0 #FALSE @.f8
 		PEEK %0 &PROP:BEAR 
 		NEQi %0 #0 @.f8
@@ -2373,7 +2373,7 @@ attack:	FUNC	; signature func attack() -> int
 	.f9:	NEQi $lOBJ #0 @.f0	; if(lOBJ == 0) 
 		MOVi %1 #BIRD 	; if((int)HERE(BIRD, lLOC) != FALSE && global VERB != THROW) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1438:29
 		EQUi %0 #FALSE @.f12
 		PEEK %0 &VERB 
 		EQUi %0 #THROW @.f12
@@ -2381,7 +2381,7 @@ attack:	FUNC	; signature func attack() -> int
 		POKE &gOBJ $lOBJ 	; global gOBJ = lOBJ
 	.f12:	MOVi %1 #VEND 	; if((int)HERE(VEND, lLOC) != FALSE && global VERB != THROW) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1439:29
 		EQUi %0 #FALSE @.f14
 		PEEK %0 &VERB 
 		EQUi %0 #THROW @.f14
@@ -2390,11 +2390,11 @@ attack:	FUNC	; signature func attack() -> int
 		POKE &gOBJ $lOBJ 	; global gOBJ = lOBJ
 	.f14:	MOVi %1 #CLAM 	; if((int)HERE(CLAM, lLOC) != FALSE || (int)HERE(OYSTER, lLOC) != FALSE) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1441:29
 		NEQi %0 #FALSE @.t15
 		MOVi %1 #OYSTER 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1441:65
 		EQUi %0 #FALSE @.f16
 	.t15:	MULi %0 #100 $lOBJ	; lOBJ=100*lOBJ+CLAM
 		ADDi $lOBJ %0 #CLAM
@@ -2409,14 +2409,14 @@ attack:	FUNC	; signature func attack() -> int
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f19:	MOVi %1 #BIRD 	; fDSTROY(BIRD)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 1448:16
 		POKE &PROP:BIRD #0 	; global PROP[BIRD]=0
 		POKE &SPK #45 	; global SPK=45
 	.f18:	NEQi $lOBJ #VEND @.f20	; if(lOBJ == VEND) 
 		MOVi %1 #VEND 	; fPSPEAK(VEND,(int)global PROP[VEND]+2)
 		PEEK %2 &PROP:VEND 
 		ADDi %2 %2 #2
-		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void
+		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void @ 1453:41
 		PEEK %0 &PROP:VEND 	; global PROP[VEND]=3-(int)global PROP[VEND]
 		SUBi %0 #3 %0
 		POKE &PROP:VEND %0 
@@ -2456,7 +2456,7 @@ attack:	FUNC	; signature func attack() -> int
 	.t34:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f35:	MOVi %1 #49 	; fRSPEAK(49)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1471:14
 		POKE &VERB #0 	; global VERB=0
 		MOVi $lOBJ #0 	; lOBJ=0
 		POKE &gOBJ #0 	; global gOBJ=0
@@ -2464,20 +2464,20 @@ attack:	FUNC	; signature func attack() -> int
 		MOVp %2 &WD1X 
 		MOVp %3 &WD2 
 		MOVp %4 &WD2X 
-		CALL &fGETIN %0 *5	; expects fGETIN(ptr, ptr, ptr, ptr) -> void
+		CALL &fGETIN %0 *5	; expects fGETIN(ptr, ptr, ptr, ptr) -> void @ 1474:60
 		MOVi %1 #25 	; if(global WD1 != (int)fMAKEWD(25) && global WD1 != (int)fMAKEWD(250519)) 
-		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int
+		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int @ 1475:37
 		PEEK %1 &WD1 
 		EQUi %1 %0 @.f37
 		MOVi %1 #250519 
-		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int
+		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int @ 1475:74
 		PEEK %1 &WD1 
 		EQUi %1 %0 @.f37
 		MOVi $goValue #GOTO2607 	; goValue = GOTO2607
 		GOTO @return  	; goto return
 	.f37:	MOVi %1 #DRAGON 	; fPSPEAK(DRAGON,3)
 		MOVi %2 #3 
-		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void
+		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void @ 1476:20
 		POKE &PROP:DRAGON #1 	; global PROP[DRAGON]=1
 		POKE &PROP:RUG #0 	; global PROP[RUG]=0
 		PEEK %0 &PLAC:DRAGON 	; lK=((int)global PLAC[DRAGON]+(int)global FIXD[DRAGON])/2
@@ -2486,19 +2486,19 @@ attack:	FUNC	; signature func attack() -> int
 		DIVi $lK %0 #2
 		ADDi %1 #DRAGON #100	; fMOVE(DRAGON+100,-1)
 		MOVi %2 #-1 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1480:23
 		ADDi %1 #RUG #100	; fMOVE(RUG+100,0)
 		MOVi %2 #0 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1481:19
 		MOVi %1 #DRAGON 	; fMOVE(DRAGON,lK)
 		MOVi %2 $lK 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1482:19
 		MOVi %1 #RUG 	; fMOVE(RUG,lK)
 		MOVi %2 $lK 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1483:16
 		MOVi %1 #BLOOD 	; fDROP(BLOOD,lK)
 		MOVi %2 $lK 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1484:18
 		MOVi $lOBJ #1 	; for (lOBJ=1 to 100+1) 
 		! ADDi <A> #100 #1
 		GEQi #1 <A> @.e38
@@ -2510,7 +2510,7 @@ attack:	FUNC	; signature func attack() -> int
 		NEQi %0 %1 @.f41
 	.t40:	MOVi %1 $lOBJ 	; fMOVE(lOBJ,lK)
 		MOVi %2 $lK 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1486:128
 	.f41:	FORi $lOBJ <A> @.l39	; }
 	.e38:	POKE &gOBJ $lOBJ 	; global gOBJ = lOBJ
 		POKE &gLOC $lK 	; global gLOC=lK
@@ -2518,11 +2518,11 @@ attack:	FUNC	; signature func attack() -> int
 		MOVi $goValue #GOTO8 	; goValue = GOTO8
 		GOTO @return  	; goto return
 	.f32:	PEEK %1 &SPK 	; fRSPEAK(global SPK)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1494:21
 		MOVi %1 #6 	; fRSPEAK(6)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1495:12
 		MOVi %1 #OGRE 	; fDSTROY(OGRE)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 1496:15
 		MOVi $lK #0 	; lK=0
 		MOVi $I #1 	; for (I=1 to 5+1) 
 		! ADDi <A> #5 #1
@@ -2547,7 +2547,7 @@ attack:	FUNC	; signature func attack() -> int
 
 ;-----------------------------------------------------------------------------
 	$goValue:	OUTi
-feed:	FUNC	; signature func feed(int OBJ) -> int
+feed:	FUNC	; signature func feed(int OBJ) -> int @ 1515:15
 	$OBJ:	INPi
 	$lLOC:	LOCi
 ;-----------------------------------------------------------------------------
@@ -2571,20 +2571,20 @@ feed:	FUNC	; signature func feed(int OBJ) -> int
 		NEQi %0 #FALSE @.t6
 		MOVi %1 #BIRD 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1529:70
 		NEQi %0 #FALSE @.f7
 	.t6:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f7:	POKE &SPK #101 	; global SPK=101
 		MOVi %1 #BIRD 	; fDSTROY(BIRD)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 1531:16
 		POKE &PROP:BIRD #0 	; global PROP[BIRD]=0
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f2:	NEQi $OBJ #DWARF @.f8	; if(OBJ == DWARF) 
 		MOVi %1 #FOOD 	; if((int)HERE(FOOD, lLOC) == FALSE) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1537:28
 		NEQi %0 #FALSE @.f9
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
@@ -2603,12 +2603,12 @@ feed:	FUNC	; signature func feed(int OBJ) -> int
 		POKE &SPK #110 	; global SPK=110
 	.f12:	MOVi %1 #FOOD 	; if((int)HERE(FOOD, lLOC) == FALSE) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1546:28
 		NEQi %0 #FALSE @.f13
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f13:	MOVi %1 #FOOD 	; fDSTROY(FOOD)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 1547:16
 		POKE &PROP:BEAR #1 	; global PROP[BEAR]=1
 		POKE &FIXED:AXE #0 	; global FIXED[AXE]=0
 		POKE &PROP:AXE #0 	; global PROP[AXE]=0
@@ -2618,7 +2618,7 @@ feed:	FUNC	; signature func feed(int OBJ) -> int
 	.f10:	NEQi $OBJ #OGRE @.f14	; if(OBJ == OGRE) 
 		MOVi %1 #FOOD 	; if((int)HERE(FOOD, lLOC) != FALSE)global SPK=202
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1556:28
 		EQUi %0 #FALSE @.f15
 		POKE &SPK #202 	; global SPK=202
 	.f15:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
@@ -2631,7 +2631,7 @@ feed:	FUNC	; signature func feed(int OBJ) -> int
 
 ;-----------------------------------------------------------------------------
 	$goValue:	OUTi
-doThrow:	FUNC	; signature func doThrow() -> int
+doThrow:	FUNC	; signature func doThrow() -> int @ 1570:18
 	$I:	LOCi
 	$lLOC:	LOCi
 	$lOBJ:	LOCi
@@ -2639,16 +2639,16 @@ doThrow:	FUNC	; signature func doThrow() -> int
 		PEEK $lLOC &gLOC 	; lLOC = global gLOC
 		PEEK $lOBJ &gOBJ 	; lOBJ = global gOBJ
 		MOVi %1 #ROD2 	; if((int)TOTING(ROD2) != FALSE && lOBJ == ROD && (int)TOTING(ROD) == FALSE) 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1576:23
 		EQUi %0 #FALSE @.f1
 		NEQi $lOBJ #ROD @.f1
 		MOVi %1 #ROD 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1576:67
 		NEQi %0 #FALSE @.f1
 		MOVi $lOBJ #ROD2 	; lOBJ=ROD2
 		POKE &gOBJ #ROD2 	; global gOBJ = ROD2
 	.f1:	MOVi %1 $lOBJ 	; if((int)TOTING(lOBJ) == FALSE) 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1577:23
 		NEQi %0 #FALSE @.f2
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
@@ -2656,52 +2656,52 @@ doThrow:	FUNC	; signature func doThrow() -> int
 		GRTi $lOBJ #MAXTRS @.f4
 		MOVi %1 #TROLL 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1578:58
 		EQUi %0 #FALSE @.f4
 		POKE &SPK #159 	; global SPK=159
 		MOVi %1 $lOBJ 	; fDROP(lOBJ,0)
 		MOVi %2 #0 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1581:16
 		MOVi %1 #TROLL 	; fMOVE(TROLL,0)
 		MOVi %2 #0 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1582:17
 		ADDi %1 #TROLL #100	; fMOVE(TROLL+100,0)
 		MOVi %2 #0 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1583:21
 		MOVi %1 #TROLL2 	; fDROP(TROLL2,global PLAC[TROLL])
 		PEEK %2 &PLAC:TROLL 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1584:35
 		ADDi %1 #TROLL2 #100	; fDROP(TROLL2+100,(int)global FIXD[TROLL])
 		PEEK %2 &FIXD:TROLL 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1585:44
 		MOVi %1 #CHASM 	; fJUGGLE(CHASM)
-		CALL &fJUGGLE %0 *2	; expects fJUGGLE(int) -> void
+		CALL &fJUGGLE %0 *2	; expects fJUGGLE(int) -> void @ 1586:17
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f4:	NEQi $lOBJ #FOOD @.f6	; if(lOBJ == FOOD && (int)HERE(BEAR, lLOC) != FALSE) 
 		MOVi %1 #BEAR 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1589:43
 		EQUi %0 #FALSE @.f6
 		MOVi $lOBJ #BEAR 	; lOBJ=BEAR
 		POKE &gOBJ #BEAR 	; global gOBJ = BEAR
 		MOVi %1 $lOBJ 	; goValue = (int)feed(lOBJ)
-		CALL &feed %0 *2	; expects feed(int) -> int
+		CALL &feed %0 *2	; expects feed(int) -> int @ 1592:30
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 	.f6:	EQUi $lOBJ #AXE @.f7	; if(lOBJ != AXE) 
 		MOVi %1 #FALSE 	; goValue = (int)discard(FALSE)
-		CALL &discard %0 *2	; expects discard(int) -> int
+		CALL &discard %0 *2	; expects discard(int) -> int @ 1594:49
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 	.f7:	MOVi %1 $lLOC 	; I=(int)fATDWRF(lLOC)
-		CALL &fATDWRF %0 *2	; expects fATDWRF(int) -> int
+		CALL &fATDWRF %0 *2	; expects fATDWRF(int) -> int @ 1595:22
 		MOVi $I %0 
 		GRTi $I #0 @.f8	; if(I <= 0) 
 		POKE &SPK #152 	; global SPK=152
 		MOVi %1 #DRAGON 	; if((int)AT(DRAGON, lLOC) != FALSE && (int)global PROP[DRAGON] == 0) goto L9175
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1598:28
 		EQUi %0 #FALSE @.f10
 		PEEK %0 &PROP:DRAGON 
 		NEQi %0 #0 @.f10
@@ -2709,39 +2709,39 @@ doThrow:	FUNC	; signature func doThrow() -> int
 	.f10:	POKE &SPK #158 	; global SPK=158
 		MOVi %1 #TROLL 	; if((int)AT(TROLL, lLOC) != FALSE) goto L9175
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1600:27
 		EQUi %0 #FALSE @.f11
 		GOTO @L9175  	; goto L9175
 	.f11:	POKE &SPK #203 	; global SPK=203
 		MOVi %1 #OGRE 	; if((int)AT(OGRE, lLOC) != FALSE) goto L9175
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1602:26
 		EQUi %0 #FALSE @.f12
 		GOTO @L9175  	; goto L9175
 	.f12:	MOVi %1 #BEAR 	; if((int)HERE(BEAR, lLOC) != FALSE && (int)global PROP[BEAR] == 0) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1603:28
 		EQUi %0 #FALSE @.f14
 		PEEK %0 &PROP:BEAR 
 		NEQi %0 #0 @.f14
 		POKE &SPK #164 	; global SPK=164
 		MOVi %1 #AXE 	; fDROP(AXE,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1606:19
 		POKE &FIXED:AXE #-1 	; global FIXED[AXE]= -1
 		POKE &PROP:AXE #1 	; global PROP[AXE]=1
 		MOVi %1 #BEAR 	; fJUGGLE(BEAR)
-		CALL &fJUGGLE %0 *2	; expects fJUGGLE(int) -> void
+		CALL &fJUGGLE %0 *2	; expects fJUGGLE(int) -> void @ 1609:17
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f14:	MOVi $lOBJ #0 	; lOBJ=0
 		POKE &gOBJ #0 	; global gOBJ = 0
-		CALL &attack %0 *1	; expects attack() -> int
+		CALL &attack %0 *1	; expects attack() -> int @ 1613:28
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 	.f8:	POKE &SPK #48 	; global SPK=48
 		MOVi %1 #7 	; if((int)fRAN(7) >= global DFLAG) 
-		CALL &fRAN %0 *2	; expects fRAN(int) -> int
+		CALL &fRAN %0 *2	; expects fRAN(int) -> int @ 1616:18
 		PEEK %1 &DFLAG 
 		LSSi %0 %1 @.f15
 		POKE &DSEEN $I #FALSE	; global DSEEN[I]=FALSE
@@ -2755,10 +2755,10 @@ doThrow:	FUNC	; signature func doThrow() -> int
 		POKE &SPK #149 	; global SPK=149
 	.f15:	NOOP
 	L9175:	PEEK %1 &SPK 	; L9175:
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1624:21
 		MOVi %1 #AXE 	; fDROP(AXE,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1625:17
 		POKE &gK #NUL 	; global gK = NUL
 		MOVi $goValue #GOTO8 	; goValue = GOTO8
 		GOTO @return  	; goto return
@@ -2767,7 +2767,7 @@ doThrow:	FUNC	; signature func doThrow() -> int
 
 ;-----------------------------------------------------------------------------
 	$goValue:	OUTi
-action:	FUNC	; signature func action(int STARTAT) -> int
+action:	FUNC	; signature func action(int STARTAT) -> int @ 1641:17
 	$STARTAT:	INPi
 	$I:	LOCi
 	$lK:	LOCi
@@ -2803,13 +2803,13 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		PEEK %0 &LINK %0
 		NEQi %0 #0 @.t8
 		MOVi %1 $lLOC 
-		CALL &fATDWRF %0 *2	; expects fATDWRF(int) -> int
+		CALL &fATDWRF %0 *2	; expects fATDWRF(int) -> int @ 1667:110
 		LEQi %0 #0 @.f9
 	.t8:	MOVi $goValue #GOTO8000 	; goValue = GOTO8000
 		GOTO @return  	; goto return
 	.f9:	PEEK $lOBJ &ATLOC $lLOC	; lOBJ=(int)global ATLOC[lLOC]
 		POKE &gOBJ $lOBJ 	; global gOBJ = lOBJ
-		CALL &carry %0 *1	; expects carry() -> int
+		CALL &carry %0 *1	; expects carry() -> int @ 1672:30
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 		GOTO @.e7  	; }
@@ -2829,38 +2829,38 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.s6#5:	POKE &SPK #28 	; global SPK=28
 		MOVi %1 #CLAM 	; if((int)HERE(CLAM, lLOC) != FALSE) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1679:31
 		EQUi %0 #FALSE @.f10
 		MOVi $lOBJ #CLAM 	; lOBJ=CLAM
 		POKE &gOBJ #CLAM 	; global gOBJ = CLAM
 	.f10:	MOVi %1 #OYSTER 	; if((int)HERE(OYSTER, lLOC) != FALSE) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1680:33
 		EQUi %0 #FALSE @.f11
 		MOVi $lOBJ #OYSTER 	; lOBJ=OYSTER
 		POKE &gOBJ #OYSTER 	; global gOBJ = OYSTER
 	.f11:	MOVi %1 #DOOR 	; if((int)AT(DOOR, lLOC) != FALSE) 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1681:29
 		EQUi %0 #FALSE @.f12
 		MOVi $lOBJ #DOOR 	; lOBJ=DOOR
 		POKE &gOBJ #DOOR 	; global gOBJ = DOOR
 	.f12:	MOVi %1 #GRATE 	; if((int)AT(GRATE, lLOC) != FALSE) 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1682:30
 		EQUi %0 #FALSE @.f13
 		MOVi $lOBJ #GRATE 	; lOBJ=GRATE
 		POKE &gOBJ #GRATE 	; global gOBJ = GRATE
 	.f13:	EQUi $lOBJ #0 @.f15	; if(lOBJ != 0 && (int)HERE(CHAIN, lLOC) != FALSE) 
 		MOVi %1 #CHAIN 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1683:45
 		EQUi %0 #FALSE @.f15
 		MOVi $goValue #GOTO8000 	; goValue = GOTO8000
 		GOTO @return  	; goto return
 	.f15:	MOVi %1 #CHAIN 	; if((int)HERE(CHAIN, lLOC) != FALSE) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1684:32
 		EQUi %0 #FALSE @.f16
 		MOVi $lOBJ #CHAIN 	; lOBJ=CHAIN
 		POKE &gOBJ #CHAIN 	; global gOBJ = CHAIN
@@ -2887,7 +2887,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		NEQi %0 #31 @.t27
 		MOVi %1 #KEYS 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1696:52
 		NEQi %0 #FALSE @.f28
 	.t27:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
@@ -2907,11 +2907,11 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		GOTO @return  	; goto return
 	.f33:	POKE &PROP:CHAIN #2 	; global PROP[CHAIN]=2
 		MOVi %1 #CHAIN 	; if((int)TOTING(CHAIN) != FALSE)fDROP(CHAIN,lLOC)
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1705:31
 		EQUi %0 #FALSE @.f34
 		MOVi %1 #CHAIN 	; fDROP(CHAIN,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1705:57
 	.f34:	POKE &FIXED:CHAIN #-1 	; global FIXED[CHAIN]= -1
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
@@ -2967,12 +2967,12 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.f42:	ADDi %0 #124 $lK	; global SPK=124+lK
 		POKE &SPK %0 
 		MOVi %1 $lOBJ 	; if((int)TOTING(lOBJ) != FALSE)global SPK=120+lK
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1737:27
 		EQUi %0 #FALSE @.f43
 		ADDi %0 #120 $lK	; global SPK=120+lK
 		POKE &SPK %0 
 	.f43:	MOVi %1 #TRIDNT 	; if((int)TOTING(TRIDNT) == FALSE)global SPK=122+lK
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1738:29
 		NEQi %0 #FALSE @.f44
 		ADDi %0 #122 $lK	; global SPK=122+lK
 		POKE &SPK %0 
@@ -2984,13 +2984,13 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f46:	MOVi %1 #CLAM 	; fDSTROY(CLAM)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 1742:19
 		MOVi %1 #OYSTER 	; fDROP(OYSTER,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1743:24
 		MOVi %1 #PEARL 	; fDROP(PEARL,105)
 		MOVi %2 #105 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 1744:22
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 		GOTO @.e7  	; }
@@ -2999,7 +2999,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		GOTO @.e7  	; }
 	.s6#6:	MOVi %1 #LAMP 	; if((int)HERE(LAMP, lLOC) != FALSE && (int)global PROP[LAMP] == 0 && global LIMIT >= 0) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1752:31
 		EQUi %0 #FALSE @.f48
 		PEEK %0 &PROP:LAMP 
 		NEQi %0 #0 @.f48
@@ -3009,7 +3009,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		POKE &gOBJ $lOBJ 	; global gOBJ = lOBJ
 	.f48:	MOVi %1 #URN 	; if((int)HERE(URN, lLOC) != FALSE && (int)global PROP[URN] == 1) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1753:30
 		EQUi %0 #FALSE @.f50
 		PEEK %0 &PROP:URN 
 		NEQi %0 #1 @.f50
@@ -3032,7 +3032,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		GOTO @return  	; goto return
 	.f55:	POKE &PROP:LAMP #1 	; global PROP[LAMP]=1
 		MOVi %1 #39 	; fRSPEAK(39)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1762:18
 		PEEK %0 &WZDARK 	; if(global WZDARK != FALSE) 
 		EQUi %0 #FALSE @.f56
 		MOVi $goValue #GOTO2000 	; goValue = GOTO2000
@@ -3051,7 +3051,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		GOTO @.e7  	; }
 	.s6#7:	MOVi %1 #LAMP 	; if((int)HERE(LAMP, lLOC) != FALSE && (int)global PROP[LAMP] == 1) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1776:31
 		EQUi %0 #FALSE @.f59
 		PEEK %0 &PROP:LAMP 
 		NEQi %0 #1 @.f59
@@ -3059,7 +3059,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		POKE &gOBJ $lOBJ 	; global gOBJ = lOBJ
 	.f59:	MOVi %1 #URN 	; if((int)HERE(URN, lLOC) != FALSE && (int)global PROP[URN] == 2) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1777:30
 		EQUi %0 #FALSE @.f61
 		PEEK %0 &PROP:URN 
 		NEQi %0 #2 @.f61
@@ -3075,12 +3075,12 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		NEQi $lOBJ #LAMP @.f65	; if(lOBJ == LAMP) 
 		POKE &PROP:LAMP #0 	; global PROP[LAMP]=0
 		MOVi %1 #40 	; fRSPEAK(40)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1784:19
 		MOVi %1 $lLOC 	; if((int)DARK(lLOC) != FALSE)fRSPEAK(16)
-		CALL &DARK %0 *2	; expects DARK(int) -> int
+		CALL &DARK %0 *2	; expects DARK(int) -> int @ 1785:27
 		EQUi %0 #FALSE @.f66
 		MOVi %1 #16 	; fRSPEAK(16)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1785:47
 	.f66:	MOVi $goValue #GOTO2012 	; goValue = GOTO2012
 		GOTO @return  	; goto return
 	.f65:	EQUi $lOBJ #DRAGON @.t67	; if(lOBJ == DRAGON || lOBJ == VOLCAN)global SPK=146
@@ -3098,21 +3098,21 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.s6#10:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 		GOTO @.e7  	; }
-	.s6#11:	CALL &attack %0 *1	; expects attack() -> int
+	.s6#11:	CALL &attack %0 *1	; expects attack() -> int @ 1797:39
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 		GOTO @.e7  	; }
 	.s6#12:	NOOP
 	L9130:	EQUi $lOBJ #BOTTLE @.t69	; L9130:
 		NEQi $lOBJ #0 @.f70
-	.t69:	CALL &LIQ %0 *1	; expects LIQ() -> int
+	.t69:	CALL &LIQ %0 *1	; expects LIQ() -> int @ 1803:52
 		MOVi $lOBJ %0 
 	.f70:	POKE &gOBJ $lOBJ 	; global gOBJ = lOBJ
 		NEQi $lOBJ #0 @.f71	; if(lOBJ == 0) 
 		MOVi $goValue #GOTO8000 	; goValue = GOTO8000
 		GOTO @return  	; goto return
 	.f71:	MOVi %1 $lOBJ 	; if((int)TOTING(lOBJ) == FALSE) 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1806:27
 		NEQi %0 #FALSE @.f72
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
@@ -3123,7 +3123,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		GOTO @return  	; goto return
 	.f74:	MOVi %1 #URN 	; if(!((int)HERE(URN, lLOC) != FALSE && (int)global PROP[URN] == 0)) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1809:32
 		EQUi %0 #FALSE @.f75
 		PEEK %0 &PROP:URN 
 		EQUi %0 #0 @.f76
@@ -3132,17 +3132,17 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		POKE &SPK #77 	; global SPK=77
 		MOVi %1 #PLANT 	; if(!((int)AT(PLANT, lLOC) != FALSE || (int)AT(DOOR, lLOC) != FALSE)) 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1813:33
 		NEQi %0 #FALSE @.f78
 		MOVi %1 #DOOR 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1813:65
 		NEQi %0 #FALSE @.f78
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f78:	MOVi %1 #DOOR 	; if(!((int)AT(DOOR, lLOC) != FALSE)) 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 1815:32
 		NEQi %0 #FALSE @.f79
 		POKE &SPK #112 	; global SPK=112
 		EQUi $lOBJ #WATER @.f80	; if(lOBJ != WATER) 
@@ -3151,7 +3151,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.f80:	MOVi %1 #PLANT 	; fPSPEAK(PLANT,(int)global PROP[PLANT]+3)
 		PEEK %2 &PROP:PLANT 
 		ADDi %2 %2 #3
-		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void
+		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void @ 1818:48
 		PEEK %0 &PROP:PLANT 	; global PROP[PLANT]=(((int)global PROP[PLANT]+1)%3)
 		ADDi %0 %0 #1
 		MODi %0 %0 #3
@@ -3173,18 +3173,18 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.f76:	MOVi $lOBJ #URN 	; lOBJ=URN
 		POKE &gOBJ #URN 	; global gOBJ = URN
 		MOVi %1 $lOBJ 	; goValue = (int)fill(lOBJ)
-		CALL &fill %0 *2	; expects fill(int) -> int
+		CALL &fill %0 *2	; expects fill(int) -> int @ 1832:33
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 		GOTO @.e7  	; }
 	.s6#13:	MOVi %1 #FOOD 	; if((int)HERE(FOOD, lLOC) == FALSE) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1838:31
 		NEQi %0 #FALSE @.f82
 		MOVi $goValue #GOTO8000 	; goValue = GOTO8000
 		GOTO @return  	; goto return
 	.f82:	MOVi %1 #FOOD 	; fDSTROY(FOOD)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 1839:19
 		POKE &SPK #72 	; global SPK=72
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
@@ -3192,13 +3192,13 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.s6#14:	NOOP
 	L9150:	NEQi $lOBJ #0 @.f85	; L9150:
 		MOVi %1 $lLOC 
-		CALL &LIQLOC %0 *2	; expects LIQLOC(int) -> int
+		CALL &LIQLOC %0 *2	; expects LIQLOC(int) -> int @ 1848:40
 		EQUi %0 #WATER @.f85
-		CALL &LIQ %0 *1	; expects LIQ() -> int
+		CALL &LIQ %0 *1	; expects LIQ() -> int @ 1848:64
 		NEQi %0 #WATER @.t84
 		MOVi %1 #BOTTLE 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1848:100
 		NEQi %0 #FALSE @.f85
 	.t84:	MOVi $goValue #GOTO8000 	; goValue = GOTO8000
 		GOTO @return  	; goto return
@@ -3208,11 +3208,11 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		POKE &SPK #110 	; global SPK=110
 	.f88:	PEEK %0 &SPK 	; if(global SPK == 110 || (int)LIQ() != WATER || (int)HERE(BOTTLE, lLOC) == FALSE) 
 		EQUi %0 #110 @.t89
-		CALL &LIQ %0 *1	; expects LIQ() -> int
+		CALL &LIQ %0 *1	; expects LIQ() -> int @ 1852:42
 		NEQi %0 #WATER @.t89
 		MOVi %1 #BOTTLE 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1852:78
 		NEQi %0 #FALSE @.f90
 	.t89:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
@@ -3222,7 +3222,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f86:	MOVi %1 #BLOOD 	; fDSTROY(BLOOD)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 1859:20
 		POKE &PROP:DRAGON #2 	; global PROP[DRAGON]=2
 		PEEK %0 &OBJSND:BIRD 	; global OBJSND[BIRD]=(int)global OBJSND[BIRD]+3
 		ADDi %0 %0 #3
@@ -3234,10 +3234,10 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.s6#17:	MOVi %1 #22 	; if((int)fYES(22,54,54) != FALSE) score(1)
 		MOVi %2 #54 
 		MOVi %3 #54 
-		CALL &fYES %0 *4	; expects fYES(int, int, int) -> int
+		CALL &fYES %0 *4	; expects fYES(int, int, int) -> int @ 1868:29
 		EQUi %0 #FALSE @.f91
 		MOVi %1 #1 	; score(1)
-		CALL &score %0 *2	; expects score(int) -> void
+		CALL &score %0 *2	; expects score(int) -> void @ 1868:47
 	.f91:	MOVi $goValue #GOTO2012 	; goValue = GOTO2012
 		GOTO @return  	; goto return
 		GOTO @.e7  	; }
@@ -3247,28 +3247,28 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		GEQi #1 <A> @.e92
 	.l93:	EQUi $I #BEAR @.f95	; if(!(I == BEAR || (int)TOTING(I) == FALSE)) 
 		MOVi %1 $I 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1876:40
 		EQUi %0 #FALSE @.f95
 		PEEK %0 &SPK 	; if(global SPK == 98)fRSPEAK(99)
 		NEQi %0 #98 @.f96
 		MOVi %1 #99 	; fRSPEAK(99)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1877:39
 	.f96:	POKE &BLKLIN #FALSE 	; global BLKLIN=FALSE
 		MOVi %1 $I 	; fPSPEAK(I,-1)
 		MOVi %2 #-1 
-		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void
+		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void @ 1879:21
 		POKE &BLKLIN #TRUE 	; global BLKLIN=TRUE
 		POKE &SPK #0 	; global SPK=0
 	.f95:	FORi $I <A> @.l93	; } /* end loop */
 	.e92:	MOVi %1 #BEAR 	; if((int)TOTING(BEAR) != FALSE)global SPK=141
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1884:27
 		EQUi %0 #FALSE @.f97
 		POKE &SPK #141 	; global SPK=141
 	.f97:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 		GOTO @.e7  	; }
 	.s6#21:	MOVi %1 $lOBJ 	; goValue = (int)fill(lOBJ)
-		CALL &fill %0 *2	; expects fill(int) -> int
+		CALL &fill %0 *2	; expects fill(int) -> int @ 1887:41
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 		GOTO @.e7  	; }
@@ -3284,32 +3284,32 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		POKE &BONUS #134 	; global BONUS=134
 	.f100:	MOVi %1 #ROD2 	; if((int)HERE(ROD2, lLOC) != FALSE)global BONUS=135
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1895:31
 		EQUi %0 #FALSE @.f101
 		POKE &BONUS #135 	; global BONUS=135
 	.f101:	PEEK %1 &BONUS 	; fRSPEAK(global BONUS)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1896:27
 		MOVi %1 #0 	; score(0)
-		CALL &score %0 *2	; expects score(int) -> void
+		CALL &score %0 *2	; expects score(int) -> void @ 1897:14
 		GOTO @.e7  	; }
 	.s6#23:	MOVi %1 #-1 	; score(-1)
-		CALL &score %0 *2	; expects score(int) -> void
+		CALL &score %0 *2	; expects score(int) -> void @ 1902:15
 		MOVi %1 #1 	; fSETPRM(1,global SCORE,global MXSCOR)
 		PEEK %2 &SCORE 
 		PEEK %3 &MXSCOR 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 1903:43
 		MOVi %1 #3 	; fSETPRM(3,global TURNS,global TURNS)
 		PEEK %2 &TURNS 
 		PEEK %3 &TURNS 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 1904:42
 		MOVi %1 #259 	; fRSPEAK(259)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1905:18
 		MOVi $goValue #GOTO2012 	; goValue = GOTO2012
 		GOTO @return  	; goto return
 		GOTO @.e7  	; }
 	.s6#24:	PEEK %1 &WD1 	; lK=(int)fVOCAB(global WD1,3)
 		MOVi %2 #3 
-		CALL &fVOCAB %0 *3	; expects fVOCAB(int, int) -> int
+		CALL &fVOCAB %0 *3	; expects fVOCAB(int, int) -> int @ 1913:34
 		MOVi $lK %0 
 		POKE &gK $lK 	; global gK = lK
 		POKE &SPK #42 	; global SPK=42
@@ -3330,7 +3330,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		PEEK %1 &PLAC:EGGS 
 		EQUi %0 %1 @.t105
 		MOVi %1 #EGGS 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 1922:81
 		EQUi %0 #FALSE @.f107
 		PEEK %0 &PLAC:EGGS 
 		NEQi $lLOC %0 @.f107
@@ -3347,7 +3347,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		POKE &gK #2 	; global gK = 2
 		MOVi %1 #EGGS 	; if((int)HERE(EGGS, lLOC) != FALSE) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1926:31
 		EQUi %0 #FALSE @.f110
 		MOVi $lK #1 	; lK=1
 		POKE &gK #2 	; global gK = 2
@@ -3357,10 +3357,10 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		POKE &gK #0 	; global gK = 0
 	.f111:	MOVi %1 #EGGS 	; fMOVE(EGGS,global PLAC[EGGS])
 		PEEK %2 &PLAC:EGGS 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 1928:35
 		MOVi %1 #EGGS 	; fPSPEAK(EGGS,lK)
 		MOVi %2 $lK 
-		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void
+		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void @ 1929:22
 		MOVi $goValue #GOTO2012 	; goValue = GOTO2012
 		GOTO @return  	; goto return
 		GOTO @.e7  	; }
@@ -3375,7 +3375,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		GEQi #1 <A> @.e112
 	.l113:	MOVi %1 $I 	; if((int)HERE(I, lLOC) != FALSE && (int)global OBJTXT[I] != 0 && (int)global PROP[I] >= 0) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1944:29
 		EQUi %0 #FALSE @.f115
 		PEEK %0 &OBJTXT $I
 		EQUi %0 #0 @.f115
@@ -3388,13 +3388,13 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.e112:	GRTi $lOBJ #100 @.t116	; if(lOBJ > 100 || lOBJ == 0 || (int)DARK(lLOC) != FALSE) 
 		EQUi $lOBJ #0 @.t116
 		MOVi %1 $lLOC 
-		CALL &DARK %0 *2	; expects DARK(int) -> int
+		CALL &DARK %0 *2	; expects DARK(int) -> int @ 1946:52
 		EQUi %0 #FALSE @.f117
 	.t116:	MOVi $goValue #GOTO8000 	; goValue = GOTO8000
 		GOTO @return  	; goto return
 	.f117:	NOOP
 	L9270:	MOVi %1 $lLOC 	; L9270:
-		CALL &DARK %0 *2	; expects DARK(int) -> int
+		CALL &DARK %0 *2	; expects DARK(int) -> int @ 1949:25
 		EQUi %0 #FALSE @.f118
 		GOTO @L5190  	; goto L5190
 	.f118:	PEEK %0 &OBJTXT $lOBJ	; if((int)global OBJTXT[lOBJ] == 0 || (int)global PROP[lOBJ] < 0) 
@@ -3410,20 +3410,20 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		PEEK %2 &OBJTXT $lOBJ
 		PEEK %3 &PROP $lOBJ
 		ADDi %2 %2 %3
-		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void
+		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void @ 1952:68
 		MOVi $goValue #GOTO2012 	; goValue = GOTO2012
 		GOTO @return  	; goto return
 	.f122:	MOVi %1 #192 	; global CLSHNT=(int)fYES(192,193,54)
 		MOVi %2 #193 
 		MOVi %3 #54 
-		CALL &fYES %0 *4	; expects fYES(int, int, int) -> int
+		CALL &fYES %0 *4	; expects fYES(int, int, int) -> int @ 1956:41
 		POKE &CLSHNT %0 
 		MOVi $goValue #GOTO2012 	; goValue = GOTO2012
 		GOTO @return  	; goto return
 		GOTO @.e7  	; }
 	.s6#29:	NOOP
 	.s6#30:	MOVp %1 &.s_SorryF4d4 	; output("Sorry. File operationrs are disabled.\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1960:55
 		POKE &gK #NUL 	; global gK = NUL
 		MOVi $goValue #GOTO8 	; goValue = GOTO8
 		GOTO @return  	; goto return
@@ -3433,7 +3433,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		POKE &SPK #224 	; global SPK=224
 	.f123:	MOVi %1 #RUG 	; if((int)HERE(RUG, lLOC) == FALSE)global SPK=225
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1968:30
 		NEQi %0 #FALSE @.f124
 		POKE &SPK #225 	; global SPK=225
 	.f124:	PEEK %0 &SPK 	; if(global SPK/2 == 112) 
@@ -3464,7 +3464,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		LSSi %0 #0 @.f128
 		POKE &SPK #227 	; global SPK=227
 	.f128:	PEEK %1 &SPK 	; fRSPEAK(global SPK)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1981:25
 		MOVi $goValue #GOTO2 	; goValue = GOTO2
 		GOTO @return  	; goto return
 		GOTO @.e7  	; }
@@ -3473,7 +3473,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		POKE &gK $lK 	; global gK = lK
 		EQUi $lK #0 @.f129	; if(lK != 0) 
 		ABSi %1 $lK 	; fRSPEAK(abs(lK))
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 1990:23
 		GEQi $lK #0 @.f130	; if(lK < 0) 
 		MOVi $goValue #GOTO2012 	; goValue = GOTO2012
 		GOTO @return  	; goto return
@@ -3483,13 +3483,13 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		! MULi <A> #MESH #2
 		SUBi %2 %2 <A>
 		MOVi %3 #0 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 1995:39
 		MOVi $I #1 	; for (I=1 to 100+1) 
 		! ADDi <A> #100 #1
 		GEQi #1 <A> @.e131
 	.l132:	MOVi %1 $I 	; if (!((int)HERE(I, lLOC) == FALSE || (int)global OBJSND[I] == 0 || (int)global PROP[I] < 0)) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 1997:32
 		EQUi %0 #FALSE @.f134
 		PEEK %0 &OBJSND $I
 		EQUi %0 #0 @.f134
@@ -3499,7 +3499,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		PEEK %2 &OBJSND $I
 		PEEK %3 &PROP $I
 		ADDi %2 %2 %3
-		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void
+		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void @ 1998:60
 		POKE &SPK #0 	; global SPK=0
 		NEQi $I #BIRD @.f134	; if(I == BIRD && (int)global OBJSND[I]+(int)global PROP[I] == 8)fDSTROY(BIRD)
 		PEEK %0 &OBJSND $I
@@ -3507,7 +3507,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		ADDi %0 %0 %1
 		NEQi %0 #8 @.f134
 		MOVi %1 #BIRD 	; fDSTROY(BIRD)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 2000:84
 	.f134:	FORi $I <A> @.l132	; } /* end loop */
 	.e131:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
@@ -3515,7 +3515,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.s6#33:	NOOP
 	L8340:	MOVi %1 #RESER 	; L8340:
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 2010:30
 		NEQi %0 #FALSE @.f138
 		PEEK %0 &FIXED:RESER 
 		SUBi %0 %0 #1
@@ -3525,56 +3525,56 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.f138:	MOVi %1 #RESER 	; fPSPEAK(RESER,(int)global PROP[RESER]+1)
 		PEEK %2 &PROP:RESER 
 		ADDi %2 %2 #1
-		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void
+		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void @ 2011:46
 		PEEK %0 &PROP:RESER 	; global PROP[RESER]=1-(int)global PROP[RESER]
 		SUBi %0 #1 %0
 		POKE &PROP:RESER %0 
 		MOVi %1 #RESER 	; if((int)AT(RESER, lLOC) != FALSE) 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 2013:30
 		EQUi %0 #FALSE @.f139
 		MOVi $goValue #GOTO2012 	; goValue = GOTO2012
 		GOTO @return  	; goto return
 	.f139:	POKE &OLDLC2 $lLOC 	; global OLDLC2=lLOC
 		POKE &NEWLOC #0 	; global NEWLOC=0
 		MOVi %1 #241 	; fRSPEAK(241)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2016:18
 		MOVi $goValue #GOTO2 	; goValue = GOTO2
 		GOTO @return  	; goto return
 	.s6:	NOOP
 	.e7:	MOVi %1 #23 	; fBUG(23)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 2020:12
 		GOTO @.e1  	; }
 	.s0#1:	NOOP
 	L4090:	PEEK %0 &VERB 	; L4090:
 		SUBi %0 %0 #1
 		SWCH %0 *34 @.s140
-	.s140#0:	CALL &carry %0 *1	; expects carry() -> int
+	.s140#0:	CALL &carry %0 *1	; expects carry() -> int @ 2031:37
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 		GOTO @.e141  	; }
 	.s140#1:	MOVi %1 #FALSE 	; goValue = (int)discard(FALSE)
-		CALL &discard %0 *2	; expects discard(int) -> int
+		CALL &discard %0 *2	; expects discard(int) -> int @ 2032:44
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 		GOTO @.e141  	; }
 	.s140#2:	MOVi %1 #1 	; fSETPRM(1,global WD2,global WD2X)
 		PEEK %2 &WD2 
 		PEEK %3 &WD2X 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 2036:39
 		PEEK %0 &WD2 	; if(global WD2 <= 0)fSETPRM(1,global WD1,global WD1X)
 		GRTi %0 #0 @.f142
 		MOVi %1 #1 	; fSETPRM(1,global WD1,global WD1X)
 		PEEK %2 &WD1 
 		PEEK %3 &WD1X 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 2037:58
 	.f142:	PEEK %0 &WD2 	; if(global WD2 > 0)global WD1=global WD2
 		LEQi %0 #0 @.f143
 		PEEK %0 &WD2 	; global WD1=global WD2
 		POKE &WD1 %0 
 	.f143:	PEEK %1 &WD1 	; I=(int)fVOCAB(global WD1,-1)
 		MOVi %2 #-1 
-		CALL &fVOCAB %0 *3	; expects fVOCAB(int, int) -> int
+		CALL &fVOCAB %0 *3	; expects fVOCAB(int, int) -> int @ 2039:34
 		MOVi $I %0 
 		EQUi $I #62 @.f145	; if(!(I == 62 || I == 65 || I == 71 || I == 2025 || I == 2034)) 
 		EQUi $I #65 @.f145
@@ -3582,7 +3582,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		EQUi $I #2025 @.f145
 		EQUi $I #2034 @.f145
 		MOVi %1 #258 	; fRSPEAK(258)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2041:19
 		MOVi $goValue #GOTO2012 	; goValue = GOTO2012
 		GOTO @return  	; goto return
 	.f145:	POKE &WD2 #0 	; global WD2=0
@@ -3602,32 +3602,32 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.s140#7:	GOTO @L9080  	; goto L9080
 		GOTO @.e141  
 	.s140#8:	MOVi %1 $lOBJ 	; if(((int)TOTING(lOBJ) == FALSE) && (lOBJ != ROD || (int)TOTING(ROD2) == FALSE))global SPK=29
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2057:28
 		NEQi %0 #FALSE @.f148
 		NEQi $lOBJ #ROD @.t147
 		MOVi %1 #ROD2 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2057:75
 		NEQi %0 #FALSE @.f148
 	.t147:	POKE &SPK #29 	; global SPK=29
 	.f148:	NEQi $lOBJ #ROD @.t149	; if(lOBJ != ROD || (int)TOTING(lOBJ) == FALSE || ((int)HERE(BIRD, lLOC) == FALSE && (global CLOSNG != FALSE || (int)AT(FISSUR, lLOC) == FALSE))) 
 		MOVi %1 $lOBJ 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2058:42
 		EQUi %0 #FALSE @.t149
 		MOVi %1 #BIRD 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2058:77
 		NEQi %0 #FALSE @.f152
 		PEEK %0 &CLOSNG 
 		NEQi %0 #FALSE @.t149
 		MOVi %1 #FISSUR 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 2058:138
 		NEQi %0 #FALSE @.f152
 	.t149:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f152:	MOVi %1 #BIRD 	; if((int)HERE(BIRD, lLOC) != FALSE)global SPK=206+(((int)global PROP[BIRD])%2)
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2059:31
 		EQUi %0 #FALSE @.f153
 		PEEK %0 &PROP:BIRD 	; global SPK=206+(((int)global PROP[BIRD])%2)
 		MODi %0 %0 #2
@@ -3647,28 +3647,28 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		NEQi %0 #FALSE @.t157
 		MOVi %1 #FISSUR 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 2062:58
 		NEQi %0 #FALSE @.f158
 	.t157:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f158:	MOVi %1 #BIRD 	; if((int)HERE(BIRD, lLOC) != FALSE)fRSPEAK(global SPK)
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2063:32
 		EQUi %0 #FALSE @.f159
 		PEEK %1 &SPK 	; fRSPEAK(global SPK)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2063:60
 	.f159:	PEEK %0 &PROP:FISSUR 	; global PROP[FISSUR]=1-(int)global PROP[FISSUR]
 		SUBi %0 #1 %0
 		POKE &PROP:FISSUR %0 
 		MOVi %1 #FISSUR 	; fPSPEAK(FISSUR,2-(int)global PROP[FISSUR])
 		PEEK %2 &PROP:FISSUR 
 		SUBi %2 #2 %2
-		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void
+		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void @ 2065:49
 		MOVi $goValue #GOTO2012 	; goValue = GOTO2012
 		GOTO @return  	; goto return
 	.f155:	MOVi %1 #JADE 	; fDROP(JADE,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 2069:22
 		POKE &PROP:JADE #0 	; global PROP[JADE]=0
 		PEEK %0 &TALLY 	; global TALLY=global TALLY-1
 		SUBi %0 %0 #1
@@ -3688,7 +3688,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.s140#32:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 		GOTO @.e141  	; }
-	.s140#11:	CALL &attack %0 *1	; expects attack() -> int
+	.s140#11:	CALL &attack %0 *1	; expects attack() -> int @ 2077:39
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 		GOTO @.e141  	; }
@@ -3696,7 +3696,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		GOTO @.e141  
 	.s140#13:	NEQi $lOBJ #FOOD @.f160	; if(lOBJ == FOOD) 
 		MOVi %1 #FOOD 	; fDSTROY(FOOD)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 2083:20
 		POKE &SPK #72 	; global SPK=72
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
@@ -3723,61 +3723,61 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.t164:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 	.f165:	MOVi %1 #URN 	; fDSTROY(URN)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 2099:18
 		MOVi %1 #AMBER 	; fDROP(AMBER,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 2100:23
 		POKE &PROP:AMBER #1 	; global PROP[AMBER]=1
 		PEEK %0 &TALLY 	; global TALLY=global TALLY-1
 		SUBi %0 %0 #1
 		POKE &TALLY %0 
 		MOVi %1 #CAVITY 	; fDROP(CAVITY,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 2103:24
 		POKE &SPK #216 	; global SPK=216
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 		GOTO @.e141  	; }
-	.s140#16:	CALL &doThrow %0 *1	; expects doThrow() -> int
+	.s140#16:	CALL &doThrow %0 *1	; expects doThrow() -> int @ 2108:40
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 		GOTO @.e141  	; }
 	.s140#18:	NOOP
 	.s140#19:	MOVi %1 $lOBJ 	; if((int)AT(lOBJ, lLOC) != FALSE || ((int)LIQ() == lOBJ && (int)AT(BOTTLE, lLOC) != FALSE) || lK == (int)LIQLOC(lLOC) || (lOBJ ==
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 2112:29
 		NEQi %0 #FALSE @.t166
-		CALL &LIQ %0 *1	; expects LIQ() -> int
+		CALL &LIQ %0 *1	; expects LIQ() -> int @ 2112:53
 		NEQi %0 $lOBJ @.f167
 		MOVi %1 #BOTTLE 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 2112:86
 		NEQi %0 #FALSE @.t166
 	.f167:	MOVi %1 $lLOC 
-		CALL &LIQLOC %0 *2	; expects LIQLOC(int) -> int
+		CALL &LIQLOC %0 *2	; expects LIQLOC(int) -> int @ 2112:123
 		EQUi $lK %0 @.t166
 		NEQi $lOBJ #DWARF @.f169
 		MOVi %1 $lLOC 
-		CALL &fATDWRF %0 *2	; expects fATDWRF(int) -> int
+		CALL &fATDWRF %0 *2	; expects fATDWRF(int) -> int @ 2113:35
 		LEQi %0 #0 @.f169
 	.t166:	POKE &SPK #94 	; global SPK=94
 	.f169:	PEEK %0 &CLOSED 	; if(global CLOSED != FALSE)global SPK=138
 		EQUi %0 #FALSE @.f170
 		POKE &SPK #138 	; global SPK=138
 	.f170:	MOVi %1 $lOBJ 	; if((int)TOTING(lOBJ) != FALSE)global SPK=24
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2115:27
 		EQUi %0 #FALSE @.f171
 		POKE &SPK #24 	; global SPK=24
 	.f171:	MOVi $goValue #GOTO2011 	; goValue = GOTO2011
 		GOTO @return  	; goto return
 		GOTO @.e141  	; }
 	.s140#20:	MOVi %1 $lOBJ 	; goValue = (int)feed(lOBJ)
-		CALL &feed %0 *2	; expects feed(int) -> int
+		CALL &feed %0 *2	; expects feed(int) -> int @ 2118:41
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 		GOTO @.e141  	; }
 	.s140#21:	MOVi %1 $lOBJ 	; goValue = (int)fill(lOBJ)
-		CALL &fill %0 *2	; expects fill(int) -> int
+		CALL &fill %0 *2	; expects fill(int) -> int @ 2119:41
 		MOVi $goValue %0 
 		GOTO @return  	; goto return
 		GOTO @.e141  	; }
@@ -3800,11 +3800,11 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		GOTO @return  	; goto return
 	.f174:	POKE &SPK #198 	; global SPK=198
 		MOVi %1 #VASE 	; if((int)TOTING(VASE) != FALSE)fDROP(VASE,lLOC)
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2133:27
 		EQUi %0 #FALSE @.f177
 		MOVi %1 #VASE 	; fDROP(VASE,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 2133:52
 	.f177:	POKE &PROP:VASE #2 	; global PROP[VASE]=2
 		POKE &FIXED:VASE #-1 	; global FIXED[VASE]= -1
 		MOVi $goValue #GOTO2011 	; goValue = GOTO2011
@@ -3824,13 +3824,13 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.s140#33:	GOTO @L8340  	; goto L8340
 	.s140:	NOOP
 	.e141:	MOVi %1 #24 	; fBUG(24)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 2148:12
 		GOTO @.e1  	; }
 	.s0#2:	MOVi $lOBJ $lK 	; lOBJ=lK
 		POKE &gOBJ $lK 	; global gOBJ = lK
 		MOVi %1 $lK 	; if((int)HERE(lK, lLOC) != FALSE) 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2159:27
 		EQUi %0 #FALSE @.f180
 	L5010:	PEEK %0 &WD2 	; L5010:
 		LEQi %0 #0 @.f181
@@ -3842,9 +3842,9 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.f182:	MOVi %1 #1 	; fSETPRM(1,global WD1,global WD1X)
 		PEEK %2 &WD1 
 		PEEK %3 &WD1X 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 2163:38
 		MOVi %1 #255 	; fRSPEAK(255)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2164:17
 		MOVi $goValue #GOTO2600 	; goValue = GOTO2600
 		GOTO @return  	; goto return
 	.f180:	NEQi $lK #GRATE @.f183	; if(lK == GRATE) 
@@ -3862,23 +3862,23 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 		GOTO @return  	; goto return
 	.f183:	NEQi $lK #DWARF @.f190	; if(lK == DWARF && (int)fATDWRF(lLOC) > 0) goto L5010
 		MOVi %1 $lLOC 
-		CALL &fATDWRF %0 *2	; expects fATDWRF(int) -> int
+		CALL &fATDWRF %0 *2	; expects fATDWRF(int) -> int @ 2173:41
 		LEQi %0 #0 @.f190
 		GOTO @L5010  	; goto L5010
-	.f190:	CALL &LIQ %0 *1	; expects LIQ() -> int
+	.f190:	CALL &LIQ %0 *1	; expects LIQ() -> int @ 2174:19
 		NEQi %0 $lK @.f191
 		MOVi %1 #BOTTLE 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2174:52
 		NEQi %0 #FALSE @L5010
 	.f191:	MOVi %1 $lLOC 
-		CALL &LIQLOC %0 *2	; expects LIQLOC(int) -> int
+		CALL &LIQLOC %0 *2	; expects LIQLOC(int) -> int @ 2174:88
 		NEQi $lK %0 @.f193
 		GOTO @L5010  	; goto L5010
 	.f193:	NEQi $lOBJ #OIL @.f195	; if(!(lOBJ != OIL || (int)HERE(URN, lLOC) == FALSE || (int)global PROP[URN] == 0)) 
 		MOVi %1 #URN 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2175:45
 		EQUi %0 #FALSE @.f195
 		PEEK %0 &PROP:URN 
 		EQUi %0 #0 @.f195
@@ -3888,7 +3888,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.f195:	NEQi $lOBJ #PLANT @.f197	; if(!(lOBJ != PLANT || (int)AT(PLANT2, lLOC) == FALSE || (int)global PROP[PLANT2] == 0)) 
 		MOVi %1 #PLANT2 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 2179:48
 		EQUi %0 #FALSE @.f197
 		PEEK %0 &PROP:PLANT2 
 		EQUi %0 #0 @.f197
@@ -3905,7 +3905,7 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.f199:	NEQi $lOBJ #ROD @L5190	; if(lOBJ != ROD || (int)HERE(ROD2, lLOC) == FALSE) goto L5190
 		MOVi %1 #ROD2 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2188:44
 		NEQi %0 #FALSE @.f201
 		GOTO @L5190  	; goto L5190
 	.f201:	MOVi $lOBJ #ROD2 	; lOBJ=ROD2
@@ -3921,21 +3921,21 @@ action:	FUNC	; signature func action(int STARTAT) -> int
 	.f204:	MOVi %1 #1 	; fSETPRM(1,global WD1,global WD1X)
 		PEEK %2 &WD1 
 		PEEK %3 &WD1X 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 2193:37
 		MOVi %1 #256 	; fRSPEAK(256)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2194:16
 		MOVi $goValue #GOTO2012 	; goValue = GOTO2012
 		GOTO @return  	; goto return
 	.s0:	NOOP
 	.e1:	MOVi %1 #99 	; fBUG(99)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 2198:10
 		MOVi $goValue #GOTO8000 	; goValue = GOTO8000
 	return:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 2207:15
 	$gotoChoice:	LOCi
 	$I:	LOCi
 	$J:	LOCi
@@ -3959,20 +3959,20 @@ main:	FUNC	; signature func main() -> void
 		MOVi $STICK #0 	; STICK = 0
 		MOVi $ATTACK #0 	; ATTACK = 0
 		POKE &MAP2:1 #0 	; global MAP2[1] = 0
-		CALL &initialise %0 *1	; expects initialise() -> void
+		CALL &initialise %0 *1	; expects initialise() -> void @ 2238:14
 		MOVi %1 #-1 	; I=(int)fRAN(-1)
-		CALL &fRAN %0 *2	; expects fRAN(int) -> int
+		CALL &fRAN %0 *2	; expects fRAN(int) -> int @ 2242:17
 		MOVi $I %0 
 		MOVi %1 #3 	; global ZZWORD=(int)fRNDVOC(3,0)+MESH*2
 		MOVi %2 #0 
-		CALL &fRNDVOC %0 *3	; expects fRNDVOC(int, int) -> int
+		CALL &fRNDVOC %0 *3	; expects fRNDVOC(int, int) -> int @ 2243:33
 		! MULi <A> #MESH #2
 		ADDi %0 %0 <A>
 		POKE &ZZWORD %0 
 		MOVi %1 #65 	; global NOVICE=(int)fYES(65,1,0)
 		MOVi %2 #1 
 		MOVi %3 #0 
-		CALL &fYES %0 *4	; expects fYES(int, int, int) -> int
+		CALL &fYES %0 *4	; expects fYES(int, int, int) -> int @ 2244:33
 		POKE &NOVICE %0 
 		POKE &NEWLOC #1 	; global NEWLOC=1
 		MOVi $lLOC #1 	; lLOC=1
@@ -3982,14 +3982,14 @@ main:	FUNC	; signature func main() -> void
 		POKE &LIMIT #1000 	; global LIMIT=1000
 	.f0:	NOOP
 	L2:	PEEK %1 &NEWLOC 	; L2:
-		CALL &OUTSID %0 *2	; expects OUTSID(int) -> int
+		CALL &OUTSID %0 *2	; expects OUTSID(int) -> int @ 2253:34
 		EQUi %0 #FALSE @.f2
 		PEEK %0 &NEWLOC 
 		EQUi %0 #0 @.f2
 		PEEK %0 &CLOSNG 
 		EQUi %0 #FALSE @.f2
 		MOVi %1 #130 	; fRSPEAK(130)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2254:15
 		POKE &NEWLOC $lLOC 	; global NEWLOC=lLOC
 		PEEK %0 &PANIC 	; if(global PANIC == FALSE)global CLOCK2=15
 		NEQi %0 #FALSE @.f3
@@ -4001,7 +4001,7 @@ main:	FUNC	; signature func main() -> void
 		EQUi %0 #2 @.f5
 		MOVi %1 $lLOC 
 		MOVi %2 #3 
-		CALL &CNDBIT %0 *3	; expects CNDBIT(int, int) -> int
+		CALL &CNDBIT %0 *3	; expects CNDBIT(int, int) -> int @ 2264:85
 		NEQi %0 #FALSE @.f5
 		MOVi $I #1 	; for (I=1 to 5+1) 
 		! ADDi <A> #5 #1
@@ -4013,7 +4013,7 @@ main:	FUNC	; signature func main() -> void
 		EQUi %0 #FALSE @.f9
 		POKE &NEWLOC $lLOC 	; global NEWLOC=lLOC
 		MOVi %1 #2 	; fRSPEAK(2)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2268:15
 		GOTO @break1  	; goto break1
 	.f9:	FORi $I <A> @.l7	; } /* end loop */
 	break1:	NOOP
@@ -4023,30 +4023,30 @@ main:	FUNC	; signature func main() -> void
 		EQUi %0 #2 @L2000
 		PEEK %1 &NEWLOC 
 		MOVi %2 #3 
-		CALL &CNDBIT %0 *3	; expects CNDBIT(int, int) -> int
+		CALL &CNDBIT %0 *3	; expects CNDBIT(int, int) -> int @ 2287:80
 		EQUi %0 #FALSE @.f11
 		GOTO @L2000  	; goto L2000
 	.f11:	PEEK %0 &DFLAG 	; if(global DFLAG == 0) 
 		NEQi %0 #0 @.f12
 		MOVi %1 $lLOC 	; if((int)INDEEP(lLOC) != FALSE)global DFLAG=1
-		CALL &INDEEP %0 *2	; expects INDEEP(int) -> int
+		CALL &INDEEP %0 *2	; expects INDEEP(int) -> int @ 2289:24
 		EQUi %0 #FALSE @L2000
 		POKE &DFLAG #1 	; global DFLAG=1
 		GOTO @L2000  	; goto L2000
 	.f12:	PEEK %0 &DFLAG 	; if(global DFLAG == 1) 
 		NEQi %0 #1 @.f14
 		MOVi %1 $lLOC 	; if((int)INDEEP(lLOC) == FALSE || (((int)fRAN(100) < (95)) && ((int)CNDBIT(lLOC,4) == FALSE || ((int)fRAN(100) < (85))))) goto L2000
-		CALL &INDEEP %0 *2	; expects INDEEP(int) -> int
+		CALL &INDEEP %0 *2	; expects INDEEP(int) -> int @ 2297:24
 		EQUi %0 #FALSE @L2000
 		MOVi %1 #100 
-		CALL &fRAN %0 *2	; expects fRAN(int) -> int
+		CALL &fRAN %0 *2	; expects fRAN(int) -> int @ 2297:53
 		GEQi %0 #95 @.f18
 		MOVi %1 $lLOC 
 		MOVi %2 #4 
-		CALL &CNDBIT %0 *3	; expects CNDBIT(int, int) -> int
+		CALL &CNDBIT %0 *3	; expects CNDBIT(int, int) -> int @ 2297:85
 		EQUi %0 #FALSE @L2000
 		MOVi %1 #100 
-		CALL &fRAN %0 *2	; expects fRAN(int) -> int
+		CALL &fRAN %0 *2	; expects fRAN(int) -> int @ 2297:113
 		GEQi %0 #85 @.f18
 		GOTO @L2000  	; goto L2000
 	.f18:	POKE &DFLAG #2 	; global DFLAG=2
@@ -4054,10 +4054,10 @@ main:	FUNC	; signature func main() -> void
 		! ADDi <A> #2 #1
 		GEQi #1 <A> @.e19
 	.l20:	MOVi %1 #5 	; J=1+(int)fRAN(5)
-		CALL &fRAN %0 *2	; expects fRAN(int) -> int
+		CALL &fRAN %0 *2	; expects fRAN(int) -> int @ 2300:20
 		ADDi $J #1 %0
 		MOVi %1 #100 	; if(((int)fRAN(100) < (50)))global DLOC[J]=0
-		CALL &fRAN %0 *2	; expects fRAN(int) -> int
+		CALL &fRAN %0 *2	; expects fRAN(int) -> int @ 2301:23
 		GEQi %0 #50 @.f21
 		POKE &DLOC $J #0	; global DLOC[J]=0
 	.f21:	FORi $I <A> @.l20	; } /* end loop */
@@ -4071,10 +4071,10 @@ main:	FUNC	; signature func main() -> void
 		POKE &ODLOC $I %0
 		FORi $I <A> @.l23	; } /* end loop */
 	.e22:	MOVi %1 #3 	; fRSPEAK(3)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2307:13
 		MOVi %1 #AXE 	; fDROP(AXE,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 2308:18
 		GOTO @L2000  	; goto L2000
 	.f14:	POKE &DTOTAL #0 	; global DTOTAL=0
 		MOVi $ATTACK #0 	; ATTACK=0
@@ -4096,7 +4096,7 @@ main:	FUNC	; signature func main() -> void
 		PEEK %0 &NEWLOC 	; if(!(global NEWLOC > 300 || (int)INDEEP(global NEWLOC) == FALSE
 		GRTi %0 #300 @.f33
 		PEEK %1 &NEWLOC 
-		CALL &INDEEP %0 *2	; expects INDEEP(int) -> int
+		CALL &INDEEP %0 *2	; expects INDEEP(int) -> int @ 2330:61
 		EQUi %0 #FALSE @.f33
 		PEEK %0 &NEWLOC 
 		PEEK %1 &ODLOC $I
@@ -4116,7 +4116,7 @@ main:	FUNC	; signature func main() -> void
 		NEQi $I #6 @.f32
 		PEEK %1 &NEWLOC 
 		MOVi %2 #3 
-		CALL &CNDBIT %0 *3	; expects CNDBIT(int, int) -> int
+		CALL &CNDBIT %0 *3	; expects CNDBIT(int, int) -> int @ 2333:51
 		NEQi %0 #FALSE @.f33
 	.f32:	PEEK %0 &TRAVEL $KK
 		ABSi %0 %0 
@@ -4134,7 +4134,7 @@ main:	FUNC	; signature func main() -> void
 		LSSi $J #2 @.f34	; if(J >= 2)J=J-1
 		SUBi $J $J #1	; J=J-1
 	.f34:	MOVi %1 $J 	; J=1+(int)fRAN(J)
-		CALL &fRAN %0 *2	; expects fRAN(int) -> int
+		CALL &fRAN %0 *2	; expects fRAN(int) -> int @ 2342:20
 		ADDi $J #1 %0
 		PEEK %0 &DLOC $I	; global ODLOC[I]=global DLOC[I]
 		POKE &ODLOC $I %0
@@ -4143,7 +4143,7 @@ main:	FUNC	; signature func main() -> void
 		PEEK %0 &DSEEN $I	; if (((int)global DSEEN[I] != FALSE && (int)INDEEP(lLOC) != FALSE) || ((int)global DLOC[I] == lLOC || (int)global ODLOC[I] == lLOC)) 
 		EQUi %0 #FALSE @.f35
 		MOVi %1 $lLOC 
-		CALL &INDEEP %0 *2	; expects INDEEP(int) -> int
+		CALL &INDEEP %0 *2	; expects INDEEP(int) -> int @ 2345:60
 		NEQi %0 #FALSE @.t36
 	.f35:	PEEK %0 &DLOC $I
 		EQUi %0 $lLOC @.t36
@@ -4163,7 +4163,7 @@ main:	FUNC	; signature func main() -> void
 		LSSi %0 #0 @.f41
 		POKE &KNFLOC $lLOC 	; global KNFLOC=lLOC
 	.f41:	MOVi %1 #1000 	; if((int)fRAN(1000) < 95*(global DFLAG-2))STICK=STICK+1
-		CALL &fRAN %0 *2	; expects fRAN(int) -> int
+		CALL &fRAN %0 *2	; expects fRAN(int) -> int @ 2355:26
 		PEEK %1 &DFLAG 
 		SUBi %1 %1 #2
 		MULi %1 #95 %1
@@ -4183,18 +4183,18 @@ main:	FUNC	; signature func main() -> void
 		PEEK %0 &PLAC:EMRALD 
 		EQUi $lLOC %0 @.f50
 	.f48:	MOVi %1 $J 	; if((int)TOTING(J) != FALSE) 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2367:26
 		EQUi %0 #FALSE @.f50
 		PEEK %0 &PLACE:CHEST 	; if((int)global PLACE[CHEST] == 0) 
 		NEQi %0 #0 @.f52
 		MOVi %1 #CHEST 	; fMOVE(CHEST,CHLOC)
 		MOVi %2 #CHLOC 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 2370:28
 		MOVi %1 #MESSAG 	; fMOVE(MESSAG,CHLOC2)
 		MOVi %2 #CHLOC2 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 2371:30
 	.f52:	MOVi %1 #128 	; fRSPEAK(128)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2373:21
 		MOVi $J #50 	; for (J=50 to MAXTRS+1) 
 		! ADDi <C> #MAXTRS #1
 		GEQi #50 <C> @.e53
@@ -4205,19 +4205,19 @@ main:	FUNC	; signature func main() -> void
 		EQUi $lLOC %0 @.f57
 	.f55:	MOVi %1 $J 	; if((int)AT(J, lLOC) != FALSE && (int)global FIXED[J] == 0)fCARRY(J,lLOC)
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 2376:31
 		EQUi %0 #FALSE @.f59
 		PEEK %0 &FIXED $J
 		NEQi %0 #0 @.f59
 		MOVi %1 $J 	; fCARRY(J,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fCARRY %0 *3	; expects fCARRY(int, int) -> void
+		CALL &fCARRY %0 *3	; expects fCARRY(int, int) -> void @ 2376:83
 	.f59:	MOVi %1 $J 	; if((int)TOTING(J) != FALSE)fDROP(J,CHLOC)
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2377:29
 		EQUi %0 #FALSE @.f57
 		MOVi %1 $J 	; fDROP(J,CHLOC)
 		MOVi %2 #CHLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 2377:52
 	.f57:	FORi $J <C> @.l54	; }
 	.e53:	POKE &DLOC:6 #CHLOC 	; global DLOC[6]=CHLOC
 		POKE &ODLOC:6 #CHLOC 	; global ODLOC[6]=CHLOC
@@ -4225,7 +4225,7 @@ main:	FUNC	; signature func main() -> void
 		GOTO @L6030  	; goto L6030
 	.f50:	MOVi %1 $J 	; if((int)HERE(J, lLOC) != FALSE)lK=1
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2386:29
 		EQUi %0 #FALSE @.f61
 		MOVi $lK #1 	; lK=1
 	.f61:	FORi $J <B> @.l47	; } /* end loop */
@@ -4236,21 +4236,21 @@ main:	FUNC	; signature func main() -> void
 		NEQi %0 #0 @.f64
 		MOVi %1 #LAMP 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 2388:95
 		NEQi %0 #FALSE @.t63
 		MOVi %1 #LAMP 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2388:125
 		EQUi %0 #FALSE @.f64
 	.t63:	PEEK %0 &PROP:LAMP 
 		NEQi %0 #1 @.f64
 		MOVi %1 #186 	; fRSPEAK(186)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2389:19
 		MOVi %1 #CHEST 	; fMOVE(CHEST,CHLOC)
 		MOVi %2 #CHLOC 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 2390:25
 		MOVi %1 #MESSAG 	; fMOVE(MESSAG,CHLOC2)
 		MOVi %2 #CHLOC2 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 2391:27
 		POKE &DLOC:6 #CHLOC 	; global DLOC[6]=CHLOC
 		POKE &ODLOC:6 #CHLOC 	; global ODLOC[6]=CHLOC
 		POKE &DSEEN:6 #FALSE 	; global DSEEN[6]=FALSE
@@ -4259,10 +4259,10 @@ main:	FUNC	; signature func main() -> void
 		PEEK %1 &DLOC:6 
 		EQUi %0 %1 @.e68
 		MOVi %1 #100 
-		CALL &fRAN %0 *2	; expects fRAN(int) -> int
+		CALL &fRAN %0 *2	; expects fRAN(int) -> int @ 2396:73
 		GEQi %0 #20 @.e68
 		MOVi %1 #127 	; fRSPEAK(127)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2396:93
 	.e65:	NOOP
 	.e43:	GOTO @.e68  	; } else 
 	.f38:	POKE &DSEEN $I #FALSE	; global DSEEN[I]=FALSE
@@ -4274,11 +4274,11 @@ main:	FUNC	; signature func main() -> void
 		MOVi %1 #1 	; fSETPRM(1,global DTOTAL,0)
 		PEEK %2 &DTOTAL 
 		MOVi %3 #0 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 2411:29
 		PEEK %1 &DTOTAL 	; fRSPEAK(4+1/global DTOTAL)
 		DIVi %1 #1 %1
 		ADDi %1 #4 %1
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2412:29
 		EQUi $ATTACK #0 @.f69	; if(ATTACK != 0) 
 		PEEK %0 &DFLAG 	; if(global DFLAG == 2)global DFLAG=3
 		NEQi %0 #2 @.f71
@@ -4286,21 +4286,21 @@ main:	FUNC	; signature func main() -> void
 	.f71:	MOVi %1 #1 	; fSETPRM(1,ATTACK,0)
 		MOVi %2 $ATTACK 
 		MOVi %3 #0 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 2415:23
 		MOVi $lK #6 	; lK=6
 		LEQi $ATTACK #1 @.f72	; if(ATTACK > 1)lK=250
 		MOVi $lK #250 	; lK=250
 	.f72:	MOVi %1 $lK 	; fRSPEAK(lK)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2418:15
 		MOVi %1 #1 	; fSETPRM(1,STICK,0)
 		MOVi %2 $STICK 
 		MOVi %3 #0 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 2419:22
 		ADDi %1 #1 $STICK	; fRSPEAK(lK+1+2/(1+STICK))
 		ADDi %2 $lK #1
 		DIVi %1 #2 %1
 		ADDi %1 %2 %1
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2420:29
 		EQUi $STICK #0 @.f69	; if(STICK != 0) 
 		POKE &OLDLC2 $lLOC 	; global OLDLC2=lLOC
 		GOTO @L99  	; goto L99
@@ -4317,36 +4317,36 @@ main:	FUNC	; signature func main() -> void
 	.f76:	PEEK %0 &COND $lLOC	; if(!(((int)global COND[lLOC] == 2) || (int)DARK(lLOC) == FALSE)) 
 		EQUi %0 #2 @.f78
 		MOVi %1 $lLOC 
-		CALL &DARK %0 *2	; expects DARK(int) -> int
+		CALL &DARK %0 *2	; expects DARK(int) -> int @ 2437:56
 		EQUi %0 #FALSE @.f78
 		PEEK %0 &WZDARK 	; if(global WZDARK != FALSE && ((int)fRAN(100) < (35))) goto L90
 		EQUi %0 #FALSE @.f80
 		MOVi %1 #100 
-		CALL &fRAN %0 *2	; expects fRAN(int) -> int
+		CALL &fRAN %0 *2	; expects fRAN(int) -> int @ 2438:48
 		GEQi %0 #35 @.f80
 		GOTO @L90  	; goto L90
 	.f80:	PEEK $KK &RTEXT:16 	; KK=(int)global RTEXT[16]
 	.f78:	MOVi %1 #BEAR 	; if((int)TOTING(BEAR) != FALSE)fRSPEAK(141)
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2442:23
 		EQUi %0 #FALSE @.f81
 		MOVi %1 #141 	; fRSPEAK(141)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2442:44
 	.f81:	MOVi %1 $KK 	; fSPEAK(KK)
-		CALL &fSPEAK %0 *2	; expects fSPEAK(int) -> void
+		CALL &fSPEAK %0 *2	; expects fSPEAK(int) -> void @ 2443:12
 		MOVi $lK #1 	; lK=1
 		PEEK %0 &COND $lLOC	; if(((int)global COND[lLOC] == 2)) goto L8
 		NEQi %0 #2 @.f82
 		GOTO @L8  	; goto L8
 	.f82:	NEQi $lLOC #33 @.f84	; if(lLOC == 33 && ((int)fRAN(100) < (25)) && global CLOSNG == FALSE)fRSPEAK(7)
 		MOVi %1 #100 
-		CALL &fRAN %0 *2	; expects fRAN(int) -> int
+		CALL &fRAN %0 *2	; expects fRAN(int) -> int @ 2446:35
 		GEQi %0 #25 @.f84
 		PEEK %0 &CLOSNG 
 		NEQi %0 #FALSE @.f84
 		MOVi %1 #7 	; fRSPEAK(7)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2446:79
 	.f84:	MOVi %1 $lLOC 	; if((int)DARK(lLOC) != FALSE) goto L2012
-		CALL &DARK %0 *2	; expects DARK(int) -> int
+		CALL &DARK %0 *2	; expects DARK(int) -> int @ 2454:21
 		EQUi %0 #FALSE @.f85
 		GOTO @L2012  	; goto L2012
 	.f85:	PEEK %0 &ABB $lLOC	; global ABB[lLOC]=(int)global ABB[lLOC]+1
@@ -4360,7 +4360,7 @@ main:	FUNC	; signature func main() -> void
 		SUBi $lOBJ $lOBJ #100	; lOBJ=lOBJ-100
 	.f87:	NEQi $lOBJ #STEPS @.f88	; if(!(lOBJ == STEPS && (int)TOTING(NUGGET) != FALSE)) 
 		MOVi %1 #NUGGET 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2461:44
 		NEQi %0 #FALSE @.f89
 	.f88:	PEEK %0 &CLOSED 	; if(global CLOSED == FALSE || (int)global PROP[lOBJ] >= 0) 
 		EQUi %0 #FALSE @.t90
@@ -4384,13 +4384,13 @@ main:	FUNC	; signature func main() -> void
 		MOVi $KK #1 	; KK=1
 	.f97:	MOVi %1 $lOBJ 	; fPSPEAK(lOBJ,KK)
 		MOVi %2 $KK 
-		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void
+		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void @ 2481:20
 	.f89:	PEEK $I &LINK $I	; I=(int)global LINK[I]
 		GOTO @L2004  	; goto L2004
 	L2009:	MOVi $lK #54 	; L2009:
 	L2010:	POKE &SPK $lK 	; L2010:
 	L2011:	PEEK %1 &SPK 	; L2011:
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2493:21
 	L2012:	POKE &VERB #0 	; L2012:
 		MOVi $OLDOBJ $lOBJ 	; OLDOBJ=lOBJ
 		MOVi $lOBJ #0 	; lOBJ=0
@@ -4403,7 +4403,7 @@ main:	FUNC	; signature func main() -> void
 		NEQi %0 #FALSE @.f101
 		MOVi %1 $lLOC 	; if((int)CNDBIT(lLOC,HINT+10) == FALSE)global HINTLC[HINT]= -1
 		ADDi %2 $HINT #10
-		CALL &CNDBIT %0 *3	; expects CNDBIT(int, int) -> int
+		CALL &CNDBIT %0 *3	; expects CNDBIT(int, int) -> int @ 2509:34
 		NEQi %0 #FALSE @.f102
 		POKE &HINTLC $HINT #-1	; global HINTLC[HINT]= -1
 	.f102:	PEEK %0 &HINTLC $HINT	; global HINTLC[HINT]=(int)global HINTLC[HINT]+1
@@ -4420,28 +4420,28 @@ main:	FUNC	; signature func main() -> void
 		NEQi %1 #0 @L40020
 		MOVi %1 #KEYS 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 2526:67
 		NEQi %0 #FALSE @L40020
 		MOVi %1 #KEYS 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2526:97
 		EQUi %0 #FALSE @.e105
 		GOTO @L40020  	; goto L40020
 		GOTO @.e105  	; }
 	.s104#1:	PEEK %0 &PLACE:BIRD 	; if(!((int)global PLACE[BIRD] == lLOC && (int)TOTING(ROD) != FALSE && OLDOBJ == BIRD)) goto L2602
 		NEQi %0 $lLOC @L2602
 		MOVi %1 #ROD 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2530:65
 		EQUi %0 #FALSE @L2602
 		EQUi $OLDOBJ #BIRD @.e105
 		GOTO @L2602  	; goto L2602
 		GOTO @.e105  	; }
 	.s104#2:	MOVi %1 #SNAKE 	; if(!((int)HERE(SNAKE, lLOC) != FALSE && (int)HERE(BIRD, lLOC) == FALSE)) goto L40020
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2534:36
 		EQUi %0 #FALSE @L40020
 		MOVi %1 #BIRD 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2534:70
 		EQUi %0 #FALSE @.e105
 		GOTO @L40020  	; goto L40020
 		GOTO @.e105  	; }
@@ -4479,13 +4479,13 @@ main:	FUNC	; signature func main() -> void
 		GOTO @L2602  	; goto L2602
 		GOTO @.e105  	; }
 	.s104#8:	MOVi %1 $lLOC 	; I=(int)fATDWRF(lLOC)
-		CALL &fATDWRF %0 *2	; expects fATDWRF(int) -> int
+		CALL &fATDWRF %0 *2	; expects fATDWRF(int) -> int @ 2557:28
 		MOVi $I %0 
 		GEQi $I #0 @.f120	; if(I < 0) goto L40020
 		GOTO @L40020  	; goto L40020
 	.f120:	MOVi %1 #OGRE 	; if(!((int)HERE(OGRE, lLOC) != FALSE && I == 0)) goto L2602
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2559:35
 		EQUi %0 #FALSE @L2602
 		EQUi $I #0 @.e105
 		GOTO @L2602  	; goto L2602
@@ -4497,13 +4497,13 @@ main:	FUNC	; signature func main() -> void
 		GOTO @L40020  	; goto L40020
 		GOTO @.e105  	; }
 	.s104:	MOVi %1 #27 	; fBUG(27)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 2566:24
 	.e105:	MULi %1 $HINT #5	; if((int)fYES(global HINTS[HINT * 5 + 3],0,54) != FALSE) 
 		ADDi %1 %1 #3
 		PEEK %1 &HINTS %1
 		MOVi %2 #0 
 		MOVi %3 #54 
-		CALL &fYES %0 *4	; expects fYES(int, int, int) -> int
+		CALL &fYES %0 *4	; expects fYES(int, int, int) -> int @ 2569:52
 		EQUi %0 #FALSE @.f125
 		MOVi %1 #1 	; fSETPRM(1,global HINTS[HINT * 5 + 2],global HINTS[HINT * 5 + 2])
 		MULi %2 $HINT #5
@@ -4512,15 +4512,15 @@ main:	FUNC	; signature func main() -> void
 		MULi %3 $HINT #5
 		ADDi %3 %3 #2
 		PEEK %3 &HINTS %3
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 2570:71
 		MOVi %1 #261 	; fRSPEAK(261)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2571:19
 		MOVi %1 #175 	; global HINTED[HINT]=(int)fYES(175,global HINTS[HINT * 5 + 4],54)
 		MULi %2 $HINT #5
 		ADDi %2 %2 #4
 		PEEK %2 &HINTS %2
 		MOVi %3 #54 
-		CALL &fYES %0 *4	; expects fYES(int, int, int) -> int
+		CALL &fYES %0 *4	; expects fYES(int, int, int) -> int @ 2572:71
 		POKE &HINTED $HINT %0
 		PEEK %0 &HINTED $HINT	; if((int)global HINTED[HINT] != FALSE && global LIMIT > 30)global LIMIT=global LIMIT+30*(int)global HINTS[HINT * 5 + 2]
 		EQUi %0 #FALSE @.f125
@@ -4542,16 +4542,16 @@ main:	FUNC	; signature func main() -> void
 		PEEK %1 &PROP:OYSTER 	; if((int)global PROP[OYSTER] < 0 && (int)TOTING(OYSTER) != FALSE)fPSPEAK(OYSTER,1)
 		GEQi %1 #0 @.f130
 		MOVi %1 #OYSTER 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2591:58
 		EQUi %0 #FALSE @.f130
 		MOVi %1 #OYSTER 	; fPSPEAK(OYSTER,1)
 		MOVi %2 #1 
-		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void
+		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void @ 2591:84
 	.f130:	MOVi $I #1 	; for (I=1 to 100+1) 
 		! ADDi <A> #100 #1
 		GEQi #1 <A> @.f128
 	.l132:	MOVi %1 $I 	; if((int)TOTING(I) != FALSE && (int)global PROP[I] < 0)global PROP[I]= -1-(int)global PROP[I]
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2593:22
 		EQUi %0 #FALSE @.f134
 		PEEK %0 &PROP $I
 		GEQi %0 #0 @.f134
@@ -4560,7 +4560,7 @@ main:	FUNC	; signature func main() -> void
 		POKE &PROP $I %0
 	.f134:	FORi $I <A> @.l132	; } /* end loop */
 	.f128:	MOVi %1 $lLOC 	; global WZDARK=(int)DARK(lLOC)
-		CALL &DARK %0 *2	; expects DARK(int) -> int
+		CALL &DARK %0 *2	; expects DARK(int) -> int @ 2597:31
 		POKE &WZDARK %0 
 		PEEK %0 &KNFLOC 	; if(global KNFLOC > 0 && global KNFLOC != lLOC)global KNFLOC=0
 		LEQi %0 #0 @.f136
@@ -4568,13 +4568,13 @@ main:	FUNC	; signature func main() -> void
 		EQUi %0 $lLOC @.f136
 		POKE &KNFLOC #0 	; global KNFLOC=0
 	.f136:	MOVi %1 #1 	; I=(int)fRAN(1)
-		CALL &fRAN %0 *2	; expects fRAN(int) -> int
+		CALL &fRAN %0 *2	; expects fRAN(int) -> int @ 2599:16
 		MOVi $I %0 
 		MOVp %1 &WD1 	; fGETIN(&global WD1,&global WD1X,&global WD2,&global WD2X)
 		MOVp %2 &WD1X 
 		MOVp %3 &WD2 
 		MOVp %4 &WD2X 
-		CALL &fGETIN %0 *5	; expects fGETIN(ptr, ptr, ptr, ptr) -> void
+		CALL &fGETIN %0 *5	; expects fGETIN(ptr, ptr, ptr, ptr) -> void @ 2600:59
 	L2607:	PEEK %0 &FOOBAR 	; L2607:
 		LEQi %0 #0 @.f137
 		PEEK %0 &FOOBAR 	; global FOOBAR=-global FOOBAR
@@ -4590,7 +4590,7 @@ main:	FUNC	; signature func main() -> void
 		NEQi %0 %1 @.f139
 		PEEK %1 &TRNDEX 	; fSPEAK(global TTEXT[global TRNDEX])
 		PEEK %1 &TTEXT %1
-		CALL &fSPEAK %0 *2	; expects fSPEAK(int) -> void
+		CALL &fSPEAK %0 *2	; expects fSPEAK(int) -> void @ 2610:38
 		PEEK %0 &TRNDEX 	; global TRNLUZ=global TRNLUZ+(int)global TRNVAL[global TRNDEX]/100000
 		PEEK %0 &TRNVAL %0
 		PEEK %1 &TRNLUZ 
@@ -4620,7 +4620,7 @@ main:	FUNC	; signature func main() -> void
 	.f143:	PEEK %1 &TALLY 	; if(global TALLY == 0 && (int)INDEEP(lLOC) != FALSE && lLOC != 33) 
 		NEQi %1 #0 @.f145
 		MOVi %1 $lLOC 
-		CALL &INDEEP %0 *2	; expects INDEEP(int) -> int
+		CALL &INDEEP %0 *2	; expects INDEEP(int) -> int @ 2622:44
 		EQUi %0 #FALSE @.f145
 		EQUi $lLOC #33 @.f145
 		PEEK %0 &CLOCK1 	; global CLOCK1=global CLOCK1-1
@@ -4638,28 +4638,28 @@ main:	FUNC	; signature func main() -> void
 		FORi $I <A> @.l148	; } /* end loop */
 	.e147:	MOVi %1 #TROLL 	; fMOVE(TROLL,0)
 		MOVi %2 #0 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 2664:17
 		ADDi %1 #TROLL #100	; fMOVE(TROLL+100,0)
 		MOVi %2 #0 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 2665:21
 		MOVi %1 #TROLL2 	; fMOVE(TROLL2,global PLAC[TROLL])
 		PEEK %2 &PLAC:TROLL 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 2666:35
 		ADDi %1 #TROLL2 #100	; fMOVE(TROLL2+100,global FIXD[TROLL])
 		PEEK %2 &FIXD:TROLL 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 2667:39
 		MOVi %1 #CHASM 	; fJUGGLE(CHASM)
-		CALL &fJUGGLE %0 *2	; expects fJUGGLE(int) -> void
+		CALL &fJUGGLE %0 *2	; expects fJUGGLE(int) -> void @ 2668:17
 		PEEK %0 &PROP:BEAR 	; if((int)global PROP[BEAR] != 3)fDSTROY(BEAR)
 		EQUi %0 #3 @.f149
 		MOVi %1 #BEAR 	; fDSTROY(BEAR)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 2669:47
 	.f149:	POKE &PROP:CHAIN #0 	; global PROP[CHAIN]=0
 		POKE &FIXED:CHAIN #0 	; global FIXED[CHAIN]=0
 		POKE &PROP:AXE #0 	; global PROP[AXE]=0
 		POKE &FIXED:AXE #0 	; global FIXED[AXE]=0
 		MOVi %1 #129 	; fRSPEAK(129)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2674:15
 		POKE &CLOCK1 #-1 	; global CLOCK1= -1
 		POKE &CLOSNG #TRUE 	; global CLOSNG=TRUE
 		GOTO @.e150  	; } else 
@@ -4673,33 +4673,33 @@ main:	FUNC	; signature func main() -> void
 		MOVi %1 #BOTTLE 	; global PROP[BOTTLE]=(int)fPUT(BOTTLE,115,1)
 		MOVi %2 #115 
 		MOVi %3 #1 
-		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int
+		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int @ 2692:47
 		POKE &PROP:BOTTLE %0 
 		MOVi %1 #PLANT 	; global PROP[PLANT]=(int)fPUT(PLANT,115,0)
 		MOVi %2 #115 
 		MOVi %3 #0 
-		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int
+		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int @ 2693:45
 		POKE &PROP:PLANT %0 
 		MOVi %1 #OYSTER 	; global PROP[OYSTER]=(int)fPUT(OYSTER,115,0)
 		MOVi %2 #115 
 		MOVi %3 #0 
-		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int
+		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int @ 2694:47
 		POKE &PROP:OYSTER %0 
 		POKE &OBJTXT:OYSTER #3 	; global OBJTXT[OYSTER]=3
 		MOVi %1 #LAMP 	; global PROP[LAMP]=(int)fPUT(LAMP,115,0)
 		MOVi %2 #115 
 		MOVi %3 #0 
-		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int
+		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int @ 2696:43
 		POKE &PROP:LAMP %0 
 		MOVi %1 #ROD 	; global PROP[ROD]=(int)fPUT(ROD,115,0)
 		MOVi %2 #115 
 		MOVi %3 #0 
-		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int
+		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int @ 2697:41
 		POKE &PROP:ROD %0 
 		MOVi %1 #DWARF 	; global PROP[DWARF]=(int)fPUT(DWARF,115,0)
 		MOVi %2 #115 
 		MOVi %3 #0 
-		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int
+		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int @ 2698:45
 		POKE &PROP:DWARF %0 
 		MOVi $lLOC #115 	; lLOC=115
 		POKE &OLDLOC #115 	; global OLDLOC=115
@@ -4707,12 +4707,12 @@ main:	FUNC	; signature func main() -> void
 		MOVi %1 #GRATE 	; I=(int)fPUT(GRATE,116,0)
 		MOVi %2 #116 
 		MOVi %3 #0 
-		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int
+		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int @ 2705:28
 		MOVi $I %0 
 		MOVi %1 #gSIGN 	; I=(int)fPUT(gSIGN,116,0)
 		MOVi %2 #116 
 		MOVi %3 #0 
-		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int
+		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int @ 2706:28
 		MOVi $I %0 
 		PEEK %0 &OBJTXT:gSIGN 	; global OBJTXT[gSIGN]=(int)global OBJTXT[gSIGN]+1
 		ADDi %0 %0 #1
@@ -4720,45 +4720,45 @@ main:	FUNC	; signature func main() -> void
 		MOVi %1 #SNAKE 	; global PROP[SNAKE]=(int)fPUT(SNAKE,116,1)
 		MOVi %2 #116 
 		MOVi %3 #1 
-		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int
+		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int @ 2708:45
 		POKE &PROP:SNAKE %0 
 		MOVi %1 #BIRD 	; global PROP[BIRD]=(int)fPUT(BIRD,116,1)
 		MOVi %2 #116 
 		MOVi %3 #1 
-		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int
+		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int @ 2709:43
 		POKE &PROP:BIRD %0 
 		MOVi %1 #CAGE 	; global PROP[CAGE]=(int)fPUT(CAGE,116,0)
 		MOVi %2 #116 
 		MOVi %3 #0 
-		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int
+		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int @ 2710:43
 		POKE &PROP:CAGE %0 
 		MOVi %1 #ROD2 	; global PROP[ROD2]=(int)fPUT(ROD2,116,0)
 		MOVi %2 #116 
 		MOVi %3 #0 
-		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int
+		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int @ 2711:43
 		POKE &PROP:ROD2 %0 
 		MOVi %1 #PILLOW 	; global PROP[PILLOW]=(int)fPUT(PILLOW,116,0)
 		MOVi %2 #116 
 		MOVi %3 #0 
-		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int
+		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int @ 2712:47
 		POKE &PROP:PILLOW %0 
 		MOVi %1 #MIRROR 	; global PROP[MIRROR]=(int)fPUT(MIRROR,115,0)
 		MOVi %2 #115 
 		MOVi %3 #0 
-		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int
+		CALL &fPUT %0 *4	; expects fPUT(int, int, int) -> int @ 2714:47
 		POKE &PROP:MIRROR %0 
 		POKE &FIXED:MIRROR #116 	; global FIXED[MIRROR]=116
 		MOVi $I #1 	; for (I=1 to 100+1) 
 		! ADDi <A> #100 #1
 		GEQi #1 <A> @.e153
 	.l154:	MOVi %1 $I 	; if((int)TOTING(I) != FALSE)fDSTROY(I)
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2718:23
 		EQUi %0 #FALSE @.f155
 		MOVi %1 $I 	; fDSTROY(I)
-		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void
+		CALL &fDSTROY %0 *2	; expects fDSTROY(int) -> void @ 2718:42
 	.f155:	FORi $I <A> @.l154	; } /* end loop */
 	.e153:	MOVi %1 #132 	; fRSPEAK(132)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2721:16
 		POKE &CLOSED #TRUE 	; global CLOSED=TRUE
 		GOTO @L2  	; goto L2
 	.f152:	PEEK %0 &PROP:LAMP 	; if((int)global PROP[LAMP] == 1)global LIMIT=global LIMIT-1
@@ -4770,23 +4770,23 @@ main:	FUNC	; signature func main() -> void
 		GRTi %0 #30 @.f158
 		MOVi %1 #BATTER 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2726:52
 		EQUi %0 #FALSE @.f158
 		PEEK %0 &PROP:BATTER 
 		NEQi %0 #0 @.f158
 		MOVi %1 #LAMP 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2726:119
 		EQUi %0 #FALSE @.f158
 		MOVi %1 #188 	; fRSPEAK(188)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2733:16
 		POKE &PROP:BATTER #1 	; global PROP[BATTER]=1
 		MOVi %1 #BATTER 	; if((int)TOTING(BATTER) != FALSE)fDROP(BATTER,lLOC)
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2735:27
 		EQUi %0 #FALSE @.f159
 		MOVi %1 #BATTER 	; fDROP(BATTER,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 2735:54
 	.f159:	PEEK %0 &LIMIT 	; global LIMIT=global LIMIT+2500
 		ADDi %0 %0 #2500
 		POKE &LIMIT %0 
@@ -4798,10 +4798,10 @@ main:	FUNC	; signature func main() -> void
 		POKE &PROP:LAMP #0 	; global PROP[LAMP]=0
 		MOVi %1 #LAMP 	; if((int)HERE(LAMP, lLOC) != FALSE)fRSPEAK(184)
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2741:29
 		EQUi %0 #FALSE @.e163
 		MOVi %1 #184 	; fRSPEAK(184)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2741:50
 		GOTO @.e163  	; } else if(global LIMIT <= 30) 
 	.f161:	PEEK %0 &LIMIT 	; if(global LIMIT <= 30) 
 		GRTi %0 #30 @.f164
@@ -4809,7 +4809,7 @@ main:	FUNC	; signature func main() -> void
 		NEQi %0 #FALSE @.f164
 		MOVi %1 #LAMP 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2743:57
 		EQUi %0 #FALSE @.f164
 		POKE &LMWARN #TRUE 	; global LMWARN=TRUE
 		POKE &SPK #187 	; global SPK=187
@@ -4820,22 +4820,22 @@ main:	FUNC	; signature func main() -> void
 		NEQi %0 #1 @.f168
 		POKE &SPK #189 	; global SPK=189
 	.f168:	PEEK %1 &SPK 	; fRSPEAK(global SPK)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2748:24
 	.f164:	NOOP
 	.e163:	NOOP
 	.e160:	NOOP
 	.e150:	MOVi $lK #43 	; lK=43
 		MOVi %1 $lLOC 	; if((int)LIQLOC(lLOC) == WATER)lK=70
-		CALL &LIQLOC %0 *2	; expects LIQLOC(int) -> int
+		CALL &LIQLOC %0 *2	; expects LIQLOC(int) -> int @ 2754:23
 		NEQi %0 #WATER @.f169
 		MOVi $lK #70 	; lK=70
 	.f169:	PEEK %1 &WD1 	; V1=(int)fVOCAB(global WD1,-1)
 		MOVi %2 #-1 
-		CALL &fVOCAB %0 *3	; expects fVOCAB(int, int) -> int
+		CALL &fVOCAB %0 *3	; expects fVOCAB(int, int) -> int @ 2755:31
 		MOVi $V1 %0 
 		PEEK %1 &WD2 	; V2=(int)fVOCAB(global WD2,-1)
 		MOVi %2 #-1 
-		CALL &fVOCAB %0 *3	; expects fVOCAB(int, int) -> int
+		CALL &fVOCAB %0 *3	; expects fVOCAB(int, int) -> int @ 2756:31
 		MOVi $V2 %0 
 		NEQi $V1 #ENTER @.f172	; if(V1 == ENTER && (V2 == STREAM || V2 == 1000+WATER)) goto L2010
 		EQUi $V2 #STREAM @L2010
@@ -4858,10 +4858,10 @@ main:	FUNC	; signature func main() -> void
 		NEQi $V2 <A> @.f178
 	.f177:	SUBi %1 $V2 #1000	; if((int)AT(V2-1000, lLOC) != FALSE)global WD2=(int)fMAKEWD(16152118)
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 2760:29
 		EQUi %0 #FALSE @.f178
 		MOVi %1 #16152118 	; global WD2=(int)fMAKEWD(16152118)
-		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int
+		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int @ 2760:71
 		POKE &WD2 %0 
 	.f178:	NOOP
 		! ADDi <A> #1000 #CAGE	; if(V1 == 1000+CAGE && V2 == 1000+BIRD && (int)HERE(CAGE, lLOC) != FALSE && (int)HERE(BIRD, lLOC) != FALSE)global WD1=(int)fMAKEWD(301200308)
@@ -4870,18 +4870,18 @@ main:	FUNC	; signature func main() -> void
 		NEQi $V2 <A> @.f181
 		MOVi %1 #CAGE 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2762:65
 		EQUi %0 #FALSE @.f181
 		MOVi %1 #BIRD 
 		MOVi %2 $lLOC 
-		CALL &HERE %0 *3	; expects HERE(int, int) -> int
+		CALL &HERE %0 *3	; expects HERE(int, int) -> int @ 2762:99
 		EQUi %0 #FALSE @.f181
 		MOVi %1 #301200308 	; global WD1=(int)fMAKEWD(301200308)
-		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int
+		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int @ 2762:142
 		POKE &WD1 %0 
 	.f181:	NOOP
 	L2620:	MOVi %1 #23051920 	; L2620:
-		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int
+		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int @ 2764:41
 		PEEK %1 &WD1 
 		NEQi %1 %0 @.f182
 		PEEK %1 &IWEST 	; global IWEST=global IWEST+1
@@ -4890,9 +4890,9 @@ main:	FUNC	; signature func main() -> void
 		PEEK %1 &IWEST 	; if(global IWEST == 10)fRSPEAK(17)
 		NEQi %1 #10 @.f182
 		MOVi %1 #17 	; fRSPEAK(17)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2766:36
 	.f182:	MOVi %1 #715 	; if(!(global WD1 != (int)fMAKEWD( 715) || global WD2 == 0)) 
-		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int
+		CALL &fMAKEWD %0 *2	; expects fMAKEWD(int) -> int @ 2768:40
 		PEEK %1 &WD1 
 		NEQi %1 %0 @.f185
 		PEEK %1 &WD2 
@@ -4903,19 +4903,19 @@ main:	FUNC	; signature func main() -> void
 		PEEK %1 &IGO 	; if(global IGO == 10)fRSPEAK(276)
 		NEQi %1 #10 @.f185
 		MOVi %1 #276 	; fRSPEAK(276)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2770:35
 	.f185:	NOOP
 	L2630:	PEEK %1 &WD1 	; L2630:
 		MOVi %2 #-1 
-		CALL &fVOCAB %0 *3	; expects fVOCAB(int, int) -> int
+		CALL &fVOCAB %0 *3	; expects fVOCAB(int, int) -> int @ 2773:30
 		MOVi $I %0 
 		NEQi $I #-1 @.f187	; if(I == -1) 
 		MOVi %1 #1 	; fSETPRM(1,global WD1,global WD1X)
 		PEEK %2 &WD1 
 		PEEK %3 &WD1X 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 2777:36
 		MOVi %1 #254 	; fRSPEAK(254)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2778:15
 		GOTO @L2600  	; goto L2600
 	.f187:	MODi $lK $I #1000	; lK=((I)%1000)
 		DIVi %0 $I #1000	; KQ=I/1000+1
@@ -4933,7 +4933,7 @@ main:	FUNC	; signature func main() -> void
 	.s188#3:	GOTO @L2010  	; goto L2010
 	.s188:	NOOP
 	.e189:	MOVi %1 #22 	; fBUG(22)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 2789:10
 	L2800:	PEEK %0 &WD2 	; L2800:
 		POKE &WD1 %0 
 		PEEK %0 &WD2X 	; global WD1X=global WD2X
@@ -4944,7 +4944,7 @@ main:	FUNC	; signature func main() -> void
 		POKE &gOBJ $lOBJ 	; global gOBJ = lOBJ
 		POKE &gLOC $lLOC 	; global gLOC = lLOC
 		MOVi %1 $I 	; gotoChoice = (int)action(I)
-		CALL &action %0 *2	; expects action(int) -> int
+		CALL &action %0 *2	; expects action(int) -> int @ 2806:30
 		MOVi $gotoChoice %0 
 		PEEK $lK &gK 	; lK = global gK
 		PEEK $lOBJ &gOBJ 	; lOBJ = global gOBJ
@@ -4990,35 +4990,35 @@ main:	FUNC	; signature func main() -> void
 	.s190#<A>:	MOVi %1 #1 	; fSETPRM(1,global WD1,global WD1X)
 		PEEK %2 &WD1 
 		PEEK %3 &WD1X 
-		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void
+		CALL &fSETPRM %0 *4	; expects fSETPRM(int, int, int) -> void @ 2825:38
 		MOVi %1 #257 	; fRSPEAK(257)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2826:17
 		MOVi $lOBJ #0 	; lOBJ=0
 		GOTO @L2600  	; goto L2600
 		GOTO @.e191  	; }
 		! SUBi <A> #GOTO18999 #GOTO2	; case GOTO18999
 	.s190#<A>:	PEEK %1 &SPK 	; fRSPEAK(global SPK)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2834:24
 		MOVi %1 #136 	; fRSPEAK(136)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2835:17
 		MOVi %1 #0 	; score(0)
-		CALL &score %0 *2	; expects score(int) -> void
+		CALL &score %0 *2	; expects score(int) -> void @ 2836:13
 		GOTO @.e191  	; }
 		! SUBi <A> #GOTO19000 #GOTO2	; case GOTO19000
 	.s190#<A>:	MOVi %1 #136 	; fRSPEAK(136)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2840:17
 		MOVi %1 #0 	; score(0)
-		CALL &score %0 *2	; expects score(int) -> void
+		CALL &score %0 *2	; expects score(int) -> void @ 2841:13
 		GOTO @.e191  	; }
 	.s190:	MOVi %1 #-1 	; fBUG(-1)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 2843:23
 	.e191:	MOVi %1 #99 	; fBUG(99)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 2846:10
 	L8:	PEEK $KK &KEY $lLOC	; L8:
 		POKE &NEWLOC $lLOC 	; global NEWLOC=lLOC
 		NEQi $KK #0 @.f192	; if(KK == 0)fBUG(26)
 		MOVi %1 #26 	; fBUG(26)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 2859:21
 	.f192:	NEQi $lK #NUL @.f193	; if(lK == NUL) goto L2
 		GOTO @L2  	; goto L2
 	.f193:	NEQi $lK #BACK @.f194	; if(lK == BACK) 
@@ -5034,7 +5034,7 @@ main:	FUNC	; signature func main() -> void
 		MOVi $K2 #91 	; K2=91
 	.f196:	MOVi %1 $lLOC 	; if((int)CNDBIT(lLOC,4) != FALSE)K2=274
 		MOVi %2 #4 
-		CALL &CNDBIT %0 *3	; expects CNDBIT(int, int) -> int
+		CALL &CNDBIT %0 *3	; expects CNDBIT(int, int) -> int @ 2872:26
 		EQUi %0 #FALSE @.f197
 		MOVi $K2 #274 	; K2=274
 	.f197:	NEQi $K2 #0 @.f198	; if(K2 == 0) 
@@ -5064,18 +5064,18 @@ main:	FUNC	; signature func main() -> void
 		EQUi $KK #0 @.f204	; if(KK != 0) goto L25
 		GOTO @L25  	; goto L25
 	.f204:	MOVi %1 #140 	; fRSPEAK(140)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2889:17
 		GOTO @L2  	; goto L2
 	.f203:	ADDi $KK $KK #1	; KK=KK+1
 		GOTO @L21  	; goto L21
 	.f198:	MOVi %1 $K2 	; fRSPEAK(K2)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2895:14
 		GOTO @L2  	; goto L2
 	.f194:	NEQi $lK #LOOK @.f205	; if(lK == LOOK) 
 		PEEK %0 &DETAIL 	; if(global DETAIL < 3)fRSPEAK(15)
 		GEQi %0 #3 @.f206
 		MOVi %1 #15 	; fRSPEAK(15)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2902:35
 	.f206:	PEEK %0 &DETAIL 	; global DETAIL=global DETAIL+1
 		ADDi %0 %0 #1
 		POKE &DETAIL %0 
@@ -5085,12 +5085,12 @@ main:	FUNC	; signature func main() -> void
 	.f205:	NEQi $lK #CAVE @.f207	; if(lK == CAVE) 
 		MOVi $lK #58 	; lK=58
 		MOVi %1 $lLOC 	; if((int)OUTSID(lLOC) != FALSE && lLOC != 8)lK=57
-		CALL &OUTSID %0 *2	; expects OUTSID(int) -> int
+		CALL &OUTSID %0 *2	; expects OUTSID(int) -> int @ 2912:24
 		EQUi %0 #FALSE @.f209
 		EQUi $lLOC #8 @.f209
 		MOVi $lK #57 	; lK=57
 	.f209:	MOVi %1 $lK 	; fRSPEAK(lK)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2913:14
 		GOTO @L2  	; goto L2
 	.f207:	PEEK %0 &OLDLOC 	; global OLDLC2=global OLDLOC
 		POKE &OLDLC2 %0 
@@ -5128,7 +5128,7 @@ main:	FUNC	; signature func main() -> void
 	.f224:	NEQi $lK #17 @.f225	; if(lK == 17)global SPK=80
 		POKE &SPK #80 	; global SPK=80
 	.f225:	PEEK %1 &SPK 	; fRSPEAK(global SPK)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2934:23
 		GOTO @L2  	; goto L2
 	.f212:	ADDi $KK $KK #1	; KK=KK+1
 		GOTO @L9  	; goto L9
@@ -5149,7 +5149,7 @@ main:	FUNC	; signature func main() -> void
 	.l228:	PEEK %1 &TRAVEL $KK	; if((int)global TRAVEL[KK] < 0)fBUG(25)
 		GEQi %1 #0 @.f229
 		MOVi %1 #25 	; fBUG(25)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 2948:42
 	.f229:	ADDi $KK $KK #1	; KK=KK+1
 		PEEK %0 &TRAVEL $KK	; global NEWLOC=abs((int)global TRAVEL[KK])/1000
 		ABSi %0 %0 
@@ -5162,20 +5162,20 @@ main:	FUNC	; signature func main() -> void
 	.f226:	PEEK %0 &NEWLOC 	; if(global NEWLOC > 100) 
 		LEQi %0 #100 @.f230
 		MOVi %1 $lK 	; if((int)TOTING(lK) != FALSE || (global NEWLOC > 200 && (int)AT(lK, lLOC) != FALSE)) goto L16
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2957:22
 		NEQi %0 #FALSE @L16
 		PEEK %0 &NEWLOC 
 		LEQi %0 #200 @L12
 		MOVi %1 $lK 
 		MOVi %2 $lLOC 
-		CALL &AT %0 *3	; expects AT(int, int) -> int
+		CALL &AT %0 *3	; expects AT(int, int) -> int @ 2957:76
 		EQUi %0 #FALSE @L12
 		GOTO @L16  	; goto L16
 		GOTO @L12  	; goto L12
 	.f230:	PEEK %0 &NEWLOC 	; if(global NEWLOC != 0 && !((int)fRAN(100) < (global NEWLOC))) goto L12
 		EQUi %0 #0 @.f235
 		MOVi %1 #100 
-		CALL &fRAN %0 *2	; expects fRAN(int) -> int
+		CALL &fRAN %0 *2	; expects fRAN(int) -> int @ 2961:44
 		PEEK %1 &NEWLOC 
 		LSSi %0 %1 @.f235
 		GOTO @L12  	; goto L12
@@ -5189,7 +5189,7 @@ main:	FUNC	; signature func main() -> void
 		LEQi %0 #500 @.f237
 		PEEK %1 &NEWLOC 	; fRSPEAK(global NEWLOC-500)
 		SUBi %1 %1 #500
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2966:29
 		POKE &NEWLOC $lLOC 	; global NEWLOC=lLOC
 		GOTO @L2  	; goto L2
 	.f237:	PEEK %0 &NEWLOC 	; global NEWLOC=global NEWLOC-300
@@ -5207,17 +5207,17 @@ main:	FUNC	; signature func main() -> void
 		PEEK %0 &HOLDNG 
 		NEQi %0 #1 @.f242
 		MOVi %1 #EMRALD 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 2982:72
 		EQUi %0 #FALSE @.f242
 		GOTO @L2  	; goto L2
 	.f242:	POKE &NEWLOC $lLOC 	; global NEWLOC=lLOC
 		MOVi %1 #117 	; fRSPEAK(117)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 2984:16
 		GOTO @L2  	; goto L2
 		GOTO @.e239  	; }
 	.s238#1:	MOVi %1 #EMRALD 	; fDROP(EMRALD,lLOC)
 		MOVi %2 $lLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 2993:22
 		GOTO @L12  	; goto L12
 		GOTO @.e239  	; }
 	.s238#2:	PEEK %0 &PROP:TROLL 	; if((int)global PROP[TROLL] != 1) 
@@ -5231,16 +5231,16 @@ main:	FUNC	; signature func main() -> void
 		NEQi %0 #0 @.f244
 		POKE &PROP:TROLL #1 	; global PROP[TROLL]=1
 	.f244:	MOVi %1 #BEAR 	; if((int)TOTING(BEAR) == FALSE) goto L2
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 3007:26
 		NEQi %0 #FALSE @.f245
 		GOTO @L2  	; goto L2
 	.f245:	MOVi %1 #162 	; fRSPEAK(162)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 3008:17
 		POKE &PROP:CHASM #1 	; global PROP[CHASM]=1
 		POKE &PROP:TROLL #2 	; global PROP[TROLL]=2
 		MOVi %1 #BEAR 	; fDROP(BEAR,global NEWLOC)
 		PEEK %2 &NEWLOC 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 3011:30
 		POKE &FIXED:BEAR #-1 	; global FIXED[BEAR]= -1
 		POKE &PROP:BEAR #3 	; global PROP[BEAR]=3
 		PEEK %0 &NEWLOC 	; global OLDLC2=global NEWLOC
@@ -5248,39 +5248,39 @@ main:	FUNC	; signature func main() -> void
 		GOTO @L99  	; goto L99
 	.f243:	MOVi %1 #TROLL 	; fPSPEAK(TROLL,1)
 		MOVi %2 #1 
-		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void
+		CALL &fPSPEAK %0 *3	; expects fPSPEAK(int, int) -> void @ 3018:20
 		POKE &PROP:TROLL #0 	; global PROP[TROLL]=0
 		MOVi %1 #TROLL2 	; fMOVE(TROLL2,0)
 		MOVi %2 #0 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 3020:19
 		ADDi %1 #TROLL2 #100	; fMOVE(TROLL2+100,0)
 		MOVi %2 #0 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 3021:23
 		MOVi %1 #TROLL 	; fMOVE(TROLL,global PLAC[TROLL])
 		PEEK %2 &PLAC:TROLL 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 3022:35
 		ADDi %1 #TROLL #100	; fMOVE(TROLL+100,global FIXD[TROLL])
 		PEEK %2 &FIXD:TROLL 
-		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void
+		CALL &fMOVE %0 *3	; expects fMOVE(int, int) -> void @ 3023:39
 		MOVi %1 #CHASM 	; fJUGGLE(CHASM)
-		CALL &fJUGGLE %0 *2	; expects fJUGGLE(int) -> void
+		CALL &fJUGGLE %0 *2	; expects fJUGGLE(int) -> void @ 3024:18
 		POKE &NEWLOC $lLOC 	; global NEWLOC=lLOC
 		GOTO @L2  	; goto L2
 	.s238:	NOOP
 	.e239:	MOVi %1 #20 	; fBUG(20)
-		CALL &fBUG %0 *2	; expects fBUG(int) -> void
+		CALL &fBUG %0 *2	; expects fBUG(int) -> void @ 3029:10
 	L90:	MOVi %1 #23 	; L90:
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 3053:13
 		POKE &OLDLC2 $lLOC 	; global OLDLC2=lLOC
 	L99:	PEEK %0 &CLOSNG 	; L99:
 		EQUi %0 #FALSE @.f246
 		MOVi %1 #131 	; fRSPEAK(131)
-		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void
+		CALL &fRSPEAK %0 *2	; expects fRSPEAK(int) -> void @ 3061:15
 		PEEK %0 &NUMDIE 	; global NUMDIE=global NUMDIE+1
 		ADDi %0 %0 #1
 		POKE &NUMDIE %0 
 		MOVi %1 #0 	; score(0)
-		CALL &score %0 *2	; expects score(int) -> void
+		CALL &score %0 *2	; expects score(int) -> void @ 3063:11
 	.f246:	PEEK %0 &NUMDIE 	; global NUMDIE=global NUMDIE+1
 		ADDi %0 %0 #1
 		POKE &NUMDIE %0 
@@ -5291,19 +5291,19 @@ main:	FUNC	; signature func main() -> void
 		MULi %2 %2 #2
 		ADDi %2 #80 %2
 		MOVi %3 #54 
-		CALL &fYES %0 *4	; expects fYES(int, int, int) -> int
+		CALL &fYES %0 *4	; expects fYES(int, int, int) -> int @ 3066:57
 		NEQi %0 #FALSE @.f247
 		MOVi %1 #0 	; score(0)
-		CALL &score %0 *2	; expects score(int) -> void
+		CALL &score %0 *2	; expects score(int) -> void @ 3066:75
 	.f247:	PEEK %0 &NUMDIE 	; if(global NUMDIE == global MAXDIE) score(0)
 		PEEK %1 &MAXDIE 
 		NEQi %0 %1 @.f248
 		MOVi %1 #0 	; score(0)
-		CALL &score %0 *2	; expects score(int) -> void
+		CALL &score %0 *2	; expects score(int) -> void @ 3067:45
 	.f248:	POKE &PLACE:WATER #0 	; global PLACE[WATER]=0
 		POKE &PLACE:OIL #0 	; global PLACE[OIL]=0
 		MOVi %1 #LAMP 	; if((int)TOTING(LAMP) != FALSE)global PROP[LAMP]=0
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 3070:23
 		EQUi %0 #FALSE @.f249
 		POKE &PROP:LAMP #0 	; global PROP[LAMP]=0
 	.f249:	MOVi $J #1 	; for (J=1 to 100+1) 
@@ -5311,14 +5311,14 @@ main:	FUNC	; signature func main() -> void
 		GEQi #1 <A> @.e250
 	.l251:	SUBi $I #101 $J	; I=101-J
 		MOVi %1 $I 	; if((int)TOTING(I) != FALSE) 
-		CALL &TOTING %0 *2	; expects TOTING(int) -> int
+		CALL &TOTING %0 *2	; expects TOTING(int) -> int @ 3073:21
 		EQUi %0 #FALSE @.f252
 		PEEK $lK &OLDLC2 	; lK=global OLDLC2
 		NEQi $I #LAMP @.f253	; if(I == LAMP)lK=1
 		MOVi $lK #1 	; lK=1
 	.f253:	MOVi %1 $I 	; fDROP(I,lK)
 		MOVi %2 $lK 
-		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void
+		CALL &fDROP %0 *3	; expects fDROP(int, int) -> void @ 3076:15
 	.f252:	FORi $J <A> @.l251	; } /* end loop */
 	.e250:	MOVi $lLOC #3 	; lLOC=3
 		POKE &OLDLOC $lLOC 	; global OLDLOC=lLOC

--- a/tests/impala/golden/adventData.gazl
+++ b/tests/impala/golden/adventData.gazl
@@ -1,7 +1,7 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PTEXT:	CNST *101	; signature array PTEXT[101] : unknown
+PTEXT:	CNST *101	; signature array PTEXT[101] : unknown @ 1:27
 	DATA #0 #4954 #4967 #4987 #5000 #5015 #5032 #5049 #5069
 	DATA #5253 #5282 #5295 #5320 #5342 #5382 #5412 #5480 #0 #0
 	DATA #5529 #5537 #5563 #5568 #5573 #5578 #5704 #5749 #5755
@@ -12,7 +12,7 @@ PTEXT:	CNST *101	; signature array PTEXT[101] : unknown
 	DATA #6753 #6791 #6814 #6829 #6856 #6883 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #6869
-RTEXT:	CNST *278	; signature array RTEXT[278] : unknown
+RTEXT:	CNST *278	; signature array RTEXT[278] : unknown @ 10:27
 	DATA #0 #6898 #7057 #7068 #7094 #7108 #7121 #7130 #7137
 	DATA #7141 #7144 #7159 #7183 #7193 #7199 #7209 #7232 #7247
 	DATA #7258 #7266 #7288 #7299 #7334 #7342 #7354 #7361 #7367
@@ -48,10 +48,10 @@ RTEXT:	CNST *278	; signature array RTEXT[278] : unknown
 	DATA #11702 #11718 #11740 #11755 #11768 #11782 #11800
 	DATA #11807 #11821 #11892 #11906 #11945 #12030 #12034
 	DATA #12049 #12072 #12095 #12200 #0
-CTEXT:	CNST *13	; signature array CTEXT[13] : unknown
+CTEXT:	CNST *13	; signature array CTEXT[13] : unknown @ 30:26
 	DATA #0 #12228 #12241 #12253 #12266 #12278 #12287 #12298
 	DATA #12309 #12320 #12334 #0 #0
-STEXT:	CNST *186	; signature array STEXT[186] : unknown
+STEXT:	CNST *186	; signature array STEXT[186] : unknown @ 33:27
 	DATA #0 #4446 #4453 #4459 #4465 #4470 #4476 #4481 #4488
 	DATA #4494 #4500 #4506 #0 #4512 #4518 #4525 #0 #4531 #4539
 	DATA #4546 #0 #0 #0 #4553 #4561 #4566 #0 #4571 #4579 #0
@@ -67,7 +67,7 @@ STEXT:	CNST *186	; signature array STEXT[186] : unknown
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #4923 #4928 #4935 #0 #0
 	DATA #4942 #0 #0 #0 #4948 #0 #0 #0 #0 #0 #0 #0 #0 #0
-LTEXT:	CNST *186	; signature array LTEXT[186] : unknown
+LTEXT:	CNST *186	; signature array LTEXT[186] : unknown @ 47:27
 	DATA #0 #1 #35 #65 #78 #96 #111 #140 #167 #205 #231 #254
 	DATA #307 #318 #357 #384 #457 #481 #511 #533 #552 #564
 	DATA #569 #575 #601 #626 #653 #667 #681 #702 #710 #734
@@ -88,7 +88,7 @@ LTEXT:	CNST *186	; signature array LTEXT[186] : unknown
 	DATA #4018 #4029 #4040 #4051 #4062 #4073 #4084 #4095 #4106
 	DATA #4141 #4184 #4206 #4220 #4234 #4291 #4302 #4332 #4376
 	DATA #4401 #4408 #4422 #4426 #4430 #4434 #4438 #4442 #0
-KEY:	CNST *186	; signature array KEY[186] : unknown
+KEY:	CNST *186	; signature array KEY[186] : unknown @ 61:25
 	DATA #0 #1 #16 #23 #30 #41 #49 #53 #68 #80 #89 #98 #111
 	DATA #120 #128 #139 #155 #156 #165 #168 #181 #182 #183
 	DATA #184 #191 #193 #197 #198 #207 #214 #217 #222 #224
@@ -108,7 +108,7 @@ KEY:	CNST *186	; signature array KEY[186] : unknown
 	DATA #822 #826 #830 #834 #838 #839 #841 #848 #852 #856
 	DATA #860 #863 #864 #865 #869 #872 #873 #874 #875 #876
 	DATA #877 #878 #0
-LOCSND:	CNST *186	; signature array LOCSND[186] : unknown
+LOCSND:	CNST *186	; signature array LOCSND[186] : unknown @ 75:28
 	DATA #0 #229 #0 #229 #229 #0 #0 #229 #0 #0 #0 #0 #0 #0 #0
 	DATA #230 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #229 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
@@ -121,7 +121,7 @@ LOCSND:	CNST *186	; signature array LOCSND[186] : unknown
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #-237 #249 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0
-LINES:	CNST *12501	; signature array LINES[12501] : unknown
+LINES:	CNST *12501	; signature array LINES[12501] : unknown @ 89:29
 	DATA #0 #-16 #1003128965 #1486677452 #1371620026
 	DATA #1626797244 #2024080985 #885817003 #213802728
 	DATA #1002977874 #1257601629 #1327983606 #1692522683
@@ -3007,14 +3007,14 @@ LINES:	CNST *12501	; signature array LINES[12501] : unknown
 	DATA #2130257097 #924009373 #1108161291 #1275306106
 	DATA #1373674633 #1676893552 #1758580913 #-1 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
-CVAL:	CNST *13	; signature array CVAL[13] : unknown
+CVAL:	CNST *13	; signature array CVAL[13] : unknown @ 873:25
 	DATA #0 #45 #120 #170 #250 #320 #375 #410 #426 #429 #9999
 	DATA #0 #0
-TTEXT:	CNST *6	; signature array TTEXT[6] : unknown
+TTEXT:	CNST *6	; signature array TTEXT[6] : unknown @ 876:25
 	DATA #0 #12393 #12415 #12427 #12442 #0
-TRNVAL:	CNST *6	; signature array TRNVAL[6] : unknown
+TRNVAL:	CNST *6	; signature array TRNVAL[6] : unknown @ 879:26
 	DATA #0 #200350 #300500 #501000 #1002500 #0
-TRAVEL:	CNST *886	; signature array TRAVEL[886] : unknown
+TRAVEL:	CNST *886	; signature array TRAVEL[886] : unknown @ 882:28
 	DATA #0 #2002 #2044 #2029 #3003 #3012 #3019 #3043 #4005
 	DATA #4013 #4014 #4046 #4030 #145006 #145045 #-8063 #1012
 	DATA #1043 #5044 #164045 #157046 #157006 #-580030 #1011
@@ -3155,7 +3155,7 @@ TRAVEL:	CNST *886	; signature array TRAVEL[886] : unknown
 	DATA #-1 #-176001 #173056 #173030 #177047 #-177017 #176049
 	DATA #176011 #-176017 #-1 #-11001 #-3001 #-33001 #-3001
 	DATA #-100001 #-33001 #0 #0 #0 #0 #0 #0 #0
-KTAB:	CNST *331	; signature array KTAB[331] : unknown
+KTAB:	CNST *331	; signature array KTAB[331] : unknown @ 940:26
 	DATA #0 #2 #2 #3 #4 #5 #6 #7 #7 #7 #8 #8 #8 #9 #10 #11 #11
 	DATA #11 #11 #12 #12 #13 #14 #15 #16 #17 #18 #19 #19 #19
 	DATA #20 #21 #21 #22 #23 #23 #24 #25 #26 #27 #28 #29 #29
@@ -3189,7 +3189,7 @@ KTAB:	CNST *331	; signature array KTAB[331] : unknown
 	DATA #3050 #3050 #3050 #3050 #3051 #3051 #3054 #3064 #3064
 	DATA #3066 #3066 #3068 #3069 #3079 #3139 #3142 #3142 #3147
 	DATA #3246 #3271 #3275 #-1 #0 #0 #0 #0
-PLAC:	CNST *101	; signature array PLAC[101] : unknown
+PLAC:	CNST *101	; signature array PLAC[101] : unknown @ 963:26
 	DATA #0 #3 #3 #8 #10 #11 #0 #14 #13 #94 #96 #19 #17 #101
 	DATA #103 #0 #106 #0 #0 #3 #3 #0 #0 #109 #25 #23 #111 #35
 	DATA #0 #97 #0 #119 #117 #117 #0 #130 #0 #126 #140 #0 #96
@@ -3198,7 +3198,7 @@ PLAC:	CNST *101	; signature array PLAC[101] : unknown
 	DATA #0 #0 #167 #177 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0
-FIXD:	CNST *101	; signature array FIXD[101] : unknown
+FIXD:	CNST *101	; signature array FIXD[101] : unknown @ 972:26
 	DATA #0 #0 #0 #9 #0 #0 #0 #15 #0 #-1 #0 #-1 #27 #-1 #0 #0
 	DATA #0 #-1 #0 #0 #0 #0 #0 #-1 #-1 #67 #-1 #110 #0 #-1 #-1
 	DATA #121 #122 #122 #0 #-1 #-1 #-1 #-1 #0 #-1 #-1 #-1 #-1
@@ -3206,12 +3206,12 @@ FIXD:	CNST *101	; signature array FIXD[101] : unknown
 	DATA #0 #0 #121 #0 #-1 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0
-ACTSPK:	CNST *36	; signature array ACTSPK[36] : unknown
+ACTSPK:	CNST *36	; signature array ACTSPK[36] : unknown @ 981:27
 	DATA #0 #24 #29 #0 #33 #0 #33 #195 #195 #42 #14 #43 #110
 	DATA #29 #110 #73 #75 #29 #61 #59 #59 #174 #109 #67 #61
 	DATA #147 #155 #195 #146 #110 #61 #61 #14 #195 #42 #61
 	! MULi <A> #21 #5
-HINTS:	CNST *<A>	; signature array HINTS[<A>] : unknown
+HINTS:	CNST *<A>	; signature array HINTS[<A>] : unknown @ 986:30
 	DATA #0 #0 #0 #0 #0 #0 #4 #2 #62 #63 #0 #5 #2 #18 #19 #0
 	DATA #8 #2 #20 #21 #0 #75 #4 #176 #177 #0 #25 #5 #178 #179
 	DATA #0 #20 #3 #180 #181 #0 #8 #2 #243 #244 #0 #25 #2 #247

--- a/tests/impala/golden/beatrick_code.gazl
+++ b/tests/impala/golden/beatrick_code.gazl
@@ -1,25 +1,25 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 20:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 21:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 29:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 29:33
 	DATA &.s_MUTEst4d2 &.s_REPEAT4d3 &.s_SKIPst4d4
 	DATA &.s_HOLDst4d5 &.s_ACCENT4d6 &.s_STUTTE4d7
 	DATA &.s_REVERS4d8 &.s_TAPEST4d9
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 41:1
+; signature extern native trace() -> unknown @ 42:1
+; signature extern native yield() -> unknown @ 43:1
+; signature extern native write() -> unknown @ 44:1
+; signature extern native read() -> unknown @ 46:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 68:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 69:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 70:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 71:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 72:1
 	CNST *1
 	! SHLi <A> #1 #OPERATOR_1_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_1_HIGH_PARAM_INDEX
@@ -32,37 +32,37 @@ signal:	GLOB *2	; signature array signal[2] : unknown
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #OPERAND_2_LOW_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
-NOP:	! DEFi #0	; signature const NOP : int
-MUTE:	! DEFi #1	; signature const MUTE : int
-REPEAT:	! DEFi #2	; signature const REPEAT : int
-SKIP:	! DEFi #3	; signature const SKIP : int
-HOLD:	! DEFi #4	; signature const HOLD : int
-ACCENT:	! DEFi #1	; signature const ACCENT : int
-STUTTER:	! DEFi #2	; signature const STUTTER : int
-REVERSE:	! DEFi #3	; signature const REVERSE : int
-TAPE_STOP:	! DEFi #4	; signature const TAPE_STOP : int
-LOOKAHEAD:	! DEFi #0x80	; signature const LOOKAHEAD : int
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 81:1
+NOP:	! DEFi #0	; signature const NOP : int @ 82:1
+MUTE:	! DEFi #1	; signature const MUTE : int @ 83:1
+REPEAT:	! DEFi #2	; signature const REPEAT : int @ 84:1
+SKIP:	! DEFi #3	; signature const SKIP : int @ 85:1
+HOLD:	! DEFi #4	; signature const HOLD : int @ 86:1
+ACCENT:	! DEFi #1	; signature const ACCENT : int @ 87:1
+STUTTER:	! DEFi #2	; signature const STUTTER : int @ 88:1
+REVERSE:	! DEFi #3	; signature const REVERSE : int @ 89:1
+TAPE_STOP:	! DEFi #4	; signature const TAPE_STOP : int @ 91:1
+LOOKAHEAD:	! DEFi #0x80	; signature const LOOKAHEAD : int @ 95:1
 	GLOB *1
-bottomOperator:	DATi #0	; signature global bottomOperator : int
-steps:	GLOB *16	; signature array steps[16] : unknown
-gains:	GLOB *16	; signature array gains[16] : unknown
-holds:	GLOB *16	; signature array holds[16] : unknown
-sfxs:	GLOB *16	; signature array sfxs[16] : unknown
+bottomOperator:	DATi #0	; signature global bottomOperator : int @ 96:1
+steps:	GLOB *16	; signature array steps[16] : unknown @ 97:1
+gains:	GLOB *16	; signature array gains[16] : unknown @ 97:23
+holds:	GLOB *16	; signature array holds[16] : unknown @ 98:23
+sfxs:	GLOB *16	; signature array sfxs[16] : unknown @ 99:22
 	GLOB *1
-lastInStep:	DATi #-1	; signature global lastInStep : int
+lastInStep:	DATi #-1	; signature global lastInStep : int @ 101:1
 	GLOB *1
-currentOutStep:	DATi #0	; signature global currentOutStep : int
+currentOutStep:	DATi #0	; signature global currentOutStep : int @ 102:1
 	GLOB *1
-stopIndex:	DATi #0	; signature global stopIndex : int
+stopIndex:	DATi #0	; signature global stopIndex : int @ 103:1
 	GLOB *1
-stopRate:	DATi #0	; signature global stopRate : int
+stopRate:	DATi #0	; signature global stopRate : int @ 104:1
 	GLOB *1
-currentGain:	DATi #0	; signature global currentGain : int
+currentGain:	DATi #0	; signature global currentGain : int @ 108:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 108:16
 ;-----------------------------------------------------------------------------
 		POKE &lastInStep #-1 	; global lastInStep = -1
 		POKE &currentGain #0x10000 	; global currentGain = 0x10000
@@ -71,7 +71,7 @@ reset:	FUNC	; signature func reset() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 114:17
 	$topOperator:	LOCi
 	$bottomOperator:	LOCi
 	$topBits:	LOCi
@@ -174,7 +174,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 178:18
 	$localClock:	LOCi
 	$inStep:	LOCi
 	$outStep:	LOCi
@@ -199,7 +199,7 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $localClock 	; write(localClock, 1, localSignal)
 		MOVi %2 #1 
 		ADRL %3 $localSignal *0
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 189:36
 	.f0:	PEEK %0 &lastInStep 	; if (global lastInStep != inStep) 
 		EQUi %0 $inStep @.f1
 		PEEK %0 &steps $inStep	; global currentOutStep = (int) global steps[inStep]
@@ -216,7 +216,7 @@ process:	FUNC	; signature func process() -> void
 		IORi %1 $i %1
 		MOVi %2 #1 
 		ADRL %3 $localSignal *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 199:49
 		GOTO @.e3  	; } else 
 	.f2:	PEEK %0 &bottomOperator 	; switch (global bottomOperator == 0 to 5) 
 		SWCH %0 *5 @.s4
@@ -225,13 +225,13 @@ process:	FUNC	; signature func process() -> void
 		ADDi %1 $i %1
 		MOVi %2 #1 
 		ADRL %3 $localSignal *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 202:80
 		GOTO @.e5  
 	.s4#STUTTER:	ANDi %1 $localClock #0x3FF	; read(i | (localClock & 0x3FF), 1, localSignal)
 		IORi %1 $i %1
 		MOVi %2 #1 
 		ADRL %3 $localSignal *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 203:64
 		GOTO @.e5  
 	.s4#TAPE_STOP:	MOVi $si #0x0 	; si = 0x0
 		MOVi $sr #0x10000 	; sr = 0x10000
@@ -243,7 +243,7 @@ process:	FUNC	; signature func process() -> void
 		IORi %1 $i %1
 		MOVi %2 #2 
 		ADRL %3 $localSignal *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 211:41
 		ANDi $f $si #0xFFFF	; f = si & 0xFFFF
 		SUBi %0 $localSignal:2 $localSignal:0	; localSignal[0] = (int) localSignal[0] + (((int) localSignal[2] - (int) localSignal[0]) * f >> 16)
 		MULi %0 %0 $f

--- a/tests/impala/golden/bender_code.gazl
+++ b/tests/impala/golden/bender_code.gazl
@@ -1,25 +1,25 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 10:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 11:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 13:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 13:33
 	DATA &.s_BITSCL4d2 &.s_SINSAM4d3 &.s_ROTSRA4d4
 	DATA &.s_DLYLEF4d5 &.s_SHARPS4d6 &.s_SHARPF4d7
 	DATA &.s_SMOOTH4d8 &.s_SMOOTH4d9
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 25:1
+; signature extern native trace() -> unknown @ 26:1
+; signature extern native yield() -> unknown @ 27:1
+; signature extern native write() -> unknown @ 28:1
+; signature extern native read() -> unknown @ 30:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 49:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 50:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 51:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 52:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 53:1
 	CNST *1
 	! SHLi <A> #1 #OPERATOR_1_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_1_HIGH_PARAM_INDEX
@@ -32,8 +32,8 @@ signal:	GLOB *2	; signature array signal[2] : unknown
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #OPERAND_2_LOW_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
-EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 58:1
+EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown @ 58:41
 	DATA #0x0 #0x1 #0x2 #0x3 #0x4 #0x5 #0x6 #0x7 #0x8 #0x9
 	DATA #0xa #0xb #0xc #0xd #0xe #0xf #0x10 #0x11 #0x12 #0x13
 	DATA #0x14 #0x15 #0x16 #0x17 #0x18 #0x19 #0x1a #0x1b #0x1c
@@ -68,30 +68,30 @@ EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unkn
 	DATA #0x7c00 #0x8000 #0x8800 #0x9000 #0x9800 #0xa000
 	DATA #0xa800 #0xb000 #0xb800 #0xc000 #0xc800 #0xd000
 	DATA #0xd800 #0xe000 #0xe800 #0xf000 #0xffff
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 80:1
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 81:1
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 82:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 83:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 84:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 85:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 86:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 88:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 88:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 90:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 91:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 94:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -105,16 +105,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 101:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4da 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 104:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float)trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 105:35
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -122,7 +122,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 119:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -131,7 +131,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 123:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -154,73 +154,73 @@ cos:	FUNC	; signature func cos(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sin:	FUNC	; signature func sin(float x) -> float
+sin:	FUNC	; signature func sin(float x) -> float @ 135:14
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		SUBf %1 $x #HALF_PI	; y = (float) cos(x - HALF_PI)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 138:30
 		MOVf $y %0 
 		RETU   	; }
 
-CURVE_SIZE_BITS:	! DEFi #4	; signature const CURVE_SIZE_BITS : int
+CURVE_SIZE_BITS:	! DEFi #4	; signature const CURVE_SIZE_BITS : int @ 144:1
 	! SHLi <A> #1 #CURVE_SIZE_BITS
-CURVE_SIZE:	! DEFi <A>	; signature const CURVE_SIZE : int
+CURVE_SIZE:	! DEFi <A>	; signature const CURVE_SIZE : int @ 145:1
 	! ADDi <A> #CURVE_SIZE #1
-CURVE_SIZE_PLUS_1:	! DEFi <A>	; signature const CURVE_SIZE_PLUS_1 : int
+CURVE_SIZE_PLUS_1:	! DEFi <A>	; signature const CURVE_SIZE_PLUS_1 : int @ 146:1
 	! SUBi <A> #12 #CURVE_SIZE_BITS
-CURVE_SHIFT:	! DEFi <A>	; signature const CURVE_SHIFT : int
+CURVE_SHIFT:	! DEFi <A>	; signature const CURVE_SHIFT : int @ 147:1
 	! XORi <A> #0 #-1
 	! SHLi <A> <A> #CURVE_SHIFT
 	! XORi <A> <A> #-1
-CURVE_FRACTION_MASK:	! DEFi <A>	; signature const CURVE_FRACTION_MASK : int
+CURVE_FRACTION_MASK:	! DEFi <A>	; signature const CURVE_FRACTION_MASK : int @ 148:1
 	! SHLi <A> #1 #CURVE_SHIFT
-CURVE_STEP_SIZE:	! DEFi <A>	; signature const CURVE_STEP_SIZE : int
+CURVE_STEP_SIZE:	! DEFi <A>	; signature const CURVE_STEP_SIZE : int @ 149:1
 	! iTOf <A> #CURVE_STEP_SIZE #1.0
 	! DIVf <A> #1.0 <A>
-STEP_TO_FLOAT_SCALE:	! DEFf <A>	; signature const STEP_TO_FLOAT_SCALE : float
-NO_SHAPER:	! DEFi #0	; signature const NO_SHAPER : int
-LINEAR_SHAPER:	! DEFi #1	; signature const LINEAR_SHAPER : int
-QUADRATIC_SHAPER:	! DEFi #2	; signature const QUADRATIC_SHAPER : int
-SHAPER_COUNT:	! DEFi #3	; signature const SHAPER_COUNT : int
-BIT_CRUSH:	! DEFi #1	; signature const BIT_CRUSH : int
-SINE_SHAPE:	! DEFi #2	; signature const SINE_SHAPE : int
-SPIN:	! DEFi #3	; signature const SPIN : int
-STEREO_DELAY:	! DEFi #4	; signature const STEREO_DELAY : int
-OPERATOR_SHAPERS:	CNST *5	; signature array OPERATOR_SHAPERS[5] : unknown
+STEP_TO_FLOAT_SCALE:	! DEFf <A>	; signature const STEP_TO_FLOAT_SCALE : float @ 149:64
+NO_SHAPER:	! DEFi #0	; signature const NO_SHAPER : int @ 152:1
+LINEAR_SHAPER:	! DEFi #1	; signature const LINEAR_SHAPER : int @ 153:1
+QUADRATIC_SHAPER:	! DEFi #2	; signature const QUADRATIC_SHAPER : int @ 154:1
+SHAPER_COUNT:	! DEFi #3	; signature const SHAPER_COUNT : int @ 155:1
+BIT_CRUSH:	! DEFi #1	; signature const BIT_CRUSH : int @ 156:1
+SINE_SHAPE:	! DEFi #2	; signature const SINE_SHAPE : int @ 157:1
+SPIN:	! DEFi #3	; signature const SPIN : int @ 158:1
+STEREO_DELAY:	! DEFi #4	; signature const STEREO_DELAY : int @ 160:1
+OPERATOR_SHAPERS:	CNST *5	; signature array OPERATOR_SHAPERS[5] : unknown @ 160:36
 	DATA #NO_SHAPER #LINEAR_SHAPER #LINEAR_SHAPER
 	DATA #QUADRATIC_SHAPER #QUADRATIC_SHAPER
-sinTable:	GLOB *0x1000	; signature array sinTable[0x1000] : unknown
-linCurveA:	GLOB *CURVE_SIZE	; signature array linCurveA[CURVE_SIZE] : unknown
-linCurveB:	GLOB *CURVE_SIZE	; signature array linCurveB[CURVE_SIZE] : unknown
-quadCurveA:	GLOB *CURVE_SIZE_PLUS_1	; signature array quadCurveA[CURVE_SIZE_PLUS_1] : unknown
-quadCurveB:	GLOB *CURVE_SIZE_PLUS_1	; signature array quadCurveB[CURVE_SIZE_PLUS_1] : unknown
-quadCurveC:	GLOB *CURVE_SIZE_PLUS_1	; signature array quadCurveC[CURVE_SIZE_PLUS_1] : unknown
+sinTable:	GLOB *0x1000	; signature array sinTable[0x1000] : unknown @ 165:1
+linCurveA:	GLOB *CURVE_SIZE	; signature array linCurveA[CURVE_SIZE] : unknown @ 166:1
+linCurveB:	GLOB *CURVE_SIZE	; signature array linCurveB[CURVE_SIZE] : unknown @ 167:1
+quadCurveA:	GLOB *CURVE_SIZE_PLUS_1	; signature array quadCurveA[CURVE_SIZE_PLUS_1] : unknown @ 168:1
+quadCurveB:	GLOB *CURVE_SIZE_PLUS_1	; signature array quadCurveB[CURVE_SIZE_PLUS_1] : unknown @ 169:1
+quadCurveC:	GLOB *CURVE_SIZE_PLUS_1	; signature array quadCurveC[CURVE_SIZE_PLUS_1] : unknown @ 170:1
 	GLOB *1
-op1:	DATi #-1	; signature global op1 : int
+op1:	DATi #-1	; signature global op1 : int @ 171:1
 	GLOB *1
-shaper:	DATi #0	; signature global shaper : int
+shaper:	DATi #0	; signature global shaper : int @ 172:1
 	GLOB *1
-op1Stuff:	DATi #0	; signature global op1Stuff : int
+op1Stuff:	DATi #0	; signature global op1Stuff : int @ 173:1
 	GLOB *1
-spinXOrR:	DATi #0	; signature global spinXOrR : int
+spinXOrR:	DATi #0	; signature global spinXOrR : int @ 174:1
 	GLOB *1
-biasL:	DATi #0	; signature global biasL : int
+biasL:	DATi #0	; signature global biasL : int @ 175:1
 	GLOB *1
-biasR:	DATi #0	; signature global biasR : int
+biasR:	DATi #0	; signature global biasR : int @ 176:1
 	GLOB *1
-delayL:	DATi #0	; signature global delayL : int
+delayL:	DATi #0	; signature global delayL : int @ 177:1
 	GLOB *1
-delayR:	DATi #0	; signature global delayR : int
+delayR:	DATi #0	; signature global delayR : int @ 178:1
 	GLOB *1
-lastOp1Param:	DATi #-1	; signature global lastOp1Param : int
+lastOp1Param:	DATi #-1	; signature global lastOp1Param : int @ 179:1
 	GLOB *1
-lastOp2:	DATi #-1	; signature global lastOp2 : int
+lastOp2:	DATi #-1	; signature global lastOp2 : int @ 180:1
 	GLOB *1
-lastShaperBits:	DATi #-1	; signature global lastShaperBits : int
+lastShaperBits:	DATi #-1	; signature global lastShaperBits : int @ 187:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 187:15
 	$i:	LOCi
 	$s:	LOCi
 ;-----------------------------------------------------------------------------
@@ -230,7 +230,7 @@ init:	FUNC	; signature func init() -> void
 		! MULf <A> #2.0 #PI	; s = ftoi(floor(0.5 + itof(0x800) * (float) sin(2.0 * PI / 4096.0 * itof(i))))
 		! DIVf <A> <A> #4096.0
 		iTOf %1 $i <A>
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 191:78
 		! iTOf <A> #0x800 #1.0
 		MULf %0 <A> %0
 		ADDf %0 #0.5 %0
@@ -249,7 +249,7 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 202:17
 	! ADDi <A> #CURVE_SIZE_PLUS_1 #3
 	$params:	LOCA *PARAM_COUNT
 	$quadPoints:	LOCA *<A>
@@ -419,7 +419,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 296:18
 	$localSignal:	LOCA *2
 	$left:	LOCi
 	$right:	LOCi
@@ -513,11 +513,11 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $localClock 	; write(localClock, 1, localSignal)
 		MOVi %2 #1 
 		ADRL %3 $localSignal *0
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 347:37
 		SUBi %1 $localClock $localDelayR	; read(localClock - localDelayR, 1, localSignal)
 		MOVi %2 #1 
 		ADRL %3 $localSignal *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 348:50
 		MOVi $left $localSignal:0 	; left = (int) localSignal[0]
 		MOVi $right $localSignal:1 	; right = (int) localSignal[1]
 		SWCH $localOp1 *5 @.s7	; switch (localOp1 == 0 to 5) 
@@ -558,7 +558,7 @@ process:	FUNC	; signature func process() -> void
 	.s7#STEREO_DELAY:	SUBi %1 $localClock $localDelayL	; read(localClock - localDelayL, 1, localSignal)
 		MOVi %2 #1 
 		ADRL %3 $localSignal *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 373:52
 		MOVi $left $localSignal:0 	; left = (int) localSignal[0]
 	.s7:	NOOP
 	.e8:	LEQi $left $peak @.f9	; if (left > peak) peak = left
@@ -621,7 +621,7 @@ process:	FUNC	; signature func process() -> void
 	.s13:	NOOP
 	.e14:	POKE &signal:0 $left 	; global signal[0] = left
 		POKE &signal:1 $right 	; global signal[1] = right
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 407:11
 		ADDi %0 $localClock $clockDir	; localClock = (localClock + clockDir) & 0xFFFF
 		ANDi $localClock %0 #0xFFFF
 		FORi $innerLoopIndex #64 @.l6	; }

--- a/tests/impala/golden/bitbox_code.gazl
+++ b/tests/impala/golden/bitbox_code.gazl
@@ -1,24 +1,24 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 10:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 11:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 13:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 13:33
 	DATA &.s_A4d2 &.s_BBASSD4d3 &.s_C4d4 &.s_D4d5 &.s_A4d2
 	DATA &.s_BHIHAT4d6 &.s_CSNARE4d7 &.s_D4d5
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 25:1
+; signature extern native trace() -> unknown @ 26:1
+; signature extern native yield() -> unknown @ 27:1
+; signature extern native write() -> unknown @ 28:1
+; signature extern native read() -> unknown @ 30:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 49:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 50:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 51:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 52:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 53:1
 	CNST *1
 	! SHLi <A> #1 #OPERATOR_1_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_1_HIGH_PARAM_INDEX
@@ -31,13 +31,13 @@ signal:	GLOB *2	; signature array signal[2] : unknown
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #OPERAND_2_LOW_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
-SOUNDS_COUNT:	! DEFi #4	; signature const SOUNDS_COUNT : int
-DRUM_COUNT:	! DEFi #3	; signature const DRUM_COUNT : int
-DRUM_PARAM_COUNT:	! DEFi #8	; signature const DRUM_PARAM_COUNT : int
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 122:1
+SOUNDS_COUNT:	! DEFi #4	; signature const SOUNDS_COUNT : int @ 122:27
+DRUM_COUNT:	! DEFi #3	; signature const DRUM_COUNT : int @ 123:25
+DRUM_PARAM_COUNT:	! DEFi #8	; signature const DRUM_PARAM_COUNT : int @ 124:31
 	! MULi <A> #DRUM_COUNT #SOUNDS_COUNT
 	! MULi <A> <A> #DRUM_PARAM_COUNT
-DRUM_PARAMS:	CNST *<A>	; signature array DRUM_PARAMS[<A>] : unknown
+DRUM_PARAMS:	CNST *<A>	; signature array DRUM_PARAMS[<A>] : unknown @ 128:74
 	DATA #435 #94 #75535 #0 #0 #0 #0 #1523 #773 #136 #52429 #0
 	DATA #0 #0 #0 #523 #556 #58 #65535 #0 #0 #0 #0 #780 #267
 	DATA #10 #35643 #0 #0 #0 #0 #500 #0 #0 #0 #32790 #5233
@@ -48,11 +48,11 @@ DRUM_PARAMS:	CNST *<A>	; signature array DRUM_PARAMS[<A>] : unknown
 	DATA #28459 #0 #459 #23332 #34147 #2513 #897 #99 #57673
 	DATA #23423 #24248 #14417 #57671 #6000 #802 #80 #53255
 	DATA #29321 #42598 #1311 #58496 #3522
-stepSounds:	GLOB *16	; signature array stepSounds[16] : unknown
+stepSounds:	GLOB *16	; signature array stepSounds[16] : unknown @ 153:28
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 170:17
 	$operand1Bits:	LOCi
 	$operand2Bits:	LOCi
 	$drumSounds:	LOCA *DRUM_COUNT
@@ -97,7 +97,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 201:18
 	$rnd:	LOCi
 	$rndXor:	LOCi
 	$rndAdd:	LOCi
@@ -200,8 +200,8 @@ process:	FUNC	; signature func process() -> void
 		PEEK %1 &clock 	; write(global clock, 1, global signal)
 		MOVi %2 #1 
 		MOVp %3 &signal 
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 252:41
+		CALL ^yield %0 *1	; expects function() -> unknown @ 253:11
 		PEEK %0 &signal:0 	; global signal[0] = (((int) global signal[0] * pump) >> 12) + y
 		MULi %0 %0 $pump
 		SHRi %0 %0 #12
@@ -215,8 +215,8 @@ process:	FUNC	; signature func process() -> void
 		PEEK %1 &clock 	; write(global clock, 1, global signal)
 		MOVi %2 #1 
 		MOVp %3 &signal 
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 256:41
+		CALL ^yield %0 *1	; expects function() -> unknown @ 257:11
 		ADDi $pump $pump #0x2	; pump = pump + 0x2
 		LEQi $pump #0x1000 @.f10	; if (pump > 0x1000) pump = 0x1000
 		MOVi $pump #0x1000 	; pump = 0x1000

--- a/tests/impala/golden/bitztest_code.gazl
+++ b/tests/impala/golden/bitztest_code.gazl
@@ -1,30 +1,30 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_Sillyr4d2 &.s_4d3 &.s_4d3 &.s_LEFTDE4d4 &.s_4d3
 	DATA &.s_4d3 &.s_4d3 &.s_RINGMO4d5
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 81:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 82:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
+instance:	DATi #0	; signature global instance : int @ 83:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 85:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 99:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 99:15
 	$i:	LOCi
 	$buf:	LOCA *256
 ;-----------------------------------------------------------------------------
@@ -33,24 +33,24 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 108:16
 ;-----------------------------------------------------------------------------
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 116:17
 	$buf:	LOCA *256
 	$params:	LOCA *PARAM_COUNT
 ;-----------------------------------------------------------------------------
 		RETU   	; }
 
-f:	! DEFi #0x309977	; signature const f : int
+f:	! DEFi #0x309977	; signature const f : int @ 121:23
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 138:18
 	$t:	LOCi
 	$u:	LOCi
 	$v:	LOCi
@@ -86,7 +86,7 @@ process:	FUNC	; signature func process() -> void
 	.e1:	SHRi $y $y #20	; global signal[0] = (y = y >> 20)
 		POKE &signal:0 $y 
 		POKE &signal:1 $y 	; global signal[1] = y
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 152:10
 		ADDi $t $t #1	; t = t + 1
 		GOTO @.l0  	; }
 		RETU   	; }

--- a/tests/impala/golden/buffer.gazl
+++ b/tests/impala/golden/buffer.gazl
@@ -1,50 +1,50 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-PANEL_TEXT_ROWS:	CNST *8	; signature array PANEL_TEXT_ROWS[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 8:1
+PANEL_TEXT_ROWS:	CNST *8	; signature array PANEL_TEXT_ROWS[8] : unknown @ 16:35
 	DATA &.s_ABC8884d2 &.s_ABC8884d2 &.s_RM4d3 &.s_AMRATE4d4
 	DATA &.s_notuse4d5 &.s_toollo4d6 &.s_74d7 &.s_ILOVEP4d8
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
+; signature extern native abort() -> unknown @ 28:1
+; signature extern native trace() -> unknown @ 30:1
 	GLOB *1
-left:	DATf #0.0	; signature global left : float
+left:	DATf #0.0	; signature global left : float @ 50:1
 	GLOB *1
-right:	DATf #0.0	; signature global right : float
+right:	DATf #0.0	; signature global right : float @ 51:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
+clock:	DATi #0	; signature global clock : int @ 52:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 53:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+instance:	DATi #0	; signature global instance : int @ 57:1
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 58:1
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 59:1
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 60:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 61:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 62:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 63:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
-SQRT_2:	! DEFf #1.41421356237309504880	; signature const SQRT_2 : float
-EPSILON_FLOAT:	! DEFf #1.0e-45	; signature const EPSILON_FLOAT : float
-SMALL_FLOAT:	! DEFf #1.0e-5	; signature const SMALL_FLOAT : float
-LARGE_FLOAT:	! DEFf #1.0e+10	; signature const LARGE_FLOAT : float
-HUGE_FLOAT:	! DEFf #1.0e+38	; signature const HUGE_FLOAT : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 64:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 65:1
+SQRT_2:	! DEFf #1.41421356237309504880	; signature const SQRT_2 : float @ 67:1
+EPSILON_FLOAT:	! DEFf #1.0e-45	; signature const EPSILON_FLOAT : float @ 68:1
+SMALL_FLOAT:	! DEFf #1.0e-5	; signature const SMALL_FLOAT : float @ 69:1
+LARGE_FLOAT:	! DEFf #1.0e+10	; signature const LARGE_FLOAT : float @ 70:1
+HUGE_FLOAT:	! DEFf #1.0e+38	; signature const HUGE_FLOAT : float @ 72:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 72:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 74:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 75:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 78:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -58,16 +58,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 85:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4d9 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 88:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float) trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 89:36
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -75,7 +75,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 103:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -84,7 +84,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 107:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -107,18 +107,18 @@ cos:	FUNC	; signature func cos(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sin:	FUNC	; signature func sin(float x) -> float
+sin:	FUNC	; signature func sin(float x) -> float @ 120:14
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		SUBf %1 $x #HALF_PI	; y = (float) cos(x - HALF_PI)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 123:30
 		MOVf $y %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr
+intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr @ 131:22
 	$i:	INPi
 	$radix:	INPi
 	$minLength:	INPi
@@ -168,7 +168,7 @@ intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, 
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr buffer) -> ptr
+floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr buffer) -> ptr @ 150:24
 	$f:	INPf
 	$precision:	INPi
 	$buffer:	INPp
@@ -305,7 +305,7 @@ floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr b
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInt:	FUNC	; signature func traceInt(int i) -> void
+traceInt:	FUNC	; signature func traceInt(int i) -> void @ 259:19
 	$i:	INPi
 	! MULi <A> #8 #GAZL_WORD_SIZE
 	! ADDi <A> <A> #2
@@ -315,58 +315,58 @@ traceInt:	FUNC	; signature func traceInt(int i) -> void
 		MOVi %3 #10 
 		MOVi %4 #1 
 		ADRL %5 $buffer *0
-		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr @ 262:37
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 262:38
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceFloat:	FUNC	; signature func traceFloat(float f) -> void
+traceFloat:	FUNC	; signature func traceFloat(float f) -> void @ 265:21
 	$f:	INPf
 	$buffer:	LOCA *32
 ;-----------------------------------------------------------------------------
 		MOVf %2 $f 	; trace(floatToString(f, 6, buffer))
 		MOVi %3 #6 
 		ADRL %4 $buffer *0
-		CALL &floatToString %1 *4	; expects floatToString(float, int, ptr) -> ptr
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL &floatToString %1 *4	; expects floatToString(float, int, ptr) -> ptr @ 268:35
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 268:36
 		RETU   	; }
 
-BUFFER_SIZE:	! DEFi #256	; signature const BUFFER_SIZE : int
+BUFFER_SIZE:	! DEFi #256	; signature const BUFFER_SIZE : int @ 274:1
 	GLOB *1
-lpx:	DATf #0.0	; signature global lpx : float
+lpx:	DATf #0.0	; signature global lpx : float @ 275:1
 	GLOB *1
-lpy:	DATf #0.0	; signature global lpy : float
+lpy:	DATf #0.0	; signature global lpy : float @ 276:1
 	GLOB *1
-rpx:	DATf #0.0	; signature global rpx : float
+rpx:	DATf #0.0	; signature global rpx : float @ 277:1
 	GLOB *1
-rpy:	DATf #0.0	; signature global rpy : float
+rpy:	DATf #0.0	; signature global rpy : float @ 278:1
 	GLOB *1
-lrx:	DATf #0.0	; signature global lrx : float
+lrx:	DATf #0.0	; signature global lrx : float @ 279:1
 	GLOB *1
-lry:	DATf #0.0	; signature global lry : float
+lry:	DATf #0.0	; signature global lry : float @ 280:1
 	GLOB *1
-rrx:	DATf #0.0	; signature global rrx : float
+rrx:	DATf #0.0	; signature global rrx : float @ 281:1
 	GLOB *1
-rry:	DATf #0.0	; signature global rry : float
+rry:	DATf #0.0	; signature global rry : float @ 282:1
 	! MULi <A> #2 #BUFFER_SIZE
-buffer:	GLOB *<A>	; signature array buffer[<A>] : unknown
+buffer:	GLOB *<A>	; signature array buffer[<A>] : unknown @ 283:1
 	GLOB *1
-bufferPointer:	DATp &buffer	; signature global bufferPointer : ptr
+bufferPointer:	DATp &buffer	; signature global bufferPointer : ptr @ 290:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 290:15
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4dd 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 292:15
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 299:16
 	$a:	LOCf
 	$lr:	LOCf
 	$rr:	LOCf
@@ -375,7 +375,7 @@ reset:	FUNC	; signature func reset() -> void
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4de 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 302:16
 		MOVf $a #0.5 	; a = 0.5
 		! MULf <A> #TWICE_PI #440.0	; lr = TWICE_PI * 440.0 / 44100.0
 		! DIVf <A> <A> #44100.0
@@ -385,36 +385,36 @@ reset:	FUNC	; signature func reset() -> void
 		MOVf $rr <A> 
 		MOVf $p0 #0.0 	; p0 = 0.0
 		MOVf %1 $p0 	; global lpx = (float) cos(p0) * a
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 307:31
 		MULf %0 %0 $a
 		POKE &lpx %0 
 		MOVf %1 $p0 	; global lpy = (float) sin(p0) * a
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 308:31
 		MULf %0 %0 $a
 		POKE &lpy %0 
 		MULf %1 $lr #0.5	; t = SQRT_2 * (float) sin(lr * 0.5)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 309:36
 		MULf $t #SQRT_2 %0
 		MULf %0 $t $t	; global lrx = t * t
 		POKE &lrx %0 
 		MOVf %1 $lr 	; global lry = (float) sin(lr)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 311:30
 		POKE &lry %0 
 		MOVf %1 $p0 	; global rpx = (float) cos(p0) * a
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 312:31
 		MULf %0 %0 $a
 		POKE &rpx %0 
 		MOVf %1 $p0 	; global rpy = (float) sin(p0) * a
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 313:31
 		MULf %0 %0 $a
 		POKE &rpy %0 
 		MULf %1 $rr #0.5	; t = SQRT_2 * (float) sin(rr * 0.5)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 314:36
 		MULf $t #SQRT_2 %0
 		MULf %0 $t $t	; global rrx = t * t
 		POKE &rrx %0 
 		MOVf %1 $rr 	; global rry = (float) sin(rr)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 316:30
 		POKE &rry %0 
 		POKE &bufferPointer &buffer 	; global bufferPointer = global buffer
 		RETU   	; }
@@ -422,14 +422,14 @@ reset:	FUNC	; signature func reset() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 324:17
 ;-----------------------------------------------------------------------------
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 338:18
 	$nx:	LOCf
 	$lpx:	LOCf
 	$lpy:	LOCf

--- a/tests/impala/golden/calc.gazl
+++ b/tests/impala/golden/calc.gazl
@@ -1,40 +1,40 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-; signature extern native output() -> unknown
-; signature extern native input() -> unknown
-; signature extern native abort() -> unknown
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-PARENTHESIS_PRECEDENCE:	! DEFi #0	; signature const PARENTHESIS_PRECEDENCE : int
-BITWISE_PRECEDENCE:	! DEFi #1	; signature const BITWISE_PRECEDENCE : int
-ADD_SUB_PRECEDENCE:	! DEFi #2	; signature const ADD_SUB_PRECEDENCE : int
-MUL_DIV_PRECEDENCE:	! DEFi #3	; signature const MUL_DIV_PRECEDENCE : int
-PREFIX_PRECEDENCE:	! DEFi #4	; signature const PREFIX_PRECEDENCE : int
-POW_PRECEDENCE:	! DEFi #5	; signature const POW_PRECEDENCE : int
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+; signature extern native output() -> unknown @ 9:21
+; signature extern native input() -> unknown @ 10:20
+; signature extern native abort() -> unknown @ 11:20
+FALSE:	! DEFi #0	; signature const FALSE : int @ 13:20
+TRUE:	! DEFi #1	; signature const TRUE : int @ 14:19
+PARENTHESIS_PRECEDENCE:	! DEFi #0	; signature const PARENTHESIS_PRECEDENCE : int @ 16:37
+BITWISE_PRECEDENCE:	! DEFi #1	; signature const BITWISE_PRECEDENCE : int @ 17:33
+ADD_SUB_PRECEDENCE:	! DEFi #2	; signature const ADD_SUB_PRECEDENCE : int @ 18:33
+MUL_DIV_PRECEDENCE:	! DEFi #3	; signature const MUL_DIV_PRECEDENCE : int @ 19:33
+PREFIX_PRECEDENCE:	! DEFi #4	; signature const PREFIX_PRECEDENCE : int @ 20:32
+POW_PRECEDENCE:	! DEFi #5	; signature const POW_PRECEDENCE : int @ 21:29
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 22:42
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 23:43
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 24:44
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 25:39
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 26:45
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 27:40
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 28:32
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 29:33
 	GLOB *1
-lastError:	DATp &NULL	; signature global lastError : ptr
+lastError:	DATp &NULL	; signature global lastError : ptr @ 31:25
 	! SUBi <A> #'z' #'a'
 	! ADDi <A> <A> #1
-memoryUsed:	GLOB *<A>	; signature array memoryUsed[<A>] : unknown
+memoryUsed:	GLOB *<A>	; signature array memoryUsed[<A>] : unknown @ 33:39
 	! SUBi <A> #'z' #'a'
 	! ADDi <A> <A> #1
-memory:	GLOB *<A>	; signature array memory[<A>] : unknown
+memory:	GLOB *<A>	; signature array memory[<A>] : unknown @ 34:35
 	GLOB *1
-lastResult:	DATf #0.0	; signature global lastResult : float
+lastResult:	DATf #0.0	; signature global lastResult : float @ 35:30
 
 ;-----------------------------------------------------------------------------
 	$d:	OUTi
-strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int
+strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int @ 37:17
 	$s0:	INPp
 	$s1:	INPp
 	$a:	LOCp
@@ -56,7 +56,7 @@ strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 49:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		PEEK %0 &lastError 	; if (global lastError == null) global lastError = s
@@ -67,7 +67,7 @@ error:	FUNC	; signature func error(ptr s) -> void
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-exp:	FUNC	; signature func exp(float x) -> float
+exp:	FUNC	; signature func exp(float x) -> float @ 79:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -91,7 +91,7 @@ exp:	FUNC	; signature func exp(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-log:	FUNC	; signature func log(float x) -> float
+log:	FUNC	; signature func log(float x) -> float @ 112:14
 	$x:	INPf
 	$a:	LOCf
 	$b:	LOCf
@@ -102,7 +102,7 @@ log:	FUNC	; signature func log(float x) -> float
 		LEQf $x #0.0 @.t0	; if (x <= 0.0 || x >= 1.0e38) error("Domain error")
 		LSSf $x #1.0e38 @.f1
 	.t0:	MOVp %1 &.s_Domain4d2 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 120:52
 		GOTO @.e2  
 	.f1:	MOVf $b #0.0 	; b = 0.0
 		MOVf $m $x 	; m = x
@@ -131,29 +131,29 @@ log:	FUNC	; signature func log(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-log2:	FUNC	; signature func log2(float x) -> float
+log2:	FUNC	; signature func log2(float x) -> float @ 140:15
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; y = (float) log(x) * LOG2R
-		CALL &log %0 *2	; expects log(float) -> float
+		CALL &log %0 *2	; expects log(float) -> float @ 143:21
 		MULf $y %0 #LOG2R
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-log10:	FUNC	; signature func log10(float x) -> float
+log10:	FUNC	; signature func log10(float x) -> float @ 146:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; y = (float) log(x) * LOG10R
-		CALL &log %0 *2	; expects log(float) -> float
+		CALL &log %0 *2	; expects log(float) -> float @ 149:21
 		MULf $y %0 #LOG10R
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 152:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -167,16 +167,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 159:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4d3 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 162:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float) trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 163:36
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -184,7 +184,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 177:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -193,7 +193,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 184:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -216,38 +216,38 @@ cos:	FUNC	; signature func cos(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sin:	FUNC	; signature func sin(float x) -> float
+sin:	FUNC	; signature func sin(float x) -> float @ 198:14
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		SUBf %1 $x #HALF_PI	; y = (float) cos(x - HALF_PI)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 201:30
 		MOVf $y %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-tan:	FUNC	; signature func tan(float x) -> float
+tan:	FUNC	; signature func tan(float x) -> float @ 204:14
 	$x:	INPf
 	$c:	LOCf
 ;-----------------------------------------------------------------------------
 		MOVf $y #0.0 	; y = 0.0
 		MOVf %1 $x 	; c = (float) cos(x)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 209:20
 		MOVf $c %0 
 		NEQf $c #0.0 @.f0	; if (c == 0.0) error("Domain error")
 		MOVp %1 &.s_Domain4d2 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 210:37
 		GOTO @.e1  
 	.f0:	MOVf %1 $x 	; y = (float) sin(x) / c
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 211:26
 		DIVf $y %0 $c
 	.e1:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-pow:	FUNC	; signature func pow(float x, float y) -> float
+pow:	FUNC	; signature func pow(float x, float y) -> float @ 214:14
 	$x:	INPf
 	$y:	INPf
 	$a:	LOCf
@@ -260,15 +260,15 @@ pow:	FUNC	; signature func pow(float x, float y) -> float
 		SUBf $a #0.0 $a	; a = -a
 	.f1:	LEQf $a #0.0 @.f2	; if (a > 0.0) z = (float) exp((float) log(a) * y)
 		MOVf %2 $a 	; z = (float) exp((float) log(a) * y)
-		CALL &log %1 *2	; expects log(float) -> float
+		CALL &log %1 *2	; expects log(float) -> float @ 221:46
 		MULf %1 %1 $y
-		CALL &exp %0 *2	; expects exp(float) -> float
+		CALL &exp %0 *2	; expects exp(float) -> float @ 221:50
 		MOVf $z %0 
 		GOTO @.e3  
 	.f2:	LSSf $a #0.0 @.t4	; if (a < 0.0 || y <= 0.0) error("Domain error")
 		GRTf $y #0.0 @.f5
 	.t4:	MOVp %1 &.s_Domain4d2 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 222:53
 	.f5:	NOOP
 	.e3:	EQUf $a $x @.f7	; if (a != x && (y * 0.5) != floor(y * 0.5)) z = -z
 		MULf %0 $y #0.5
@@ -281,7 +281,7 @@ pow:	FUNC	; signature func pow(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-floorFunc:	FUNC	; signature func floorFunc(float x) -> float
+floorFunc:	FUNC	; signature func floorFunc(float x) -> float @ 226:20
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		FLOf $y $x 	; y = floor(x)
@@ -290,7 +290,7 @@ floorFunc:	FUNC	; signature func floorFunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-ceilFunc:	FUNC	; signature func ceilFunc(float x) -> float
+ceilFunc:	FUNC	; signature func ceilFunc(float x) -> float @ 232:19
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		SUBf %1 #0.0 $x	; y = -floor(-x)
@@ -301,18 +301,18 @@ ceilFunc:	FUNC	; signature func ceilFunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sqrt:	FUNC	; signature func sqrt(float x) -> float
+sqrt:	FUNC	; signature func sqrt(float x) -> float @ 238:15
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; y = (float) pow(x, 0.5)
 		MOVf %2 #0.5 
-		CALL &pow %0 *3	; expects pow(float, float) -> float
+		CALL &pow %0 *3	; expects pow(float, float) -> float @ 241:25
 		MOVf $y %0 
 		RETU   	; }
 
-FUNCTION_COUNT:	! DEFi #10	; signature const FUNCTION_COUNT : int
+FUNCTION_COUNT:	! DEFi #10	; signature const FUNCTION_COUNT : int @ 244:30
 	! MULi <A> #FUNCTION_COUNT #2
-FUNCTIONS:	CNST *<A>	; signature array FUNCTIONS[<A>] : unknown
+FUNCTIONS:	CNST *<A>	; signature array FUNCTIONS[<A>] : unknown @ 245:46
 	DATA &.s_ceil4d4 &ceilFunc &.s_exp4d5 &exp &.s_floor4d6
 	DATA &floorFunc &.s_log4d7 &log &.s_log24d8 &log2
 	DATA &.s_log104d9 &log10 &.s_sqrt4da &sqrt &.s_cos4db &cos
@@ -320,7 +320,7 @@ FUNCTIONS:	CNST *<A>	; signature array FUNCTIONS[<A>] : unknown
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-isalpha:	FUNC	; signature func isalpha(int c) -> int
+isalpha:	FUNC	; signature func isalpha(int c) -> int @ 258:18
 	$c:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $b #FALSE 	; b = FALSE
@@ -334,7 +334,7 @@ isalpha:	FUNC	; signature func isalpha(int c) -> int
 
 ;-----------------------------------------------------------------------------
 	$l:	OUTi
-lower:	FUNC	; signature func lower(int c) -> int
+lower:	FUNC	; signature func lower(int c) -> int @ 265:16
 	$c:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $l $c 	; l = c
@@ -347,7 +347,7 @@ lower:	FUNC	; signature func lower(int c) -> int
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-eatWhite:	FUNC	; signature func eatWhite(ptr b) -> ptr
+eatWhite:	FUNC	; signature func eatWhite(ptr b) -> ptr @ 272:19
 	$b:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp $p $b 	; p = b
@@ -357,14 +357,14 @@ eatWhite:	FUNC	; signature func eatWhite(ptr b) -> ptr
 		GOTO @.l0  
 	.e1:	RETU   	; }
 
-EPSILON_FLOAT:	! DEFf #1.0e-45	; signature const EPSILON_FLOAT : float
-SMALL_FLOAT:	! DEFf #1.0e-5	; signature const SMALL_FLOAT : float
-LARGE_FLOAT:	! DEFf #1.0e+10	; signature const LARGE_FLOAT : float
-HUGE_FLOAT:	! DEFf #1.0e+38	; signature const HUGE_FLOAT : float
+EPSILON_FLOAT:	! DEFf #1.0e-45	; signature const EPSILON_FLOAT : float @ 280:1
+SMALL_FLOAT:	! DEFf #1.0e-5	; signature const SMALL_FLOAT : float @ 281:1
+LARGE_FLOAT:	! DEFf #1.0e+10	; signature const LARGE_FLOAT : float @ 282:1
+HUGE_FLOAT:	! DEFf #1.0e+38	; signature const HUGE_FLOAT : float @ 284:1
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-hexToFloat:	FUNC	; signature func hexToFloat(ptr b, ptr v) -> ptr
+hexToFloat:	FUNC	; signature func hexToFloat(ptr b, ptr v) -> ptr @ 284:21
 	$b:	INPp
 	$v:	INPp
 	$i:	LOCi
@@ -399,7 +399,7 @@ hexToFloat:	FUNC	; signature func hexToFloat(ptr b, ptr v) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-intToHex:	FUNC	; signature func intToHex(int i, ptr buffer) -> ptr
+intToHex:	FUNC	; signature func intToHex(int i, ptr buffer) -> ptr @ 301:19
 	$i:	INPi
 	$buffer:	INPp
 	$x:	LOCi
@@ -419,7 +419,7 @@ intToHex:	FUNC	; signature func intToHex(int i, ptr buffer) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-stringToFloat:	FUNC	; signature func stringToFloat(ptr b, ptr v) -> ptr
+stringToFloat:	FUNC	; signature func stringToFloat(ptr b, ptr v) -> ptr @ 314:24
 	$b:	INPp
 	$v:	INPp
 	$f:	LOCf
@@ -489,7 +489,7 @@ stringToFloat:	FUNC	; signature func stringToFloat(ptr b, ptr v) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr buffer) -> ptr
+floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr buffer) -> ptr @ 356:24
 	$f:	INPf
 	$precision:	INPi
 	$buffer:	INPp
@@ -624,7 +624,7 @@ floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr b
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
+evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr @ 461:19
 	$b:	INPp
 	$v:	INPp
 	$precedence:	INPi
@@ -635,17 +635,17 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
 		MOVp %1 $b 	; p = (pointer) eatWhite(b)
-		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr
+		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr @ 469:27
 		MOVp $p %0 
 		PEEK %0 $p 	; switch ((int) *p == 0 to 128) 
 		SWCH %0 *128 @.s0
 	.s0#0:	MOVp %1 &.s_Unexpe4e0 	; error("Unexpected end of line")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 472:48
 		GOTO @.e1  
 	.s0#'-':	ADDp %1 $p #1	; p = (pointer) evaluate(p + 1, v, PREFIX_PRECEDENCE)
 		MOVp %2 $v 
 		MOVi %3 #PREFIX_PRECEDENCE 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 474:55
 		MOVp $p %0 
 		PEEK %0 $v 	; *v = -(float) *v
 		SUBf %0 #0.0 %0
@@ -658,12 +658,12 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 	.s0#'(':	ADDp %1 $p #1	; p = (pointer) evaluate(p + 1, v, PARENTHESIS_PRECEDENCE)
 		MOVp %2 $v 
 		MOVi %3 #PARENTHESIS_PRECEDENCE 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 482:60
 		MOVp $p %0 
 		PEEK %0 $p 	; if ((int) *p != ')') error("Expected ')'")
 		EQUi %0 #')' @.f2
 		MOVp %1 &.s_Expect4e1 	; error("Expected ')'")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 483:46
 	.f2:	ADDp $p $p #1	; p = p + 1
 		GOTO @.e1  	; }
 	.s0#'0':	NOOP
@@ -678,25 +678,25 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 	.s0#'9':	PEEK %0 $p 	; if ((int) *p == '0' && (int) lower(p[1]) == 'x') q = (pointer) hexToFloat(p + 2, v)
 		NEQi %0 #'0' @.f4
 		PEEK %1 $p #1
-		CALL &lower %0 *2	; expects lower(int) -> int
+		CALL &lower %0 *2	; expects lower(int) -> int @ 487:45
 		NEQi %0 #'x' @.f4
 		ADDp %1 $p #2	; q = (pointer) hexToFloat(p + 2, v)
 		MOVp %2 $v 
-		CALL &hexToFloat %0 *3	; expects hexToFloat(ptr, ptr) -> ptr
+		CALL &hexToFloat %0 *3	; expects hexToFloat(ptr, ptr) -> ptr @ 487:87
 		MOVp $q %0 
 		GOTO @.e5  
 	.f4:	MOVp %1 $p 	; q = (pointer) stringToFloat(p, v)
 		MOVp %2 $v 
-		CALL &stringToFloat %0 *3	; expects stringToFloat(ptr, ptr) -> ptr
+		CALL &stringToFloat %0 *3	; expects stringToFloat(ptr, ptr) -> ptr @ 488:42
 		MOVp $q %0 
 	.e5:	NEQp $p $q @.f6	; if (p == q) error("Invalid number")
 		MOVp %1 &.s_Invali4e2 	; error("Invalid number")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 489:39
 	.f6:	MOVp $p $q 	; p = q
 		GOTO @.e1  	; }
 	.s0#'e':	NOOP
 	.s0#'E':	PEEK %1 $p #1	; if ((int) isalpha(p[1]) != FALSE) goto symbol
-		CALL &isalpha %0 *2	; expects isalpha(int) -> int
+		CALL &isalpha %0 *2	; expects isalpha(int) -> int @ 493:28
 		EQUi %0 #FALSE @.f7
 		GOTO @symbol  	; goto symbol
 	.f7:	ADDp $p $p #1	; p = p + 1
@@ -704,10 +704,10 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 		GOTO @.e1  	; }
 	.s0#'p':	NOOP
 	.s0#'P':	PEEK %1 $p #1	; if ((int) lower(p[1]) != 'i' || (int) isalpha(p[2]) != FALSE) goto symbol
-		CALL &lower %0 *2	; expects lower(int) -> int
+		CALL &lower %0 *2	; expects lower(int) -> int @ 498:26
 		NEQi %0 #'i' @symbol
 		PEEK %1 $p #2
-		CALL &isalpha %0 *2	; expects isalpha(int) -> int
+		CALL &isalpha %0 *2	; expects isalpha(int) -> int @ 498:56
 		EQUi %0 #FALSE @.f9
 		GOTO @symbol  	; goto symbol
 	.f9:	ADDp $p $p #2	; p = p + 2
@@ -723,7 +723,7 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 	.l12:	PEEK $c $s 	; while ((c = (int) *s) != 0 && (int) lower(*q) == c) 
 		EQUi $c #0 @.e14
 		PEEK %1 $q 
-		CALL &lower %0 *2	; expects lower(int) -> int
+		CALL &lower %0 *2	; expects lower(int) -> int @ 507:52
 		NEQi %0 $c @.e14
 		ADDp $s $s #1	; s = s + 1
 		ADDp $q $q #1	; q = q + 1
@@ -731,45 +731,45 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 	.e14:	PEEK %0 $s 	; if ((int) *s == 0) 
 		NEQi %0 #0 @.f15
 		MOVp %1 $q 	; q = (pointer) eatWhite(q)
-		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr
+		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr @ 512:32
 		MOVp $q %0 
 		PEEK %0 $q 	; if ((int) *q == '(') 
 		NEQi %0 #'(' @.f15
 		ADDp %1 $q #1	; p = (pointer) evaluate(q + 1, v, PARENTHESIS_PRECEDENCE)
 		MOVp %2 $v 
 		MOVi %3 #PARENTHESIS_PRECEDENCE 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 514:64
 		MOVp $p %0 
 		PEEK %0 $p 	; if ((int) *p != ')') error("Expected ')'")
 		EQUi %0 #')' @.f17
 		MOVp %1 &.s_Expect4e1 	; error("Expected ')'")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 515:50
 	.f17:	ADDp $p $p #1	; p = p + 1
 		MULi %0 $i #2	; (float) *v = (float) ((funcptr)global FUNCTIONS[i * 2 + 1])((float) *v)
 		ADDi %0 %0 #1
 		PEEK %2 $v 
-		PEEK %0 &FUNCTIONS %0	; expects function(float) -> unknown
+		PEEK %0 &FUNCTIONS %0	; expects function(float) -> unknown @ 517:79
 		CALL %0 %1 *2
 		POKE $v %1 
 		GOTO @wasFunction  	; goto wasFunction
 	.f15:	FORi $i #FUNCTION_COUNT @.l11	; }
 	.e10:	PEEK %1 $p 	; c = (int) lower(*p)
-		CALL &lower %0 *2	; expects lower(int) -> int
+		CALL &lower %0 *2	; expects lower(int) -> int @ 522:24
 		MOVi $c %0 
 		MOVi %1 $c 	; if ((int) isalpha(c) == FALSE || (int) isalpha(p[1]) == TRUE) error("Syntax error")
-		CALL &isalpha %0 *2	; expects isalpha(int) -> int
+		CALL &isalpha %0 *2	; expects isalpha(int) -> int @ 523:26
 		EQUi %0 #FALSE @.t18
 		PEEK %1 $p #1
-		CALL &isalpha %0 *2	; expects isalpha(int) -> int
+		CALL &isalpha %0 *2	; expects isalpha(int) -> int @ 523:58
 		NEQi %0 #TRUE @.f19
 	.t18:	MOVp %1 &.s_Syntax4e3 	; error("Syntax error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 523:88
 		GOTO @.e20  
 	.f19:	SUBi %0 $c #'a'	; if ((int) global memoryUsed[c - 'a'] == 0) error("Undefined variable")
 		PEEK %0 &memoryUsed %0
 		NEQi %0 #0 @.f21
 		MOVp %1 &.s_Undefi4e4 	; error("Undefined variable")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 524:80
 		GOTO @.e22  
 	.f21:	ADDp $p $p #1	; p = p + 1
 		SUBi %0 $c #'a'	; *v = (float) global memory[c - 'a']
@@ -780,7 +780,7 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 	wasFunction:	NOOP
 	.e1:	NOOP
 	repeat:	MOVp %1 $p 	; p = (pointer) eatWhite(p)
-		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr
+		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr @ 534:28
 		MOVp $p %0 
 		! ADDi <A> #'|' #1	; switch ((int) *p == '%' to ('|' + 1)) 
 		! SUBi <A> <A> #'%'
@@ -792,7 +792,7 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 		ADDp %1 $p #1	; p = (pointer) evaluate(p + 1, &f, BITWISE_PRECEDENCE)
 		ADRL %2 $f *0
 		MOVi %3 #BITWISE_PRECEDENCE 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 539:59
 		MOVp $p %0 
 		PEEK %0 $v 	; *v = itof(ftoi((float) *v) | ftoi(f))
 		fTOi %0 %0 #1.0
@@ -807,7 +807,7 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 		ADDp %1 $p #1	; p = (pointer) evaluate(p + 1, &f, BITWISE_PRECEDENCE)
 		ADRL %2 $f *0
 		MOVi %3 #BITWISE_PRECEDENCE 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 546:59
 		MOVp $p %0 
 		PEEK %0 $v 	; *v = itof(ftoi((float) *v) & ftoi(f))
 		fTOi %0 %0 #1.0
@@ -822,7 +822,7 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 		ADDp %1 $p #1	; p = (pointer) evaluate(p + 1, &f, BITWISE_PRECEDENCE)
 		ADRL %2 $f *0
 		MOVi %3 #BITWISE_PRECEDENCE 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 553:59
 		MOVp $p %0 
 		PEEK %0 $v 	; *v = itof(ftoi((float) *v) ^ ftoi(f))
 		fTOi %0 %0 #1.0
@@ -839,7 +839,7 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 		ADDp %1 $p #2	; p = (pointer) evaluate(p + 2, &f, BITWISE_PRECEDENCE)
 		ADRL %2 $f *0
 		MOVi %3 #BITWISE_PRECEDENCE 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 560:59
 		MOVp $p %0 
 		PEEK %0 $v 	; *v = itof(ftoi((float) *v) << ftoi(f))
 		fTOi %0 %0 #1.0
@@ -856,7 +856,7 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 		ADDp %1 $p #2	; p = (pointer) evaluate(p + 2, &f, BITWISE_PRECEDENCE)
 		ADRL %2 $f *0
 		MOVi %3 #BITWISE_PRECEDENCE 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 567:59
 		MOVp $p %0 
 		PEEK %0 $v 	; *v = itof(ftoi((float) *v) >>> ftoi(f))
 		fTOi %0 %0 #1.0
@@ -871,7 +871,7 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 		ADDp %1 $p #1	; p = (pointer) evaluate(p + 1, &f, ADD_SUB_PRECEDENCE)
 		ADRL %2 $f *0
 		MOVi %3 #ADD_SUB_PRECEDENCE 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 574:59
 		MOVp $p %0 
 		PEEK %0 $v 	; *v = (float) *v + f
 		ADDf %0 %0 $f
@@ -883,7 +883,7 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 		ADDp %1 $p #1	; p = (pointer) evaluate(p + 1, &f, ADD_SUB_PRECEDENCE)
 		ADRL %2 $f *0
 		MOVi %3 #ADD_SUB_PRECEDENCE 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 581:59
 		MOVp $p %0 
 		PEEK %0 $v 	; *v = (float) *v - f
 		SUBf %0 %0 $f
@@ -897,11 +897,11 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 		ADDp %1 $p #2	; p = (pointer) evaluate(p + 2, &f, POW_PRECEDENCE)
 		ADRL %2 $f *0
 		MOVi %3 #POW_PRECEDENCE 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 589:56
 		MOVp $p %0 
 		PEEK %1 $v 	; *v = pow((float) *v, f)
 		MOVf %2 $f 
-		CALL &pow %0 *3	; expects pow(float, float) -> float
+		CALL &pow %0 *3	; expects pow(float, float) -> float @ 590:30
 		POKE $v %0 
 		GOTO @repeat  	; goto repeat
 		GOTO @.e24  	; } else 
@@ -909,7 +909,7 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 		ADDp %1 $p #1	; p = (pointer) evaluate(p + 1, &f, MUL_DIV_PRECEDENCE)
 		ADRL %2 $f *0
 		MOVi %3 #MUL_DIV_PRECEDENCE 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 595:60
 		MOVp $p %0 
 		PEEK %0 $v 	; *v = (float) *v * f
 		MULf %0 %0 $f
@@ -921,11 +921,11 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 		ADDp %1 $p #1	; p = (pointer) evaluate(p + 1, &f, MUL_DIV_PRECEDENCE)
 		ADRL %2 $f *0
 		MOVi %3 #MUL_DIV_PRECEDENCE 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 603:59
 		MOVp $p %0 
 		NEQf $f #0.0 @.f39	; if (f == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4d3 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 604:45
 		GOTO @repeat  
 	.f39:	PEEK %0 $v 	; *v = (float) *v / f
 		DIVf %0 %0 $f
@@ -937,11 +937,11 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 		ADDp %1 $p #1	; p = (pointer) evaluate(p + 1, &f, MUL_DIV_PRECEDENCE)
 		ADRL %2 $f *0
 		MOVi %3 #MUL_DIV_PRECEDENCE 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 611:59
 		MOVp $p %0 
 		PEEK %1 $v 	; *v = fmod(*v, f)
 		MOVf %2 $f 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 612:22
 		POKE $v %0 
 		GOTO @repeat  	; goto repeat
 	.f41:	NOOP
@@ -951,7 +951,7 @@ evaluate:	FUNC	; signature func evaluate(ptr b, ptr v, int precedence) -> ptr
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 620:15
 	$s:	LOCA *256
 	$p:	LOCp
 	$q:	LOCp
@@ -962,83 +962,83 @@ main:	FUNC	; signature func main() -> void
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
 	.l0:	MOVp %1 &.s_calc4e5 	; output("calc> ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 631:19
 		MOVi %1 #255 	; input(255, s)
 		ADRL %2 $s *0
-		CALL ^input %0 *3	; expects function(int, ptr) -> unknown
+		CALL ^input %0 *3	; expects function(int, ptr) -> unknown @ 632:16
 		ADRL %1 $s *0	; p = (pointer) eatWhite(s)
-		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr
+		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr @ 634:28
 		MOVp $p %0 
 		PEEK %0 $p 	; if ((int) *p == 0 || (int) strcmp(p, "quit") == 0) goto quit
 		EQUi %0 #0 @quit
 		MOVp %1 $p 
 		MOVp %2 &.s_quit4e6 
-		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int @ 635:48
 		NEQi %0 #0 @.f2
 		GOTO @quit  	; goto quit
 	.f2:	MOVi $assignTo #-1 	; assignTo = -1
 		PEEK %1 $p 	; c = (int) lower(*p)
-		CALL &lower %0 *2	; expects lower(int) -> int
+		CALL &lower %0 *2	; expects lower(int) -> int @ 638:22
 		MOVi $c %0 
 		MOVi %1 $c 	; if ((int) isalpha(c) != FALSE && c != 'e') 
-		CALL &isalpha %0 *2	; expects isalpha(int) -> int
+		CALL &isalpha %0 *2	; expects isalpha(int) -> int @ 639:24
 		EQUi %0 #FALSE @.f4
 		EQUi $c #'e' @.f4
 		ADDp %1 $p #1	; q = (pointer) eatWhite(p + 1)
-		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr
+		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr @ 640:33
 		MOVp $q %0 
 		PEEK %0 $q 	; if ((int) *q == '=') 
 		NEQi %0 #'=' @.f4
 		ADDp %1 $q #1	; p = (pointer) eatWhite(q + 1)
-		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr
+		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr @ 642:34
 		MOVp $p %0 
 		SUBi $assignTo $c #'a'	; assignTo = c - 'a'
 	.f4:	POKE &lastError &NULL 	; global lastError = null
 		MOVp %1 $p 	; p = (pointer) evaluate(p, &f, 0)
 		ADRL %2 $f *0
 		MOVi %3 #0 
-		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr
+		CALL &evaluate %0 *4	; expects evaluate(ptr, ptr, int) -> ptr @ 648:35
 		MOVp $p %0 
 		MOVp %1 $p 	; p = (pointer) eatWhite(p)
-		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr
+		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr @ 649:28
 		MOVp $p %0 
 		PEEK %0 $p 	; if ((int) *p != 0) error("Syntax error")
 		EQUi %0 #0 @.f6
 		MOVp %1 &.s_Syntax4e3 	; error("Syntax error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 650:43
 	.f6:	PEEK $p &lastError 	; if ((p = global lastError) != null) output(p)
 		EQUp $p &NULL @.f7
 		MOVp %1 $p 	; output(p)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 652:48
 		GOTO @.e8  
 	.f7:	POKE &lastResult $f 	; global lastResult = f
 		LSSi $assignTo #0 @.f9	; if (assignTo >= 0) 
 		ADDi $s:0 #'a' $assignTo	; s[0] = 'a' + assignTo
 		MOVi $s:1 #0 	; s[1] = 0
 		ADRL %1 $s *0	; output(s)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 658:14
 	.f9:	MOVp %1 &.s_4e7 	; output(" = ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 660:17
 		MOVf %2 $f 	; output(floatToString(f, 6, buffer))
 		MOVi %3 #6 
 		ADRL %4 $buffer *0
-		CALL &floatToString %1 *4	; expects floatToString(float, int, ptr) -> ptr
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL &floatToString %1 *4	; expects floatToString(float, int, ptr) -> ptr @ 661:38
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 661:39
 		fTOi $i $f #1.0	; if (itof(i = ftoi(f)) == f) 
 		iTOf %0 $i #1.0
 		NEQf %0 $f @.f10
 		MOVp %1 &.s_0x4e8 	; output("\n = 0x")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 663:22
 		MOVi %2 $i 	; output(intToHex(i, buffer))
 		ADRL %3 $buffer *0
-		CALL &intToHex %1 *3	; expects intToHex(int, ptr) -> ptr
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL &intToHex %1 *3	; expects intToHex(int, ptr) -> ptr @ 664:31
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 664:32
 	.f10:	LSSi $assignTo #0 @.f11	; if (assignTo >= 0) 
 		POKE &memory $assignTo $f	; global memory[assignTo] = f
 		POKE &memoryUsed $assignTo #1	; global memoryUsed[assignTo] = 1
 	.f11:	NOOP
 	.e8:	MOVp %1 &.s_4e9 	; output("\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 671:15
 		GOTO @.l0  	; }
 	quit:	RETU   	; }
 

--- a/tests/impala/golden/chess.gazl
+++ b/tests/impala/golden/chess.gazl
@@ -1,85 +1,85 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-; signature extern native output() -> unknown
-; signature extern native input() -> unknown
-; signature extern native clock() -> unknown
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
+; signature extern native output() -> unknown @ 36:1
+; signature extern native input() -> unknown @ 37:1
+; signature extern native clock() -> unknown @ 39:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 40:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 41:1
 	! ADDi <A> #8 #2
-STRIDE:	! DEFi <A>	; signature const STRIDE : int
+STRIDE:	! DEFi <A>	; signature const STRIDE : int @ 44:1
 	! ADDi <A> #8 #4
 	! MULi <A> <A> #STRIDE
-BOARD_SIZE:	! DEFi <A>	; signature const BOARD_SIZE : int
+BOARD_SIZE:	! DEFi <A>	; signature const BOARD_SIZE : int @ 45:1
 	! MULi <A> #STRIDE #2
-RANK_1:	! DEFi <A>	; signature const RANK_1 : int
+RANK_1:	! DEFi <A>	; signature const RANK_1 : int @ 46:1
 	! MULi <A> #STRIDE #3
-RANK_2:	! DEFi <A>	; signature const RANK_2 : int
+RANK_2:	! DEFi <A>	; signature const RANK_2 : int @ 47:1
 	! MULi <A> #STRIDE #4
-RANK_3:	! DEFi <A>	; signature const RANK_3 : int
+RANK_3:	! DEFi <A>	; signature const RANK_3 : int @ 48:1
 	! MULi <A> #STRIDE #5
-RANK_4:	! DEFi <A>	; signature const RANK_4 : int
+RANK_4:	! DEFi <A>	; signature const RANK_4 : int @ 49:1
 	! MULi <A> #STRIDE #6
-RANK_5:	! DEFi <A>	; signature const RANK_5 : int
+RANK_5:	! DEFi <A>	; signature const RANK_5 : int @ 50:1
 	! MULi <A> #STRIDE #7
-RANK_6:	! DEFi <A>	; signature const RANK_6 : int
+RANK_6:	! DEFi <A>	; signature const RANK_6 : int @ 51:1
 	! MULi <A> #STRIDE #8
-RANK_7:	! DEFi <A>	; signature const RANK_7 : int
+RANK_7:	! DEFi <A>	; signature const RANK_7 : int @ 52:1
 	! MULi <A> #STRIDE #9
-RANK_8:	! DEFi <A>	; signature const RANK_8 : int
-OFFBOARD:	! DEFi #-1	; signature const OFFBOARD : int
-EMPTY:	! DEFi #0	; signature const EMPTY : int
-PAWN:	! DEFi #1	; signature const PAWN : int
-ROOK:	! DEFi #2	; signature const ROOK : int
-KNIGHT:	! DEFi #3	; signature const KNIGHT : int
-BISHOP:	! DEFi #4	; signature const BISHOP : int
-QUEEN:	! DEFi #5	; signature const QUEEN : int
-KING:	! DEFi #6	; signature const KING : int
-BLACK:	! DEFi #8	; signature const BLACK : int
-WHITE:	! DEFi #16	; signature const WHITE : int
-PIECE_MASK:	! DEFi #7	; signature const PIECE_MASK : int
+RANK_8:	! DEFi <A>	; signature const RANK_8 : int @ 54:1
+OFFBOARD:	! DEFi #-1	; signature const OFFBOARD : int @ 55:1
+EMPTY:	! DEFi #0	; signature const EMPTY : int @ 56:1
+PAWN:	! DEFi #1	; signature const PAWN : int @ 57:1
+ROOK:	! DEFi #2	; signature const ROOK : int @ 58:1
+KNIGHT:	! DEFi #3	; signature const KNIGHT : int @ 59:1
+BISHOP:	! DEFi #4	; signature const BISHOP : int @ 60:1
+QUEEN:	! DEFi #5	; signature const QUEEN : int @ 61:1
+KING:	! DEFi #6	; signature const KING : int @ 62:1
+BLACK:	! DEFi #8	; signature const BLACK : int @ 63:1
+WHITE:	! DEFi #16	; signature const WHITE : int @ 64:1
+PIECE_MASK:	! DEFi #7	; signature const PIECE_MASK : int @ 65:1
 	! IORi <A> #BLACK #WHITE
-COLOR_MASK:	! DEFi <A>	; signature const COLOR_MASK : int
+COLOR_MASK:	! DEFi <A>	; signature const COLOR_MASK : int @ 66:1
 	! XORi <A> #BLACK #WHITE
-COLOR_SWITCH_XOR:	! DEFi <A>	; signature const COLOR_SWITCH_XOR : int
-MOVED_MASK:	! DEFi #32	; signature const MOVED_MASK : int
+COLOR_SWITCH_XOR:	! DEFi <A>	; signature const COLOR_SWITCH_XOR : int @ 67:1
+MOVED_MASK:	! DEFi #32	; signature const MOVED_MASK : int @ 68:1
 	! IORi <A> #PIECE_MASK #MOVED_MASK
-PIECE_AND_MOVED_MASK:	! DEFi <A>	; signature const PIECE_AND_MOVED_MASK : int
-MAX_PIECE_AND_MOVED_VALUE:	! DEFi #64	; signature const MAX_PIECE_AND_MOVED_VALUE : int
-MIN_DEPTH:	! DEFi #4	; signature const MIN_DEPTH : int
-MAX_DEPTH:	! DEFi #16	; signature const MAX_DEPTH : int
-QUIESCENCE_DEPTH:	! DEFi #8	; signature const QUIESCENCE_DEPTH : int
-TO_SHIFT:	! DEFi #8	; signature const TO_SHIFT : int
-SCORE_SHIFT:	! DEFi #16	; signature const SCORE_SHIFT : int
-MOVE_MASK:	! DEFi #0x0000FFFF	; signature const MOVE_MASK : int
-FROM_MASK:	! DEFi #0x000000FF	; signature const FROM_MASK : int
-TO_MASK:	! DEFi #0x0000FF00	; signature const TO_MASK : int
+PIECE_AND_MOVED_MASK:	! DEFi <A>	; signature const PIECE_AND_MOVED_MASK : int @ 69:1
+MAX_PIECE_AND_MOVED_VALUE:	! DEFi #64	; signature const MAX_PIECE_AND_MOVED_VALUE : int @ 71:1
+MIN_DEPTH:	! DEFi #4	; signature const MIN_DEPTH : int @ 72:1
+MAX_DEPTH:	! DEFi #16	; signature const MAX_DEPTH : int @ 73:1
+QUIESCENCE_DEPTH:	! DEFi #8	; signature const QUIESCENCE_DEPTH : int @ 74:1
+TO_SHIFT:	! DEFi #8	; signature const TO_SHIFT : int @ 75:1
+SCORE_SHIFT:	! DEFi #16	; signature const SCORE_SHIFT : int @ 76:1
+MOVE_MASK:	! DEFi #0x0000FFFF	; signature const MOVE_MASK : int @ 77:1
+FROM_MASK:	! DEFi #0x000000FF	; signature const FROM_MASK : int @ 78:1
+TO_MASK:	! DEFi #0x0000FF00	; signature const TO_MASK : int @ 79:1
 	! XORi <A> #MOVE_MASK #-1
-SCORE_MASK:	! DEFi <A>	; signature const SCORE_MASK : int
-CHECKMATE:	! DEFi #0xFFFF	; signature const CHECKMATE : int
-STALEMATE:	! DEFi #0xFFFE	; signature const STALEMATE : int
-IN_CHECK:	! DEFi #0xFFFD	; signature const IN_CHECK : int
-VALID_MOVE:	! DEFi #0xFFFC	; signature const VALID_MOVE : int
-INVALID_MOVE:	! DEFi #-1	; signature const INVALID_MOVE : int
-MAX_SCORE:	! DEFi #10000	; signature const MAX_SCORE : int
+SCORE_MASK:	! DEFi <A>	; signature const SCORE_MASK : int @ 80:1
+CHECKMATE:	! DEFi #0xFFFF	; signature const CHECKMATE : int @ 81:1
+STALEMATE:	! DEFi #0xFFFE	; signature const STALEMATE : int @ 82:1
+IN_CHECK:	! DEFi #0xFFFD	; signature const IN_CHECK : int @ 83:1
+VALID_MOVE:	! DEFi #0xFFFC	; signature const VALID_MOVE : int @ 84:1
+INVALID_MOVE:	! DEFi #-1	; signature const INVALID_MOVE : int @ 85:1
+MAX_SCORE:	! DEFi #10000	; signature const MAX_SCORE : int @ 86:1
 	! SUBi <A> #0 #MAX_SCORE
-MIN_SCORE:	! DEFi <A>	; signature const MIN_SCORE : int
-PAWN_VALUE:	! DEFi #100	; signature const PAWN_VALUE : int
+MIN_SCORE:	! DEFi <A>	; signature const MIN_SCORE : int @ 87:1
+PAWN_VALUE:	! DEFi #100	; signature const PAWN_VALUE : int @ 88:1
 	! MULi <A> #9 #PAWN_VALUE
-QUEEN_VALUE:	! DEFi <A>	; signature const QUEEN_VALUE : int
+QUEEN_VALUE:	! DEFi <A>	; signature const QUEEN_VALUE : int @ 89:1
 	! SUBi <A> #QUEEN_VALUE #PAWN_VALUE
-PROMOTION_SCORE:	! DEFi <A>	; signature const PROMOTION_SCORE : int
+PROMOTION_SCORE:	! DEFi <A>	; signature const PROMOTION_SCORE : int @ 90:1
 	! SUBi <A> #MAX_SCORE #MAX_DEPTH
-CAPTURE_KING_MIN_SCORE:	! DEFi <A>	; signature const CAPTURE_KING_MIN_SCORE : int
+CAPTURE_KING_MIN_SCORE:	! DEFi <A>	; signature const CAPTURE_KING_MIN_SCORE : int @ 91:1
 	! DIVi <A> #PAWN_VALUE #10
-RANDOM_AMOUNT:	! DEFi <A>	; signature const RANDOM_AMOUNT : int
+RANDOM_AMOUNT:	! DEFi <A>	; signature const RANDOM_AMOUNT : int @ 92:1
 	! DIVi <A> #PAWN_VALUE #10
-PAWN_ADVANCE_SCORE:	! DEFi <A>	; signature const PAWN_ADVANCE_SCORE : int
+PAWN_ADVANCE_SCORE:	! DEFi <A>	; signature const PAWN_ADVANCE_SCORE : int @ 93:1
 	! DIVi <A> #PAWN_VALUE #2
-CASTLING_SCORE:	! DEFi <A>	; signature const CASTLING_SCORE : int
-CASTLING_MASK:	! DEFi #0x80	; signature const CASTLING_MASK : int
-HISTORY_SIZE:	! DEFi #256	; signature const HISTORY_SIZE : int
-DIRS:	CNST *8	; signature array DIRS[8] : unknown
+CASTLING_SCORE:	! DEFi <A>	; signature const CASTLING_SCORE : int @ 94:1
+CASTLING_MASK:	! DEFi #0x80	; signature const CASTLING_MASK : int @ 95:1
+HISTORY_SIZE:	! DEFi #256	; signature const HISTORY_SIZE : int @ 97:1
+DIRS:	CNST *8	; signature array DIRS[8] : unknown @ 97:24
 	! ADDi <A> #STRIDE #1
 	DATA #STRIDE
 	DATA <A>
@@ -95,7 +95,7 @@ DIRS:	CNST *8	; signature array DIRS[8] : unknown
 	! SUBi <A> #STRIDE #1
 	DATA #-1
 	DATA <A>
-KNIGHT_MOVES:	CNST *8	; signature array KNIGHT_MOVES[8] : unknown
+KNIGHT_MOVES:	CNST *8	; signature array KNIGHT_MOVES[8] : unknown @ 98:32
 	! MULi <A> #STRIDE #2
 	! ADDi <A> <A> #1
 	! ADDi <B> #2 #STRIDE
@@ -119,7 +119,7 @@ KNIGHT_MOVES:	CNST *8	; signature array KNIGHT_MOVES[8] : unknown
 	! SUBi <B> <B> #1
 	DATA <A>
 	DATA <B>
-PIECE_VALUES:	CNST *7	; signature array PIECE_VALUES[7] : unknown
+PIECE_VALUES:	CNST *7	; signature array PIECE_VALUES[7] : unknown @ 99:32
 	! MULi <B> #5 #PAWN_VALUE
 	DATA #0 #PAWN_VALUE
 	! MULi <A> #3 #PAWN_VALUE
@@ -129,12 +129,12 @@ PIECE_VALUES:	CNST *7	; signature array PIECE_VALUES[7] : unknown
 	DATA <B>
 	DATA #QUEEN_VALUE #MAX_SCORE
 	! ADDi <B> #8 #4
-RANK_VALUES:	CNST *<B>	; signature array RANK_VALUES[<B>] : unknown
+RANK_VALUES:	CNST *<B>	; signature array RANK_VALUES[<B>] : unknown @ 100:34
 	DATA #0 #0 #0 #30 #50 #60 #60 #50 #30 #0 #0 #0
-MAX_TARGET_SQUARES:	! DEFi #32	; signature const MAX_TARGET_SQUARES : int
-MAX_MOVES:	! DEFi #256	; signature const MAX_MOVES : int
-MAX_CAPTURES:	! DEFi #32	; signature const MAX_CAPTURES : int
-INIT_BOARD:	CNST *BOARD_SIZE	; signature array INIT_BOARD[BOARD_SIZE] : unknown
+MAX_TARGET_SQUARES:	! DEFi #32	; signature const MAX_TARGET_SQUARES : int @ 103:1
+MAX_MOVES:	! DEFi #256	; signature const MAX_MOVES : int @ 104:1
+MAX_CAPTURES:	! DEFi #32	; signature const MAX_CAPTURES : int @ 107:1
+INIT_BOARD:	CNST *BOARD_SIZE	; signature array INIT_BOARD[BOARD_SIZE] : unknown @ 107:39
 	DATA #OFFBOARD #OFFBOARD #OFFBOARD #OFFBOARD #OFFBOARD
 	DATA #OFFBOARD #OFFBOARD #OFFBOARD #OFFBOARD #OFFBOARD
 	DATA #OFFBOARD #OFFBOARD #OFFBOARD #OFFBOARD #OFFBOARD
@@ -222,45 +222,45 @@ INIT_BOARD:	CNST *BOARD_SIZE	; signature array INIT_BOARD[BOARD_SIZE] : unknown
 	DATi #32
 	DATs PRNBQK  prnbqk
 	DATi #32 #0
-PIECE_CHARS:	! DEFp &.s_PRNBQK4d2	; signature const PIECE_CHARS : ptr
-PIECE_NAMES:	CNST *8	; signature array PIECE_NAMES[8] : unknown
+PIECE_CHARS:	! DEFp &.s_PRNBQK4d2	; signature const PIECE_CHARS : ptr @ 122:47
+PIECE_NAMES:	CNST *8	; signature array PIECE_NAMES[8] : unknown @ 123:31
 	DATA &.s_PRNBQK4d2:16 &.s_pawn4d2 &.s_rook4d3
 	DATA &.s_knight4d4 &.s_bishop4d5 &.s_queen4d6 &.s_king4d7
-board:	GLOB *BOARD_SIZE	; signature array board[BOARD_SIZE] : unknown
-nextPiece:	GLOB *BOARD_SIZE	; signature array nextPiece[BOARD_SIZE] : unknown
-prevPiece:	GLOB *BOARD_SIZE	; signature array prevPiece[BOARD_SIZE] : unknown
+board:	GLOB *BOARD_SIZE	; signature array board[BOARD_SIZE] : unknown @ 125:31
+nextPiece:	GLOB *BOARD_SIZE	; signature array nextPiece[BOARD_SIZE] : unknown @ 126:35
+prevPiece:	GLOB *BOARD_SIZE	; signature array prevPiece[BOARD_SIZE] : unknown @ 127:35
 	GLOB *1
-xCapture:	DATi #0	; signature global xCapture : int
+xCapture:	DATi #0	; signature global xCapture : int @ 128:20
 	GLOB *1
-turnColor:	DATi #0	; signature global turnColor : int
+turnColor:	DATi #0	; signature global turnColor : int @ 129:21
 	GLOB *1
-boardHash:	DATi #0	; signature global boardHash : int
+boardHash:	DATi #0	; signature global boardHash : int @ 130:21
 	! MULi <B> #64 #1024
-HASH_TABLE_SIZE:	! DEFi <B>	; signature const HASH_TABLE_SIZE : int
+HASH_TABLE_SIZE:	! DEFi <B>	; signature const HASH_TABLE_SIZE : int @ 148:1
 	! XORi <B> #0 #-1
-HASH_MASK:	! DEFi <B>	; signature const HASH_MASK : int
+HASH_MASK:	! DEFi <B>	; signature const HASH_MASK : int @ 150:1
 	! MULi <B> #BOARD_SIZE #64
-pieceKeys:	GLOB *<B>	; signature array pieceKeys[<B>] : unknown
-xCaptureKeys:	GLOB *256	; signature array xCaptureKeys[256] : unknown
+pieceKeys:	GLOB *<B>	; signature array pieceKeys[<B>] : unknown @ 150:40
+xCaptureKeys:	GLOB *256	; signature array xCaptureKeys[256] : unknown @ 151:31
 	! ADDi <B> #WHITE #1
-colorKeys:	GLOB *<B>	; signature array colorKeys[<B>] : unknown
-hashTable:	GLOB *HASH_TABLE_SIZE	; signature array hashTable[HASH_TABLE_SIZE] : unknown
+colorKeys:	GLOB *<B>	; signature array colorKeys[<B>] : unknown @ 152:34
+hashTable:	GLOB *HASH_TABLE_SIZE	; signature array hashTable[HASH_TABLE_SIZE] : unknown @ 153:40
 	GLOB *1
-evalCounter:	DATi #0	; signature global evalCounter : int
+evalCounter:	DATi #0	; signature global evalCounter : int @ 154:27
 	! MULi <B> #HISTORY_SIZE #4
-history:	GLOB *<B>	; signature array history[<B>] : unknown
+history:	GLOB *<B>	; signature array history[<B>] : unknown @ 155:39
 	GLOB *1
-historyCount:	DATi #0	; signature global historyCount : int
+historyCount:	DATi #0	; signature global historyCount : int @ 156:28
 	GLOB *1
-minEvals:	DATi #10000	; signature global minEvals : int
+minEvals:	DATi #10000	; signature global minEvals : int @ 157:28
 	GLOB *1
-randPX:	DATi #123456789	; signature global randPX : int
+randPX:	DATi #123456789	; signature global randPX : int @ 159:30
 	GLOB *1
-randPY:	DATi #362436069	; signature global randPY : int
+randPY:	DATi #362436069	; signature global randPY : int @ 160:30
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-nextRandom:	FUNC	; signature func nextRandom() -> int
+nextRandom:	FUNC	; signature func nextRandom() -> int @ 162:21
 	$x:	LOCi
 	$t:	LOCi
 ;-----------------------------------------------------------------------------
@@ -281,30 +281,30 @@ nextRandom:	FUNC	; signature func nextRandom() -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-initGlobals:	FUNC	; signature func initGlobals() -> void
+initGlobals:	FUNC	; signature func initGlobals() -> void @ 177:22
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
 		MOVi $i #0 	; for (i = 0 to 64 * BOARD_SIZE) 
 		! MULi <B> #64 #BOARD_SIZE
 		GEQi #0 <B> @.e0
-	.l1:	CALL &nextRandom %0 *1	; expects nextRandom() -> int
+	.l1:	CALL &nextRandom %0 *1	; expects nextRandom() -> int @ 186:37
 		POKE &pieceKeys $i %0
 		FORi $i <B> @.l1	; }
 	.e0:	MOVi $i #0 	; for (i = 0 to 256) 
 		GEQi #0 #256 @.e2
-	.l3:	CALL &nextRandom %0 *1	; expects nextRandom() -> int
+	.l3:	CALL &nextRandom %0 *1	; expects nextRandom() -> int @ 189:40
 		POKE &xCaptureKeys $i %0
 		FORi $i #256 @.l3	; }
-	.e2:	CALL &nextRandom %0 *1	; expects nextRandom() -> int
+	.e2:	CALL &nextRandom %0 *1	; expects nextRandom() -> int @ 191:40
 		POKE &colorKeys:WHITE %0 
-		CALL &nextRandom %0 *1	; expects nextRandom() -> int
+		CALL &nextRandom %0 *1	; expects nextRandom() -> int @ 192:40
 		POKE &colorKeys:BLACK %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-isOnBoard:	FUNC	; signature func isOnBoard(int square) -> int
+isOnBoard:	FUNC	; signature func isOnBoard(int square) -> int @ 195:20
 	$square:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $b #FALSE 	; b = FALSE
@@ -318,7 +318,7 @@ isOnBoard:	FUNC	; signature func isOnBoard(int square) -> int
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-isValidColor:	FUNC	; signature func isValidColor(int color) -> int
+isValidColor:	FUNC	; signature func isValidColor(int color) -> int @ 204:23
 	$color:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $b #FALSE 	; b = FALSE
@@ -330,18 +330,18 @@ isValidColor:	FUNC	; signature func isValidColor(int color) -> int
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-isValidMove:	FUNC	; signature func isValidMove(int move) -> int
+isValidMove:	FUNC	; signature func isValidMove(int move) -> int @ 213:22
 	$move:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $b #FALSE 	; b = FALSE
 		ANDi %0 $move #MOVE_MASK	; if ((move & MOVE_MASK) == move && (int) isOnBoard(move & FROM_MASK) != FALSE && (int) isOnBoard((move & TO_MASK) >> TO_SHIFT) != FALSE) 
 		NEQi %0 $move @.f1
 		ANDi %1 $move #FROM_MASK
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 217:70
 		EQUi %0 #FALSE @.f1
 		ANDi %1 $move #TO_MASK
 		SHRi %1 %1 #TO_SHIFT
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 217:128
 		EQUi %0 #FALSE @.f1
 		MOVi $b #TRUE 	; b = TRUE
 	.f1:	RETU   	; }
@@ -349,7 +349,7 @@ isValidMove:	FUNC	; signature func isValidMove(int move) -> int
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-isValidPiece:	FUNC	; signature func isValidPiece(int piece) -> int
+isValidPiece:	FUNC	; signature func isValidPiece(int piece) -> int @ 222:23
 	$piece:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $b #FALSE 	; b = FALSE
@@ -360,7 +360,7 @@ isValidPiece:	FUNC	; signature func isValidPiece(int piece) -> int
 		ANDi %0 $piece #PIECE_MASK
 		GRTi %0 #6 @.f1
 		ANDi %1 $piece #COLOR_MASK
-		CALL &isValidColor %0 *2	; expects isValidColor(int) -> int
+		CALL &isValidColor %0 *2	; expects isValidColor(int) -> int @ 227:46
 		EQUi %0 #FALSE @.f1
 		MOVi $b #TRUE 	; b = TRUE
 	.f1:	RETU   	; }
@@ -368,12 +368,12 @@ isValidPiece:	FUNC	; signature func isValidPiece(int piece) -> int
 
 ;-----------------------------------------------------------------------------
 	$f:	OUTi
-moveFrom:	FUNC	; signature func moveFrom(int move) -> int
+moveFrom:	FUNC	; signature func moveFrom(int move) -> int @ 232:19
 	$move:	INPi
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isValidMove(move) != FALSE)
 		MOVi %1 $move 
-		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int
+		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int @ 235:33
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisV4d2 
 		CALL ^assertFail %0 *1
@@ -383,12 +383,12 @@ moveFrom:	FUNC	; signature func moveFrom(int move) -> int
 
 ;-----------------------------------------------------------------------------
 	$t:	OUTi
-moveTo:	FUNC	; signature func moveTo(int move) -> int
+moveTo:	FUNC	; signature func moveTo(int move) -> int @ 239:17
 	$move:	INPi
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isValidMove(move) != FALSE)
 		MOVi %1 $move 
-		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int
+		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int @ 242:33
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisV4d2 
 		CALL ^assertFail %0 *1
@@ -398,7 +398,7 @@ moveTo:	FUNC	; signature func moveTo(int move) -> int
 
 ;-----------------------------------------------------------------------------
 	$m:	OUTi
-makeMove:	FUNC	; signature func makeMove(int fromCol, int fromRow, int toCol, int toRow) -> int
+makeMove:	FUNC	; signature func makeMove(int fromCol, int fromRow, int toCol, int toRow) -> int @ 246:19
 	$fromCol:	INPi
 	$fromRow:	INPi
 	$toCol:	INPi
@@ -419,7 +419,7 @@ makeMove:	FUNC	; signature func makeMove(int fromCol, int fromRow, int toCol, in
 
 ;-----------------------------------------------------------------------------
 	$c:	OUTi
-switchColor:	FUNC	; signature func switchColor(int color) -> int
+switchColor:	FUNC	; signature func switchColor(int color) -> int @ 252:22
 	$color:	INPi
 ;-----------------------------------------------------------------------------
 		XORi $c $color #COLOR_SWITCH_XOR	; c = (color ^ COLOR_SWITCH_XOR)
@@ -428,7 +428,7 @@ switchColor:	FUNC	; signature func switchColor(int color) -> int
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-checkInvariant:	FUNC	; signature func checkInvariant() -> int
+checkInvariant:	FUNC	; signature func checkInvariant() -> int @ 258:25
 	! IORi <B> #BLACK #WHITE
 	! ADDi <B> <B> #1
 	! IORi <B> #BLACK #WHITE
@@ -443,7 +443,7 @@ checkInvariant:	FUNC	; signature func checkInvariant() -> int
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isValidColor(global turnColor) != FALSE)
 		PEEK %1 &turnColor 
-		CALL &isValidColor %0 *2	; expects isValidColor(int) -> int
+		CALL &isValidColor %0 *2	; expects isValidColor(int) -> int @ 263:46
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisV4d3 
 		CALL ^assertFail %0 *1
@@ -461,7 +461,7 @@ checkInvariant:	FUNC	; signature func checkInvariant() -> int
 		PEEK %1 &xCapture 
 		! XORi <B> #128 #-1
 		ANDi %1 %1 <B>
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 267:50
 		NEQi %0 #FALSE @.a4
 		MOVp %1 &.a_intisO4d5 
 		CALL ^assertFail %0 *1
@@ -542,7 +542,7 @@ checkInvariant:	FUNC	; signature func checkInvariant() -> int
 	.a19:	NOOP
 		! EQUi #DEBUG #0 @.a20	; assert((int) isValidPiece(p) != FALSE)
 		MOVi %1 $p 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 287:33
 		NEQi %0 #FALSE @.a20
 		MOVp %1 &.a_intisV4db 
 		CALL ^assertFail %0 *1
@@ -552,7 +552,7 @@ checkInvariant:	FUNC	; signature func checkInvariant() -> int
 		SETL $counts $color %0
 		GOTO @.l17  	; }
 	.e18:	MOVi %1 $color 	; color = (int) switchColor(color)
-		CALL &switchColor %0 *2	; expects switchColor(int) -> int
+		CALL &switchColor %0 *2	; expects switchColor(int) -> int @ 291:35
 		MOVi $color %0 
 		NEQi $color #BLACK @.l16	; } while (color != BLACK)
 		MOVi $h #0 	; h = 0
@@ -570,7 +570,7 @@ checkInvariant:	FUNC	; signature func checkInvariant() -> int
 	.a23:	LEQi $p #EMPTY @.f25	; if (p > EMPTY) 
 		! EQUi #DEBUG #0 @.a26	; assert((int) isValidPiece(p) != FALSE)
 		MOVi %1 $p 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 300:33
 		NEQi %0 #FALSE @.a26
 		MOVp %1 &.a_intisV4db 
 		CALL ^assertFail %0 *1
@@ -613,7 +613,7 @@ checkInvariant:	FUNC	; signature func checkInvariant() -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-putPiece:	FUNC	; signature func putPiece(int square, int piece) -> void
+putPiece:	FUNC	; signature func putPiece(int square, int piece) -> void @ 314:19
 	$square:	INPi
 	$piece:	INPi
 	$c:	LOCi
@@ -621,14 +621,14 @@ putPiece:	FUNC	; signature func putPiece(int square, int piece) -> void
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(square) != FALSE)
 		MOVi %1 $square 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 317:33
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e1 
 		CALL ^assertFail %0 *1
 	.a0:	NOOP
 		! EQUi #DEBUG #0 @.a1	; assert((int) isValidPiece(piece) != FALSE)
 		MOVi %1 $piece 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 318:35
 		NEQi %0 #FALSE @.a1
 		MOVp %1 &.a_intisV4e2 
 		CALL ^assertFail %0 *1
@@ -657,7 +657,7 @@ putPiece:	FUNC	; signature func putPiece(int square, int piece) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-liftPiece:	FUNC	; signature func liftPiece(int square) -> void
+liftPiece:	FUNC	; signature func liftPiece(int square) -> void @ 331:20
 	$square:	INPi
 	$piece:	LOCi
 	$n:	LOCi
@@ -665,7 +665,7 @@ liftPiece:	FUNC	; signature func liftPiece(int square) -> void
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(square) != FALSE)
 		MOVi %1 $square 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 334:33
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e1 
 		CALL ^assertFail %0 *1
@@ -691,7 +691,7 @@ liftPiece:	FUNC	; signature func liftPiece(int square) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-movePiece:	FUNC	; signature func movePiece(int frm, int t, int newPiece) -> void
+movePiece:	FUNC	; signature func movePiece(int frm, int t, int newPiece) -> void @ 346:20
 	$frm:	INPi
 	$t:	INPi
 	$newPiece:	INPi
@@ -701,21 +701,21 @@ movePiece:	FUNC	; signature func movePiece(int frm, int t, int newPiece) -> void
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(frm) != FALSE)
 		MOVi %1 $frm 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 349:30
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e5 
 		CALL ^assertFail %0 *1
 	.a0:	NOOP
 		! EQUi #DEBUG #0 @.a1	; assert((int) isOnBoard(t) != FALSE)
 		MOVi %1 $t 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 350:28
 		NEQi %0 #FALSE @.a1
 		MOVp %1 &.a_intisO4e6 
 		CALL ^assertFail %0 *1
 	.a1:	NOOP
 		! EQUi #DEBUG #0 @.a2	; assert((int) isValidPiece(newPiece) != FALSE)
 		MOVi %1 $newPiece 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 351:38
 		NEQi %0 #FALSE @.a2
 		MOVp %1 &.a_intisV4e7 
 		CALL ^assertFail %0 *1
@@ -734,7 +734,7 @@ movePiece:	FUNC	; signature func movePiece(int frm, int t, int newPiece) -> void
 		PEEK $oldPiece &board $frm	; oldPiece = (int) global board[frm]
 		! EQUi #DEBUG #0 @.a5	; assert((int) isValidPiece(oldPiece) != FALSE)
 		MOVi %1 $oldPiece 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 357:38
 		NEQi %0 #FALSE @.a5
 		MOVp %1 &.a_intisV4ea 
 		CALL ^assertFail %0 *1
@@ -761,7 +761,7 @@ movePiece:	FUNC	; signature func movePiece(int frm, int t, int newPiece) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-restart:	FUNC	; signature func restart() -> void
+restart:	FUNC	; signature func restart() -> void @ 368:18
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
 		POKE &prevPiece:WHITE #WHITE 	; global nextPiece[WHITE] = (int) global prevPiece[WHITE] = WHITE
@@ -780,7 +780,7 @@ restart:	FUNC	; signature func restart() -> void
 		LEQi %1 #EMPTY @.f4
 		MOVi %1 $i 	; putPiece(i, (int) global INIT_BOARD[i])
 		PEEK %2 &INIT_BOARD $i
-		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void
+		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void @ 379:43
 	.f4:	NOOP
 	.e3:	FORi $i #BOARD_SIZE @.l1	; }
 	.e0:	MOVi $i #0 	; for (i = 0 to HASH_TABLE_SIZE) 
@@ -791,7 +791,7 @@ restart:	FUNC	; signature func restart() -> void
 		POKE &xCapture #0 	; global xCapture = 0
 		POKE &historyCount #0 	; global historyCount = 0
 		! EQUi #DEBUG #0 @.a7	; assert((int) checkInvariant() != FALSE)
-		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int
+		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int @ 388:32
 		NEQi %0 #FALSE @.a7
 		MOVp %1 &.a_intche4eb 
 		CALL ^assertFail %0 *1
@@ -800,7 +800,7 @@ restart:	FUNC	; signature func restart() -> void
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-squareCapturesCastlingKing:	FUNC	; signature func squareCapturesCastlingKing(int square) -> int
+squareCapturesCastlingKing:	FUNC	; signature func squareCapturesCastlingKing(int square) -> int @ 391:37
 	$square:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $b #FALSE 	; b = FALSE
@@ -818,12 +818,12 @@ squareCapturesCastlingKing:	FUNC	; signature func squareCapturesCastlingKing(int
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-squareCapturesKing:	FUNC	; signature func squareCapturesKing(int square) -> int
+squareCapturesKing:	FUNC	; signature func squareCapturesKing(int square) -> int @ 407:29
 	$square:	INPi
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(square) != FALSE)
 		MOVi %1 $square 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 410:33
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e1 
 		CALL ^assertFail %0 *1
@@ -832,7 +832,7 @@ squareCapturesKing:	FUNC	; signature func squareCapturesKing(int square) -> int
 		ANDi %0 %0 #PIECE_MASK
 		EQUi %0 #KING @.t1
 		MOVi %1 $square 
-		CALL &squareCapturesCastlingKing %0 *2	; expects squareCapturesCastlingKing(int) -> int
+		CALL &squareCapturesCastlingKing %0 *2	; expects squareCapturesCastlingKing(int) -> int @ 413:100
 		EQUi %0 #FALSE @.f2
 	.t1:	MOVi $b #TRUE 	; b = TRUE
 	.f2:	RETU   	; }
@@ -840,7 +840,7 @@ squareCapturesKing:	FUNC	; signature func squareCapturesKing(int square) -> int
 
 ;-----------------------------------------------------------------------------
 	$score:	OUTi
-doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured, int oldXCapture) -> int
+doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured, int oldXCapture) -> int @ 432:17
 	$frm:	INPi
 	$t:	INPi
 	$oldPiece:	INPi
@@ -850,21 +850,21 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(frm) != FALSE)
 		MOVi %1 $frm 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 436:30
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e5 
 		CALL ^assertFail %0 *1
 	.a0:	NOOP
 		! EQUi #DEBUG #0 @.a1	; assert((int) isOnBoard(t) != FALSE)
 		MOVi %1 $t 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 437:28
 		NEQi %0 #FALSE @.a1
 		MOVp %1 &.a_intisO4e6 
 		CALL ^assertFail %0 *1
 	.a1:	NOOP
 		! EQUi #DEBUG #0 @.a2	; assert((int) isValidPiece(oldPiece) != FALSE)
 		MOVi %1 $oldPiece 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 438:38
 		NEQi %0 #FALSE @.a2
 		MOVp %1 &.a_intisV4ea 
 		CALL ^assertFail %0 *1
@@ -872,7 +872,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		! EQUi #DEBUG #0 @.a3	; assert(captured == EMPTY || (int) isValidPiece(captured) != FALSE)
 		EQUi $captured #EMPTY @.a3
 		MOVi %1 $captured 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 439:59
 		NEQi %0 #FALSE @.a3
 		MOVp %1 &.a_captur4ec 
 		CALL ^assertFail %0 *1
@@ -883,12 +883,12 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		CALL ^assertFail %0 *1
 	.a5:	NOOP
 		! EQUi #DEBUG #0 @.a6	; assert((int) checkInvariant() != FALSE)
-		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int
+		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int @ 442:32
 		NEQi %0 #FALSE @.a6
 		MOVp %1 &.a_intche4eb 
 		CALL ^assertFail %0 *1
 	.a6:	MOVi $newPiece $oldPiece 	; newPiece = oldPiece
-		CALL &nextRandom %0 *1	; expects nextRandom() -> int
+		CALL &nextRandom %0 *1	; expects nextRandom() -> int @ 445:30
 		ANDi %0 %0 #7
 		SUBi $score %0 #4
 		POKE &xCapture #0 	; global xCapture = 0
@@ -907,7 +907,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		ADDi %2 #RANK_1 #4
 		! IORi <B> #ROOK #WHITE
 		IORi %3 <B> #MOVED_MASK
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 455:66
 		! ADDi <B> #RANK_1 #4	; global xCapture = (RANK_1 + 4) | CASTLING_MASK
 		! IORi <B> <B> #CASTLING_MASK
 		POKE &xCapture <B> 
@@ -919,7 +919,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		ADDi %2 #RANK_1 #6
 		! IORi <B> #ROOK #WHITE
 		IORi %3 <B> #MOVED_MASK
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 464:66
 		! ADDi <B> #RANK_1 #6	; global xCapture = (RANK_1 + 6) | CASTLING_MASK
 		! IORi <B> <B> #CASTLING_MASK
 		POKE &xCapture <B> 
@@ -946,7 +946,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		ADDi %2 #RANK_8 #4
 		! IORi <A> #ROOK #BLACK
 		IORi %3 <A> #MOVED_MASK
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 482:66
 		! ADDi <A> #RANK_8 #4	; global xCapture = (RANK_8 + 4) | CASTLING_MASK
 		! IORi <A> <A> #CASTLING_MASK
 		POKE &xCapture <A> 
@@ -958,7 +958,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		ADDi %2 #RANK_8 #6
 		! IORi <A> #ROOK #BLACK
 		IORi %3 <A> #MOVED_MASK
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 491:66
 		! ADDi <A> #RANK_8 #6	; global xCapture = (RANK_8 + 6) | CASTLING_MASK
 		! IORi <A> <A> #CASTLING_MASK
 		POKE &xCapture <A> 
@@ -983,7 +983,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		MOVp %1 &.a_intglo4ed 
 		CALL ^assertFail %0 *1
 	.a14:	SUBi %1 $t #STRIDE	; liftPiece(t - STRIDE)
-		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void
+		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void @ 508:26
 		ADDi %0 $score #PAWN_ADVANCE_SCORE	; score = score + PAWN_ADVANCE_SCORE + PAWN_VALUE
 		ADDi $score %0 #PAWN_VALUE
 		GOTO @.e8  	; } else if (t >= RANK_8) 
@@ -1008,7 +1008,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		MOVp %1 &.a_intglo4ee 
 		CALL ^assertFail %0 *1
 	.a19:	ADDi %1 $t #STRIDE	; liftPiece(t + STRIDE)
-		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void
+		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void @ 529:26
 		ADDi %0 $score #PAWN_ADVANCE_SCORE	; score = score + PAWN_ADVANCE_SCORE + PAWN_VALUE
 		ADDi $score %0 #PAWN_VALUE
 		GOTO @.e8  	; } else if (t < RANK_2) 
@@ -1043,11 +1043,11 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		SUBi $score %0 %1
 	.e8:	LEQi $captured #EMPTY @.f25	; if (captured > EMPTY) 
 		MOVi %1 $t 	; liftPiece(t)
-		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void
+		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void @ 571:15
 	.f25:	MOVi %1 $frm 	; movePiece(frm, t, newPiece | MOVED_MASK)
 		MOVi %2 $t 
 		IORi %3 $newPiece #MOVED_MASK
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 573:42
 		! IORi <B> #PIECE_MASK #COLOR_MASK	; switch ((captured & (PIECE_MASK | COLOR_MASK)) == 0 to MAX_PIECE_AND_MOVED_VALUE) 
 		ANDi %0 $captured <B>
 		SWCH %0 *MAX_PIECE_AND_MOVED_VALUE @.s26
@@ -1073,10 +1073,10 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 		PEEK %1 &RANK_VALUES %1
 		ADDi $score %0 %1
 	.e27:	PEEK %1 &turnColor 	; global turnColor = (int) switchColor(global turnColor)
-		CALL &switchColor %0 *2	; expects switchColor(int) -> int
+		CALL &switchColor %0 *2	; expects switchColor(int) -> int @ 596:56
 		POKE &turnColor %0 
 		! EQUi #DEBUG #0 @.a28	; assert((int) checkInvariant() != FALSE)
-		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int
+		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int @ 598:32
 		NEQi %0 #FALSE @.a28
 		MOVp %1 &.a_intche4eb 
 		CALL ^assertFail %0 *1
@@ -1085,7 +1085,7 @@ doMove:	FUNC	; signature func doMove(int frm, int t, int oldPiece, int captured,
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captured, int oldXCapture) -> void
+undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captured, int oldXCapture) -> void @ 603:19
 	$frm:	INPi
 	$t:	INPi
 	$oldPiece:	INPi
@@ -1094,21 +1094,21 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(frm) != FALSE)
 		MOVi %1 $frm 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 605:30
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e5 
 		CALL ^assertFail %0 *1
 	.a0:	NOOP
 		! EQUi #DEBUG #0 @.a1	; assert((int) isOnBoard(t) != FALSE)
 		MOVi %1 $t 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 606:28
 		NEQi %0 #FALSE @.a1
 		MOVp %1 &.a_intisO4e6 
 		CALL ^assertFail %0 *1
 	.a1:	NOOP
 		! EQUi #DEBUG #0 @.a2	; assert((int) isValidPiece(oldPiece) != FALSE)
 		MOVi %1 $oldPiece 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 607:38
 		NEQi %0 #FALSE @.a2
 		MOVp %1 &.a_intisV4ea 
 		CALL ^assertFail %0 *1
@@ -1116,7 +1116,7 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 		! EQUi #DEBUG #0 @.a3	; assert(captured == EMPTY || (int) isValidPiece(captured) != FALSE)
 		EQUi $captured #EMPTY @.a3
 		MOVi %1 $captured 
-		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int
+		CALL &isValidPiece %0 *2	; expects isValidPiece(int) -> int @ 608:59
 		NEQi %0 #FALSE @.a3
 		MOVp %1 &.a_captur4ec 
 		CALL ^assertFail %0 *1
@@ -1127,20 +1127,20 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 		CALL ^assertFail %0 *1
 	.a5:	NOOP
 		! EQUi #DEBUG #0 @.a6	; assert((int) checkInvariant() != FALSE)
-		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int
+		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int @ 611:32
 		NEQi %0 #FALSE @.a6
 		MOVp %1 &.a_intche4eb 
 		CALL ^assertFail %0 *1
 	.a6:	POKE &xCapture $oldXCapture 	; global xCapture = oldXCapture
 		MOVi %1 $frm 	; putPiece(frm, oldPiece)
 		MOVi %2 $oldPiece 
-		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void
+		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void @ 614:25
 		MOVi %1 $t 	; liftPiece(t)
-		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void
+		CALL &liftPiece %0 *2	; expects liftPiece(int) -> void @ 615:14
 		LEQi $captured #EMPTY @.f7	; if (captured > EMPTY) 
 		MOVi %1 $t 	; putPiece(t, captured)
 		MOVi %2 $captured 
-		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void
+		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void @ 617:24
 	.f7:	SWCH $oldPiece *MAX_PIECE_AND_MOVED_VALUE @.s8	; switch (oldPiece == 0 to MAX_PIECE_AND_MOVED_VALUE) 
 		! IORi <B> #KING #WHITE	; case KING | WHITE
 	.s8#<B>:	NOOP
@@ -1155,14 +1155,14 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 	.s10#<B>:	ADDi %1 #RANK_1 #4	; movePiece(RANK_1 + 4, RANK_1 + 1, ROOK | WHITE)
 		ADDi %2 #RANK_1 #1
 		IORi %3 #ROOK #WHITE
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 627:53
 		GOTO @.e9  	; }
 		! ADDi <B> #RANK_1 #7	; case RANK_1 + 7
 		! SUBi <B> <B> <A>
 	.s10#<B>:	ADDi %1 #RANK_1 #6	; movePiece(RANK_1 + 6, RANK_1 + 8, ROOK | WHITE)
 		ADDi %2 #RANK_1 #8
 		IORi %3 #ROOK #WHITE
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 634:53
 	.s10:	NOOP
 	.e11:	GOTO @.e9  	; }
 		! IORi <A> #KING #BLACK	; case KING | BLACK
@@ -1178,14 +1178,14 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 	.s12#<A>:	ADDi %1 #RANK_8 #4	; movePiece(RANK_8 + 4, RANK_8 + 1, ROOK | BLACK)
 		ADDi %2 #RANK_8 #1
 		IORi %3 #ROOK #BLACK
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 645:53
 		GOTO @.e9  	; }
 		! ADDi <A> #RANK_8 #7	; case RANK_8 + 7
 		! SUBi <A> <A> <B>
 	.s12#<A>:	ADDi %1 #RANK_8 #6	; movePiece(RANK_8 + 6, RANK_8 + 8, ROOK | BLACK)
 		ADDi %2 #RANK_8 #8
 		IORi %3 #ROOK #BLACK
-		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void
+		CALL &movePiece %0 *4	; expects movePiece(int, int, int) -> void @ 652:53
 	.s12:	NOOP
 	.e13:	GOTO @.e9  	; }
 		! IORi <B> #PAWN #WHITE	; case PAWN | WHITE | MOVED_MASK
@@ -1194,7 +1194,7 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 		SUBi %1 $t #STRIDE	; putPiece(t - STRIDE, PAWN | BLACK | MOVED_MASK)
 		! IORi <B> #PAWN #BLACK
 		IORi %2 <B> #MOVED_MASK
-		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void
+		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void @ 662:52
 		GOTO @.e9  	; }
 		! IORi <B> #PAWN #BLACK	; case PAWN | BLACK | MOVED_MASK
 		! IORi <B> <B> #MOVED_MASK
@@ -1202,14 +1202,14 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 		ADDi %1 $t #STRIDE	; putPiece(t + STRIDE, PAWN | WHITE | MOVED_MASK)
 		! IORi <B> #PAWN #WHITE
 		IORi %2 <B> #MOVED_MASK
-		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void
+		CALL &putPiece %0 *3	; expects putPiece(int, int) -> void @ 671:52
 	.f15:	NOOP
 	.s8:	NOOP
 	.e9:	PEEK %1 &turnColor 	; global turnColor = (int) switchColor(global turnColor)
-		CALL &switchColor %0 *2	; expects switchColor(int) -> int
+		CALL &switchColor %0 *2	; expects switchColor(int) -> int @ 676:56
 		POKE &turnColor %0 
 		! EQUi #DEBUG #0 @.a16	; assert((int) checkInvariant() != FALSE)
-		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int
+		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int @ 678:32
 		NEQi %0 #FALSE @.a16
 		MOVp %1 &.a_intche4eb 
 		CALL ^assertFail %0 *1
@@ -1218,7 +1218,7 @@ undoMove:	FUNC	; signature func undoMove(int frm, int t, int oldPiece, int captu
 
 ;-----------------------------------------------------------------------------
 	$newToCount:	OUTi
-traceRBQ:	FUNC	; signature func traceRBQ(int color, int frm, int toCount, ptr tos, int start, int step) -> int
+traceRBQ:	FUNC	; signature func traceRBQ(int color, int frm, int toCount, ptr tos, int start, int step) -> int @ 681:19
 	$color:	INPi
 	$frm:	INPi
 	$toCount:	INPi
@@ -1232,13 +1232,13 @@ traceRBQ:	FUNC	; signature func traceRBQ(int color, int frm, int toCount, ptr to
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(frm) != FALSE)
 		MOVi %1 $frm 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 685:30
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e5 
 		CALL ^assertFail %0 *1
 	.a0:	MOVi $newToCount $toCount 	; newToCount = toCount
 		MOVi %1 $color 	; cx = (int) switchColor(color)
-		CALL &switchColor %0 *2	; expects switchColor(int) -> int
+		CALL &switchColor %0 *2	; expects switchColor(int) -> int @ 690:31
 		MOVi $cx %0 
 		MOVi $d $start 	; d = start
 	.l1:	GEQi $d #8 @.e2	; while (d < 8) 
@@ -1262,7 +1262,7 @@ traceRBQ:	FUNC	; signature func traceRBQ(int color, int frm, int toCount, ptr to
 
 ;-----------------------------------------------------------------------------
 	$toCount:	OUTi
-listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
+listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int @ 708:20
 	$color:	INPi
 	$frm:	INPi
 	$tos:	INPp
@@ -1274,7 +1274,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isOnBoard(frm) != FALSE)
 		MOVi %1 $frm 
-		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int
+		CALL &isOnBoard %0 *2	; expects isOnBoard(int) -> int @ 712:30
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisO4e5 
 		CALL ^assertFail %0 *1
@@ -1300,7 +1300,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 		POKE $tos $toCount %0
 		ADDi $toCount $toCount #1	; toCount = toCount + 1
 	.f4:	MOVi %1 $color 	; cx = (int) switchColor(color)
-		CALL &switchColor %0 *2	; expects switchColor(int) -> int
+		CALL &switchColor %0 *2	; expects switchColor(int) -> int @ 729:33
 		MOVi $cx %0 
 		SUBi $t $t #1	; t = t - 1
 		PEEK %0 &board $t	; if (((int) global board[t] & COLOR_MASK) == cx || global xCapture == t || (int) squareCapturesCastlingKing(t) != FALSE) 
@@ -1309,7 +1309,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 		PEEK %0 &xCapture 
 		EQUi %0 $t @.t7
 		MOVi %1 $t 
-		CALL &squareCapturesCastlingKing %0 *2	; expects squareCapturesCastlingKing(int) -> int
+		CALL &squareCapturesCastlingKing %0 *2	; expects squareCapturesCastlingKing(int) -> int @ 731:114
 		EQUi %0 #FALSE @.f8
 	.t7:	POKE $tos $toCount $t	; tos[toCount] = t
 		ADDi $toCount $toCount #1	; toCount = toCount + 1
@@ -1320,7 +1320,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 		PEEK %0 &xCapture 
 		EQUi %0 $t @.t9
 		MOVi %1 $t 
-		CALL &squareCapturesCastlingKing %0 *2	; expects squareCapturesCastlingKing(int) -> int
+		CALL &squareCapturesCastlingKing %0 *2	; expects squareCapturesCastlingKing(int) -> int @ 736:114
 		EQUi %0 #FALSE @.e2
 	.t9:	POKE $tos $toCount $t	; tos[toCount] = t
 		ADDi $toCount $toCount #1	; toCount = toCount + 1
@@ -1331,7 +1331,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 		MOVp %4 $tos 
 		MOVi %5 #0 
 		MOVi %6 #2 
-		CALL &traceRBQ %0 *7	; expects traceRBQ(int, int, int, ptr, int, int) -> int
+		CALL &traceRBQ %0 *7	; expects traceRBQ(int, int, int, ptr, int, int) -> int @ 742:70
 		MOVi $toCount %0 
 		GOTO @.e2  
 	.s1#BISHOP:	MOVi %1 $color 	; toCount = (int) traceRBQ(color, frm, toCount, tos, 1, 2)
@@ -1340,7 +1340,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 		MOVp %4 $tos 
 		MOVi %5 #1 
 		MOVi %6 #2 
-		CALL &traceRBQ %0 *7	; expects traceRBQ(int, int, int, ptr, int, int) -> int
+		CALL &traceRBQ %0 *7	; expects traceRBQ(int, int, int, ptr, int, int) -> int @ 743:72
 		MOVi $toCount %0 
 		GOTO @.e2  
 	.s1#QUEEN:	MOVi %1 $color 	; toCount = (int) traceRBQ(color, frm, toCount, tos, 0, 1)
@@ -1349,7 +1349,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 		MOVp %4 $tos 
 		MOVi %5 #0 
 		MOVi %6 #1 
-		CALL &traceRBQ %0 *7	; expects traceRBQ(int, int, int, ptr, int, int) -> int
+		CALL &traceRBQ %0 *7	; expects traceRBQ(int, int, int, ptr, int, int) -> int @ 744:71
 		MOVi $toCount %0 
 		GOTO @.e2  
 	.s1#KING:	MOVi $d #0 	; for (d = 0 to 8) 
@@ -1424,7 +1424,7 @@ listMoves:	FUNC	; signature func listMoves(int color, int frm, ptr tos) -> int
 
 ;-----------------------------------------------------------------------------
 	$b:	OUTi
-canCaptureKing:	FUNC	; signature func canCaptureKing(int color) -> int
+canCaptureKing:	FUNC	; signature func canCaptureKing(int color) -> int @ 795:25
 	$color:	INPi
 	$tos:	LOCA *MAX_TARGET_SQUARES
 	$frm:	LOCi
@@ -1433,7 +1433,7 @@ canCaptureKing:	FUNC	; signature func canCaptureKing(int color) -> int
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isValidColor(color) != FALSE)
 		MOVi %1 $color 
-		CALL &isValidColor %0 *2	; expects isValidColor(int) -> int
+		CALL &isValidColor %0 *2	; expects isValidColor(int) -> int @ 799:35
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisV4f1 
 		CALL ^assertFail %0 *1
@@ -1443,12 +1443,12 @@ canCaptureKing:	FUNC	; signature func canCaptureKing(int color) -> int
 		MOVi %1 $color 	; toCount = (int) listMoves(color, frm, tos)
 		MOVi %2 $frm 
 		ADRL %3 $tos *0
-		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int
+		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int @ 803:45
 		MOVi $toCount %0 
 		MOVi $i #0 	; for (i = 0 to toCount) 
 		GEQi #0 $toCount @.e3
 	.l4:	GETL %1 $tos $i	; if ((int) squareCapturesKing(tos[i]) != FALSE) 
-		CALL &squareCapturesKing %0 *2	; expects squareCapturesKing(int) -> int
+		CALL &squareCapturesKing %0 *2	; expects squareCapturesKing(int) -> int @ 805:41
 		EQUi %0 #FALSE @.f5
 		MOVi $b #TRUE 	; b = TRUE
 		GOTO @returnNow  	; goto returnNow
@@ -1458,11 +1458,11 @@ canCaptureKing:	FUNC	; signature func canCaptureKing(int color) -> int
 	.e2:	NOOP
 	returnNow:	RETU   	; }
 
-; signature extern func search() -> unknown
+; signature extern func search() -> unknown @ 815:23
 
 ;-----------------------------------------------------------------------------
 	$bestMove:	OUTi
-findBestMove:	FUNC	; signature func findBestMove(int lowestScore, int alpha, int beta, int depth, int score, int movesCount, ptr moves) -> int
+findBestMove:	FUNC	; signature func findBestMove(int lowestScore, int alpha, int beta, int depth, int score, int movesCount, ptr moves) -> int @ 817:23
 	$lowestScore:	INPi
 	$alpha:	INPi
 	$beta:	INPi
@@ -1491,10 +1491,10 @@ findBestMove:	FUNC	; signature func findBestMove(int lowestScore, int alpha, int
 		GEQi $myAlpha $beta @.e2
 		PEEK $move $moves $i	; move = (int) moves[i]
 		MOVi %1 $move 	; frm = (int) moveFrom(move)
-		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int
+		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int @ 828:29
 		MOVi $frm %0 
 		MOVi %1 $move 	; t = (int) moveTo(move)
-		CALL &moveTo %0 *2	; expects moveTo(int) -> int
+		CALL &moveTo %0 *2	; expects moveTo(int) -> int @ 829:25
 		MOVi $t %0 
 		PEEK $oldPiece &board $frm	; oldPiece = (int) global board[frm]
 		PEEK $captured &board $t	; captured = (int) global board[t]
@@ -1504,7 +1504,7 @@ findBestMove:	FUNC	; signature func findBestMove(int lowestScore, int alpha, int
 		MOVi %3 $oldPiece 
 		MOVi %4 $captured 
 		MOVi %5 $oldXCapture 
-		CALL &doMove %0 *6	; expects doMove(int, int, int, int, int) -> int
+		CALL &doMove %0 *6	; expects doMove(int, int, int, int, int) -> int @ 833:68
 		MOVi $moveScore %0 
 		ADDi $s $score $moveScore	; s = score + moveScore
 		LEQi $depth #0 @.f3	; if (depth > 0) 
@@ -1516,7 +1516,7 @@ findBestMove:	FUNC	; signature func findBestMove(int lowestScore, int alpha, int
 		SUBi %3 $depth #1
 		SUBi %4 #0 $s
 		MOVi %5 $capturesOnly 
-		CALL &search %0 *6	; expects search(int, int, int, int, int) -> unknown
+		CALL &search %0 *6	; expects search(int, int, int, int, int) -> unknown @ 841:69
 		SHRi %0 %0 #SCORE_SHIFT
 		SUBi $s #0 %0
 	.f3:	GEQi $bestScore $s @.f5	; if (bestScore < s) 
@@ -1529,7 +1529,7 @@ findBestMove:	FUNC	; signature func findBestMove(int lowestScore, int alpha, int
 		MOVi %3 $oldPiece 
 		MOVi %4 $captured 
 		MOVi %5 $oldXCapture 
-		CALL &undoMove %0 *6	; expects undoMove(int, int, int, int, int) -> void
+		CALL &undoMove %0 *6	; expects undoMove(int, int, int, int, int) -> void @ 851:52
 		ADDi $i $i #1	; i = i + 1
 		GOTO @.l0  	; }
 	.e2:	SHLi %0 $bestScore #SCORE_SHIFT	; bestMove = bestMove | (bestScore << SCORE_SHIFT)
@@ -1539,7 +1539,7 @@ findBestMove:	FUNC	; signature func findBestMove(int lowestScore, int alpha, int
 
 ;-----------------------------------------------------------------------------
 	$bestMove:	OUTi
-searchCaptures:	FUNC	; signature func searchCaptures(int alpha, int beta, int depth, int score, int firstMove) -> int
+searchCaptures:	FUNC	; signature func searchCaptures(int alpha, int beta, int depth, int score, int firstMove) -> int @ 857:25
 	$alpha:	INPi
 	$beta:	INPi
 	$depth:	INPi
@@ -1563,7 +1563,7 @@ searchCaptures:	FUNC	; signature func searchCaptures(int alpha, int beta, int de
 		! EQUi #DEBUG #0 @.a1	; assert(firstMove == 0 || (int) isValidMove(firstMove) != FALSE)
 		EQUi $firstMove #0 @.a1
 		MOVi %1 $firstMove 
-		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int
+		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int @ 862:56
 		NEQi %0 #FALSE @.a1
 		MOVp %1 &.a_firstM4f3 
 		CALL ^assertFail %0 *1
@@ -1581,7 +1581,7 @@ searchCaptures:	FUNC	; signature func searchCaptures(int alpha, int beta, int de
 		PEEK %1 &turnColor 	; toCount = (int) listMoves(global turnColor, frm, tos)
 		MOVi %2 $frm 
 		ADRL %3 $tos *0
-		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int
+		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int @ 875:57
 		MOVi $toCount %0 
 		MOVi $i #0 	; for (i = 0 to toCount) 
 		GEQi #0 $toCount @.e8
@@ -1589,7 +1589,7 @@ searchCaptures:	FUNC	; signature func searchCaptures(int alpha, int beta, int de
 		SHLi %0 $t #TO_SHIFT	; move = frm | (t << TO_SHIFT)
 		IORi $move $frm %0
 		MOVi %1 $t 	; if ((int) squareCapturesKing(t) != FALSE) 
-		CALL &squareCapturesKing %0 *2	; expects squareCapturesKing(int) -> int
+		CALL &squareCapturesKing %0 *2	; expects squareCapturesKing(int) -> int @ 880:37
 		EQUi %0 #FALSE @.f10
 		ADDi %0 #CAPTURE_KING_MIN_SCORE $depth	; bestMove = ((CAPTURE_KING_MIN_SCORE + depth) << SCORE_SHIFT) | move
 		SHLi %0 %0 #SCORE_SHIFT
@@ -1622,7 +1622,7 @@ searchCaptures:	FUNC	; signature func searchCaptures(int alpha, int beta, int de
 		MOVi %5 $score 
 		MOVi %6 $capturesCount 
 		ADRL %7 $moves *0
-		CALL &findBestMove %0 *8	; expects findBestMove(int, int, int, int, int, int, ptr) -> int
+		CALL &findBestMove %0 *8	; expects findBestMove(int, int, int, int, int, int, ptr) -> int @ 900:90
 		MOVi $bestMove %0 
 	.e5:	NOOP
 	returnNow:	RETU   	; }
@@ -1630,7 +1630,7 @@ searchCaptures:	FUNC	; signature func searchCaptures(int alpha, int beta, int de
 
 ;-----------------------------------------------------------------------------
 	$bestMove:	OUTi
-searchAll:	FUNC	; signature func searchAll(int alpha, int beta, int depth, int score, int firstMove) -> int
+searchAll:	FUNC	; signature func searchAll(int alpha, int beta, int depth, int score, int firstMove) -> int @ 905:20
 	$alpha:	INPi
 	$beta:	INPi
 	$depth:	INPi
@@ -1654,7 +1654,7 @@ searchAll:	FUNC	; signature func searchAll(int alpha, int beta, int depth, int s
 		! EQUi #DEBUG #0 @.a1	; assert(firstMove == 0 || (int) isValidMove(firstMove) != FALSE)
 		EQUi $firstMove #0 @.a1
 		MOVi %1 $firstMove 
-		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int
+		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int @ 911:56
 		NEQi %0 #FALSE @.a1
 		MOVp %1 &.a_firstM4f3 
 		CALL ^assertFail %0 *1
@@ -1672,7 +1672,7 @@ searchAll:	FUNC	; signature func searchAll(int alpha, int beta, int depth, int s
 		PEEK %1 &turnColor 	; toCount = (int) listMoves(global turnColor, frm, tos)
 		MOVi %2 $frm 
 		ADRL %3 $tos *0
-		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int
+		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int @ 929:57
 		MOVi $toCount %0 
 		MOVi $i #0 	; for (i = 0 to toCount) 
 		GEQi #0 $toCount @.e7
@@ -1680,7 +1680,7 @@ searchAll:	FUNC	; signature func searchAll(int alpha, int beta, int depth, int s
 		SHLi %0 $t #TO_SHIFT	; move = frm | (t << TO_SHIFT)
 		IORi $move $frm %0
 		MOVi %1 $t 	; if ((int) squareCapturesKing(t) != FALSE) 
-		CALL &squareCapturesKing %0 *2	; expects squareCapturesKing(int) -> int
+		CALL &squareCapturesKing %0 *2	; expects squareCapturesKing(int) -> int @ 934:37
 		EQUi %0 #FALSE @.f9
 		ADDi %0 #CAPTURE_KING_MIN_SCORE $depth	; bestMove = ((CAPTURE_KING_MIN_SCORE + depth) << SCORE_SHIFT) | move
 		SHLi %0 %0 #SCORE_SHIFT
@@ -1730,7 +1730,7 @@ searchAll:	FUNC	; signature func searchAll(int alpha, int beta, int depth, int s
 		MOVi %5 $score 
 		MOVi %6 $movesCount 
 		ADRL %7 $moves *0
-		CALL &findBestMove %0 *8	; expects findBestMove(int, int, int, int, int, int, ptr) -> int
+		CALL &findBestMove %0 *8	; expects findBestMove(int, int, int, int, int, int, ptr) -> int @ 967:95
 		MOVi $bestMove %0 
 	.e4:	NOOP
 	returnNow:	RETU   	; }
@@ -1738,7 +1738,7 @@ searchAll:	FUNC	; signature func searchAll(int alpha, int beta, int depth, int s
 
 ;-----------------------------------------------------------------------------
 	$result:	OUTi
-search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, int capturesOnly) -> int
+search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, int capturesOnly) -> int @ 972:17
 	$alpha:	INPi
 	$beta:	INPi
 	$depth:	INPi
@@ -1759,7 +1759,7 @@ search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, 
 		CALL ^assertFail %0 *1
 	.a0:	NOOP
 		! EQUi #DEBUG #0 @.a1	; assert((int) checkInvariant() != FALSE)
-		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int
+		CALL &checkInvariant %0 *1	; expects checkInvariant() -> int @ 977:32
 		NEQi %0 #FALSE @.a1
 		MOVp %1 &.a_intche4eb 
 		CALL ^assertFail %0 *1
@@ -1791,7 +1791,7 @@ search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, 
 		MOVi %3 $depth 
 		MOVi %4 $score 
 		MOVi %5 $firstMove 
-		CALL &searchCaptures %0 *6	; expects searchCaptures(int, int, int, int, int) -> int
+		CALL &searchCaptures %0 *6	; expects searchCaptures(int, int, int, int, int) -> int @ 1007:70
 		MOVi $best %0 
 		MOVi $result $best 	; result = best
 		GOTO @.e5  	; } else 
@@ -1800,7 +1800,7 @@ search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, 
 		MOVi %3 $depth 
 		MOVi %4 $score 
 		MOVi %5 $firstMove 
-		CALL &searchAll %0 *6	; expects searchAll(int, int, int, int, int) -> int
+		CALL &searchAll %0 *6	; expects searchAll(int, int, int, int, int) -> int @ 1013:65
 		MOVi $best %0 
 		MOVi $result $best 	; result = best
 		SHRi $s $result #SCORE_SHIFT	; s = result >> SCORE_SHIFT
@@ -1814,8 +1814,8 @@ search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, 
 		SUBi %0 #0 %0
 		NEQi $s %0 @.f8
 		PEEK %2 &turnColor 	; if ((int) canCaptureKing((int) switchColor(global turnColor)) != FALSE) 
-		CALL &switchColor %1 *2	; expects switchColor(int) -> int
-		CALL &canCaptureKing %0 *2	; expects canCaptureKing(int) -> int
+		CALL &switchColor %1 *2	; expects switchColor(int) -> int @ 1030:64
+		CALL &canCaptureKing %0 *2	; expects canCaptureKing(int) -> int @ 1030:66
 		EQUi %0 #FALSE @.f9
 		ANDi %0 $result #SCORE_MASK	; result = (result & SCORE_MASK) | CHECKMATE
 		IORi $result %0 #CHECKMATE
@@ -1829,7 +1829,7 @@ search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, 
 		EQUi $bestMove #0 @.f11	; if (bestMove != 0) 
 		! EQUi #DEBUG #0 @.a12	; assert((int) isValidMove(bestMove) != FALSE)
 		MOVi %1 $bestMove 
-		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int
+		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int @ 1040:38
 		NEQi %0 #FALSE @.a12
 		MOVp %1 &.a_intisV4f6 
 		CALL ^assertFail %0 *1
@@ -1848,7 +1848,7 @@ search:	FUNC	; signature func search(int alpha, int beta, int depth, int score, 
 
 ;-----------------------------------------------------------------------------
 	$status:	OUTi
-executeMove:	FUNC	; signature func executeMove(int move) -> int
+executeMove:	FUNC	; signature func executeMove(int move) -> int @ 1053:22
 	$move:	INPi
 	$tos:	LOCA *MAX_TARGET_SQUARES
 	$frm:	LOCi
@@ -1861,7 +1861,7 @@ executeMove:	FUNC	; signature func executeMove(int move) -> int
 ;-----------------------------------------------------------------------------
 		! EQUi #DEBUG #0 @.a0	; assert((int) isValidMove(move) != FALSE)
 		MOVi %1 $move 
-		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int
+		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int @ 1057:33
 		NEQi %0 #FALSE @.a0
 		MOVp %1 &.a_intisV4d2 
 		CALL ^assertFail %0 *1
@@ -1881,7 +1881,7 @@ executeMove:	FUNC	; signature func executeMove(int move) -> int
 	.a3:	PEEK %1 &turnColor 	; toCount = (int) listMoves(global turnColor, frm, tos)
 		MOVi %2 $frm 
 		ADRL %3 $tos *0
-		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int
+		CALL &listMoves %0 *4	; expects listMoves(int, int, ptr) -> int @ 1062:56
 		MOVi $toCount %0 
 		! EQUi #DEBUG #0 @.a5	; assert(toCount <= MAX_TARGET_SQUARES)
 		LEQi $toCount #MAX_TARGET_SQUARES @.a5
@@ -1901,13 +1901,13 @@ executeMove:	FUNC	; signature func executeMove(int move) -> int
 		MOVi %3 $oldPiece 
 		MOVi %4 $captured 
 		MOVi %5 $oldXCapture 
-		CALL &doMove %0 *6	; expects doMove(int, int, int, int, int) -> int
+		CALL &doMove %0 *6	; expects doMove(int, int, int, int, int) -> int @ 1070:52
 		MOVi %1 #MIN_SCORE 	; switch (((int) search(MIN_SCORE, MAX_SCORE, 1, 0, FALSE) & MOVE_MASK) == IN_CHECK to (CHECKMATE + 1)) 
 		MOVi %2 #MAX_SCORE 
 		MOVi %3 #1 
 		MOVi %4 #0 
 		MOVi %5 #FALSE 
-		CALL &search %0 *6	; expects search(int, int, int, int, int) -> int
+		CALL &search %0 *6	; expects search(int, int, int, int, int) -> int @ 1072:62
 		! ADDi <B> #CHECKMATE #1
 		! SUBi <B> <B> #IN_CHECK
 		ANDi %0 %0 #MOVE_MASK
@@ -1930,7 +1930,7 @@ executeMove:	FUNC	; signature func executeMove(int move) -> int
 		MOVi %3 $oldPiece 
 		MOVi %4 $captured 
 		MOVi %5 $oldXCapture 
-		CALL &undoMove %0 *6	; expects undoMove(int, int, int, int, int) -> void
+		CALL &undoMove %0 *6	; expects undoMove(int, int, int, int, int) -> void @ 1077:56
 		MOVi $status #IN_CHECK 	; status = IN_CHECK
 		GOTO @returnNow  	; goto returnNow
 	.e10:	NOOP
@@ -1943,7 +1943,7 @@ executeMove:	FUNC	; signature func executeMove(int move) -> int
 
 ;-----------------------------------------------------------------------------
 	$move:	OUTi
-getComputerMove:	FUNC	; signature func getComputerMove() -> int
+getComputerMove:	FUNC	; signature func getComputerMove() -> int @ 1094:26
 	$d:	LOCi
 	$m:	LOCi
 	$printedThinking:	LOCi
@@ -1960,22 +1960,22 @@ getComputerMove:	FUNC	; signature func getComputerMove() -> int
 		LEQi %0 #10000 @.f3
 		NEQi $printedThinking #FALSE @.f4	; if (printedThinking == FALSE) 
 		MOVp %1 &.s_Thinki4d8 	; output("Thinking...")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1105:26
 		MOVi $printedThinking #TRUE 	; printedThinking = TRUE
 	.f4:	MOVp %1 &.s_Thinki4d8:10 	; output(".")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1108:15
 	.f3:	MOVi %1 #MIN_SCORE 	; m = (int) search(MIN_SCORE, MAX_SCORE, d, 0, FALSE)
 		MOVi %2 #MAX_SCORE 
 		MOVi %3 $d 
 		MOVi %4 #0 
 		MOVi %5 #FALSE 
-		CALL &search %0 *6	; expects search(int, int, int, int, int) -> int
+		CALL &search %0 *6	; expects search(int, int, int, int, int) -> int @ 1110:54
 		MOVi $m %0 
 		ADDi $d $d #1	; d = d + 1
 		GOTO @.l0  	; }
 	.e2:	EQUi $printedThinking #FALSE @.f5	; if (printedThinking != FALSE) 
 		MOVp %1 &.s_4d9 	; output("\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1114:15
 	.f5:	NOOP
 		! EQUi #DEBUG #0 @.a6	; assert((m & MOVE_MASK) == CHECKMATE || (m & MOVE_MASK) == STALEMATE || (int) isValidMove(m & MOVE_MASK) != FALSE)
 		ANDi %0 $m #MOVE_MASK
@@ -1983,26 +1983,26 @@ getComputerMove:	FUNC	; signature func getComputerMove() -> int
 		ANDi %0 $m #MOVE_MASK
 		EQUi %0 #STALEMATE @.a6
 		ANDi %1 $m #MOVE_MASK
-		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int
+		CALL &isValidMove %0 *2	; expects isValidMove(int) -> int @ 1116:106
 		NEQi %0 #FALSE @.a6
 		MOVp %1 &.a_mMOVEM4f8 
 		CALL ^assertFail %0 *1
 	.a6:	ANDi $move $m #MOVE_MASK	; move = (m & MOVE_MASK)
 		RETU   	; }
 
-REDISPLAY_BOARD:	! DEFi #-1	; signature const REDISPLAY_BOARD : int
-LET_COMPUTER_PLAY:	! DEFi #-2	; signature const LET_COMPUTER_PLAY : int
-TAKE_BACK:	! DEFi #-3	; signature const TAKE_BACK : int
-NEW_GAME:	! DEFi #-4	; signature const NEW_GAME : int
-QUIT:	! DEFi #-5	; signature const QUIT : int
-SYNTAX_ERROR:	! DEFi #-6	; signature const SYNTAX_ERROR : int
-MATE:	! DEFi #-7	; signature const MATE : int
-SET_MAXIMUM_LEVEL:	! DEFi #-97	; signature const SET_MAXIMUM_LEVEL : int
-SET_MINIMUM_LEVEL:	! DEFi #-101	; signature const SET_MINIMUM_LEVEL : int
+REDISPLAY_BOARD:	! DEFi #-1	; signature const REDISPLAY_BOARD : int @ 1121:1
+LET_COMPUTER_PLAY:	! DEFi #-2	; signature const LET_COMPUTER_PLAY : int @ 1122:1
+TAKE_BACK:	! DEFi #-3	; signature const TAKE_BACK : int @ 1123:1
+NEW_GAME:	! DEFi #-4	; signature const NEW_GAME : int @ 1124:1
+QUIT:	! DEFi #-5	; signature const QUIT : int @ 1125:1
+SYNTAX_ERROR:	! DEFi #-6	; signature const SYNTAX_ERROR : int @ 1126:1
+MATE:	! DEFi #-7	; signature const MATE : int @ 1127:1
+SET_MAXIMUM_LEVEL:	! DEFi #-97	; signature const SET_MAXIMUM_LEVEL : int @ 1128:1
+SET_MINIMUM_LEVEL:	! DEFi #-101	; signature const SET_MINIMUM_LEVEL : int @ 1130:1
 
 ;-----------------------------------------------------------------------------
 	$d:	OUTi
-strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int
+strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int @ 1130:17
 	$s0:	INPp
 	$s1:	INPp
 	$a:	LOCp
@@ -2024,7 +2024,7 @@ strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int
 
 ;-----------------------------------------------------------------------------
 	$d:	OUTi
-strncmp:	FUNC	; signature func strncmp(ptr s0, ptr s1, int n) -> int
+strncmp:	FUNC	; signature func strncmp(ptr s0, ptr s1, int n) -> int @ 1142:18
 	$s0:	INPp
 	$s1:	INPp
 	$n:	INPi
@@ -2054,7 +2054,7 @@ strncmp:	FUNC	; signature func strncmp(ptr s0, ptr s1, int n) -> int
 
 ;-----------------------------------------------------------------------------
 	$u:	OUTi
-toupper:	FUNC	; signature func toupper(int c) -> int
+toupper:	FUNC	; signature func toupper(int c) -> int @ 1162:18
 	$c:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi $u $c 	; u = c
@@ -2067,7 +2067,7 @@ toupper:	FUNC	; signature func toupper(int c) -> int
 
 ;-----------------------------------------------------------------------------
 	$result:	OUTi
-getUserMove:	FUNC	; signature func getUserMove() -> int
+getUserMove:	FUNC	; signature func getUserMove() -> int @ 1171:22
 	$level:	LOCi
 	$s:	LOCA *256
 	$l:	LOCi
@@ -2079,10 +2079,10 @@ getUserMove:	FUNC	; signature func getUserMove() -> int
 ;-----------------------------------------------------------------------------
 	.l0:	MOVi $result #SYNTAX_ERROR 	; result = SYNTAX_ERROR
 		MOVp %1 &.s_4da 	; output(">")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1177:14
 		MOVi %1 #1023 	; l = (int) input(1023, s)
 		ADRL %2 $s *0
-		CALL ^input %0 *3	; expects function(int, ptr) -> unknown
+		CALL ^input %0 *3	; expects function(int, ptr) -> unknown @ 1178:27
 		MOVi $l %0 
 		LEQi $l #0 @.f2	; if (l > 0 && (int) s[l - 1] == '\n') 
 		SUBi %0 $l #1
@@ -2095,26 +2095,26 @@ getUserMove:	FUNC	; signature func getUserMove() -> int
 		GOTO @.e4  	; } else if ((int) strcmp(s, "go") == 0) 
 	.f3:	ADRL %1 $s *0	; if ((int) strcmp(s, "go") == 0) 
 		MOVp %2 &.s_go4db 
-		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int @ 1184:36
 		NEQi %0 #0 @.f5
 		MOVi $result #LET_COMPUTER_PLAY 	; result = LET_COMPUTER_PLAY
 		GOTO @.e6  	; } else if ((int) strcmp(s, "back") == 0) 
 	.f5:	ADRL %1 $s *0	; if ((int) strcmp(s, "back") == 0) 
 		MOVp %2 &.s_back4dc 
-		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int @ 1186:38
 		NEQi %0 #0 @.f7
 		MOVi $result #TAKE_BACK 	; result = TAKE_BACK
 		GOTO @.e8  	; } else if ((int) strcmp(s, "new") == 0) 
 	.f7:	ADRL %1 $s *0	; if ((int) strcmp(s, "new") == 0) 
 		MOVp %2 &.s_new4dd 
-		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int @ 1188:37
 		NEQi %0 #0 @.f9
 		MOVi $result #NEW_GAME 	; result = NEW_GAME
 		GOTO @.e10  	; } else if ((int) strncmp(s, "level ", 6) == 0 && l == 7 && (level = (int) s[6] - '0') >= 1 && level <= 5) 
 	.f9:	ADRL %1 $s *0	; if ((int) strncmp(s, "level ", 6) == 0 && l == 7 && (level = (int) s[6] - '0') >= 1 && level <= 5) 
 		MOVp %2 &.s_level4de 
 		MOVi %3 #6 
-		CALL &strncmp %0 *4	; expects strncmp(ptr, ptr, int) -> int
+		CALL &strncmp %0 *4	; expects strncmp(ptr, ptr, int) -> int @ 1190:44
 		NEQi %0 #0 @.f12
 		NEQi $l #7 @.f12
 		SUBi $level $s:6 #'0'
@@ -2125,19 +2125,19 @@ getUserMove:	FUNC	; signature func getUserMove() -> int
 		GOTO @.e13  	; } else if ((int) strcmp(s, "quit") == 0) 
 	.f12:	ADRL %1 $s *0	; if ((int) strcmp(s, "quit") == 0) 
 		MOVp %2 &.s_quit4df 
-		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int @ 1192:38
 		NEQi %0 #0 @.f14
 		MOVi $result #QUIT 	; result = QUIT
 		GOTO @.e15  	; } else 
 	.f14:	MOVE %1 $s:0 	; fromCol = ((int) toupper(s[0]) - 'A')
-		CALL &toupper %0 *2	; expects toupper(int) -> int
+		CALL &toupper %0 *2	; expects toupper(int) -> int @ 1195:35
 		SUBi $fromCol %0 #'A'
 		SUBi $fromRow $s:1 #'1'	; fromRow = ((int) s[1] - '1')
 		MOVi $i #2 	; i = 2
 		NEQi $s:2 #'-' @.f16	; if ((int) s[2] == '-') i = 3
 		MOVi $i #3 	; i = 3
 	.f16:	GETL %1 $s $i	; toCol = ((int) toupper(s[i]) - 'A')
-		CALL &toupper %0 *2	; expects toupper(int) -> int
+		CALL &toupper %0 *2	; expects toupper(int) -> int @ 1199:33
 		SUBi $toCol %0 #'A'
 		ADDi %0 $i #1	; toRow = ((int) s[i + 1] - '1')
 		GETL %0 $s %0
@@ -2154,11 +2154,11 @@ getUserMove:	FUNC	; signature func getUserMove() -> int
 		MOVi %2 $fromRow 
 		MOVi %3 $toCol 
 		MOVi %4 $toRow 
-		CALL &makeMove %0 *5	; expects makeMove(int, int, int, int) -> int
+		CALL &makeMove %0 *5	; expects makeMove(int, int, int, int) -> int @ 1203:60
 		MOVi $result %0 
 		GOTO @.e19  	; } else 
 	.f18:	MOVp %1 &.s_Enterm4e0 	; output("Enter moves like 'd2d4' or:\n'level 1-5' to set computer level (default is 3).\n'go' to switch color and let the computer play.\n'back' to take back a step.\n'new' to start a new game.\n'quit' to exit.\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1205:218
 	.e19:	NOOP
 	.e15:	NOOP
 	.e13:	NOOP
@@ -2171,7 +2171,7 @@ getUserMove:	FUNC	; signature func getUserMove() -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-printBoard:	FUNC	; signature func printBoard(int frm, int t) -> void
+printBoard:	FUNC	; signature func printBoard(int frm, int t) -> void @ 1211:21
 	$frm:	INPi
 	$t:	INPi
 	$y:	LOCi
@@ -2184,16 +2184,16 @@ printBoard:	FUNC	; signature func printBoard(int frm, int t) -> void
 		MOVi $buffer:1 #0 	; buffer[1] = 0
 		MOVi $lastI #-1 	; lastI = -1
 		MOVp %1 &.s_ABCDEF4e1 	; output("    A B C D E F G H\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1216:33
 		MOVp %1 &.s_4e2 	; output("  +-----------------+\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1217:35
 		MOVi $y #0 	; for (y = 0 to 8) 
 		GEQi #0 #8 @.e0
 	.l1:	SUBi $buffer:0 #'8' $y	; buffer[0] = '8' - y
 		ADRL %1 $buffer *0	; output(buffer)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1220:17
 		MOVp %1 &.s_4e3 	; output(" |")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1221:15
 		MOVi $x #0 	; for (x = 0 to 8) 
 		GEQi #0 #8 @.e2
 	.l3:	SUBi %0 #9 $y	; i = (9 - y) * STRIDE + (x + 1)
@@ -2213,7 +2213,7 @@ printBoard:	FUNC	; signature func printBoard(int frm, int t) -> void
 	.e9:	NOOP
 	.f7:	MOVi $buffer:0 $c 	; buffer[0] = c
 		ADRL %1 $buffer *0	; output(buffer)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1231:18
 		PEEK %0 &board $i	; c = (int) global PIECE_CHARS[(int) global board[i] & (PIECE_MASK | BLACK)]
 		! IORi <B> #PIECE_MASK #BLACK
 		ANDi %0 %0 <B>
@@ -2225,7 +2225,7 @@ printBoard:	FUNC	; signature func printBoard(int frm, int t) -> void
 		MOVi $c #'.' 	; c = '.'
 	.f11:	MOVi $buffer:0 $c 	; buffer[0] = c
 		ADRL %1 $buffer *0	; output(buffer)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1235:18
 		MOVi $lastI $i 	; lastI = i
 		FORi $x #8 @.l3	; }
 	.e2:	MOVi $c #' ' 	; c = ' '
@@ -2234,26 +2234,26 @@ printBoard:	FUNC	; signature func printBoard(int frm, int t) -> void
 	.t12:	MOVi $c #')' 	; c = ')'
 	.f13:	MOVi $buffer:0 $c 	; buffer[0] = c
 		ADRL %1 $buffer *0	; output(buffer)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1241:17
 		MOVp %1 &.s_4e4 	; output("| ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1242:15
 		SUBi $buffer:0 #'8' $y	; buffer[0] = '8' - y
 		ADRL %1 $buffer *0	; output(buffer)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1244:17
 		MOVp %1 &.s_4e2:21 	; output("\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1245:15
 		MOVi $lastI #-1 	; lastI = -1
 		FORi $y #8 @.l1	; }
 	.e0:	MOVp %1 &.s_4e2 	; output("  +-----------------+\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1248:35
 		MOVp %1 &.s_ABCDEF4e5 	; output("    A B C D E F G H\n\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1249:35
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-registerMove:	FUNC	; signature func registerMove(int move, int piece, int captured, int xCapture) -> void
+registerMove:	FUNC	; signature func registerMove(int move, int piece, int captured, int xCapture) -> void @ 1252:23
 	$move:	INPi
 	$piece:	INPi
 	$captured:	INPi
@@ -2292,7 +2292,7 @@ registerMove:	FUNC	; signature func registerMove(int move, int piece, int captur
 
 ;-----------------------------------------------------------------------------
 	$move:	OUTi
-takeBackMove:	FUNC	; signature func takeBackMove() -> int
+takeBackMove:	FUNC	; signature func takeBackMove() -> int @ 1269:23
 	$i:	LOCi
 	$frm:	LOCi
 	$t:	LOCi
@@ -2307,10 +2307,10 @@ takeBackMove:	FUNC	; signature func takeBackMove() -> int
 		ADDi %0 $i #0	; move = (int) global history[i + 0]
 		PEEK $move &history %0
 		MOVi %1 $move 	; frm = (int) moveFrom(move)
-		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int
+		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int @ 1277:29
 		MOVi $frm %0 
 		MOVi %1 $move 	; t = (int) moveTo(move)
-		CALL &moveTo %0 *2	; expects moveTo(int) -> int
+		CALL &moveTo %0 *2	; expects moveTo(int) -> int @ 1278:25
 		MOVi $t %0 
 		MOVi %1 $frm 	; undoMove(frm, t, (int) global history[i + 1], (int) global history[i + 2], (int) global history[i + 3])
 		MOVi %2 $t 
@@ -2320,7 +2320,7 @@ takeBackMove:	FUNC	; signature func takeBackMove() -> int
 		PEEK %4 &history %4
 		ADDi %5 $i #3
 		PEEK %5 &history %5
-		CALL &undoMove %0 *6	; expects undoMove(int, int, int, int, int) -> void
+		CALL &undoMove %0 *6	; expects undoMove(int, int, int, int, int) -> void @ 1279:106
 		GOTO @.e1  	; } else 
 	.f0:	MOVi $move #0 	; move = 0
 	.e1:	RETU   	; }
@@ -2328,7 +2328,7 @@ takeBackMove:	FUNC	; signature func takeBackMove() -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-setLevel:	FUNC	; signature func setLevel(int level) -> void
+setLevel:	FUNC	; signature func setLevel(int level) -> void @ 1285:19
 	$level:	INPi
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
@@ -2344,7 +2344,7 @@ setLevel:	FUNC	; signature func setLevel(int level) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 1292:15
 	$lastFrom:	LOCi
 	$lastTo:	LOCi
 	$lastPiece:	LOCi
@@ -2359,29 +2359,29 @@ main:	FUNC	; signature func main() -> void
 	$level:	LOCi
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
-		CALL &initGlobals %0 *1	; expects initGlobals() -> void
+		CALL &initGlobals %0 *1	; expects initGlobals() -> void @ 1296:15
 		MOVp %1 &.s_ec4e6 	; output("        ,....,\n      ,::::::<\n     ,::/^\\\"``.\n    ,::/, `   e`.\n   ,::
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1298:344
 		MOVp %1 &.s_PRIYOM4e7 	; output("PRIYOME CHESS COMPUTER\n\n         V1.0\n\n(C) Magnus Lidstroem\n\nPress enter to continue")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1299:102
 		MOVi %1 #1 	; input(1, buffer)
 		ADRL %2 $buffer *0
-		CALL ^input %0 *3	; expects function(int, ptr) -> unknown
+		CALL ^input %0 *3	; expects function(int, ptr) -> unknown @ 1300:18
 		MOVi $i #0 	; for (i = 0 to 30) output("\n")
 		GEQi #0 #30 @.e0
 	.l1:	MOVp %1 &.s_ec4e6:300 	; output("\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1301:32
 		FORi $i #30 @.l1
-	.e0:	CALL ^clock %0 *1	; expects function() -> unknown
+	.e0:	CALL ^clock %0 *1	; expects function() -> unknown @ 1303:47
 		PEEK %1 &randPX 
 		XORi %1 %1 %0
 		POKE &randPX %1 
-		CALL &restart %0 *1	; expects restart() -> void
+		CALL &restart %0 *1	; expects restart() -> void @ 1305:11
 		MOVi %1 #2 	; setLevel(2)
-		CALL &setLevel %0 *2	; expects setLevel(int) -> void
+		CALL &setLevel %0 *2	; expects setLevel(int) -> void @ 1306:13
 		MOVi %1 #0 	; printBoard(0, 0)
 		MOVi %2 #0 
-		CALL &printBoard %0 *3	; expects printBoard(int, int) -> void
+		CALL &printBoard %0 *3	; expects printBoard(int, int) -> void @ 1308:18
 		MOVi $isComputersTurn #FALSE 	; isComputersTurn = FALSE
 		MOVi $lastFrom #0 	; lastFrom = 0
 		MOVi $lastTo #0 	; lastTo = 0
@@ -2393,10 +2393,10 @@ main:	FUNC	; signature func main() -> void
 		NEQi %0 #WHITE @.f4
 		MOVp $p &.s_Whites4e9 	; p = "White's turn.\n"
 	.f4:	MOVp %1 $p 	; output(p)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1319:14
 	.f3:	MOVp $action &.s_Lastmo4ea 	; action = "Last move:"
 		NEQi $isComputersTurn #FALSE @.f5	; if (isComputersTurn == FALSE) 
-		CALL &getUserMove %0 *1	; expects getUserMove() -> int
+		CALL &getUserMove %0 *1	; expects getUserMove() -> int @ 1324:35
 		MOVi $lastMove %0 
 		! ADDi <B> #REDISPLAY_BOARD #1	; switch (lastMove == NEW_GAME to REDISPLAY_BOARD + 1) 
 		! SUBi <B> <B> #NEW_GAME
@@ -2405,30 +2405,30 @@ main:	FUNC	; signature func main() -> void
 		! SUBi <B> #REDISPLAY_BOARD #NEW_GAME	; case REDISPLAY_BOARD
 	.s6#<B>:	MOVi %1 $lastFrom 	; printBoard(lastFrom, lastTo)
 		MOVi %2 $lastTo 
-		CALL &printBoard %0 *3	; expects printBoard(int, int) -> void
+		CALL &printBoard %0 *3	; expects printBoard(int, int) -> void @ 1327:35
 		GOTO @.e7  	; }
 		! SUBi <B> #LET_COMPUTER_PLAY #NEW_GAME	; case LET_COMPUTER_PLAY
 	.s6#<B>:	MOVi $isComputersTurn #TRUE 	; isComputersTurn = TRUE
 		GOTO @.e7  	; }
 		! SUBi <B> #TAKE_BACK #NEW_GAME	; case TAKE_BACK
-	.s6#<B>:	CALL &takeBackMove %0 *1	; expects takeBackMove() -> int
+	.s6#<B>:	CALL &takeBackMove %0 *1	; expects takeBackMove() -> int @ 1335:38
 		MOVi $lastMove %0 
 		LEQi $lastMove #0 @.f8	; if (lastMove > 0) 
 		MOVi %1 $lastMove 	; lastFrom = (int) moveFrom(lastMove)
-		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int
+		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int @ 1337:43
 		MOVi $lastFrom %0 
 		MOVi %1 $lastMove 	; lastTo = (int) moveTo(lastMove)
-		CALL &moveTo %0 *2	; expects moveTo(int) -> int
+		CALL &moveTo %0 *2	; expects moveTo(int) -> int @ 1338:39
 		MOVi $lastTo %0 
 		MOVi $lastMove #0 	; lastMove = 0
 		MOVp $action &.s_Tookba4eb 	; action = "Took back move:"
 		GOTO @.e7  	; } else 
 	.f8:	MOVp %1 &.s_Nomove4ec 	; output("No move to take back.\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1342:41
 		MOVi $lastMove #-1 	; lastMove = -1
 	.e9:	GOTO @.e7  	; }
 		! SUBi <B> #NEW_GAME #NEW_GAME	; case NEW_GAME
-	.s6#<B>:	CALL &restart %0 *1	; expects restart() -> void
+	.s6#<B>:	CALL &restart %0 *1	; expects restart() -> void @ 1348:16
 		MOVi $lastMove #0 	; lastMove = 0
 		MOVi $lastFrom #0 	; lastFrom = 0
 		MOVi $lastTo #0 	; lastTo = 0
@@ -2437,20 +2437,20 @@ main:	FUNC	; signature func main() -> void
 		GRTi $lastMove #SET_MAXIMUM_LEVEL @.f5
 		SUBi $level $lastMove #SET_MINIMUM_LEVEL	; level = lastMove - SET_MINIMUM_LEVEL
 		MOVi %1 $level 	; setLevel(level)
-		CALL &setLevel %0 *2	; expects setLevel(int) -> void
+		CALL &setLevel %0 *2	; expects setLevel(int) -> void @ 1357:23
 		MOVp %1 &.s_Setcom4ed 	; output("Set computer level to ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1358:40
 		ADDi %0 $level #1	; buffer[0] = level + 1 + '0'
 		ADDi $buffer:0 %0 #'0'
 		MOVi $buffer:1 #0 	; buffer[1] = 0
 		ADRL %1 $buffer *0	; output(buffer)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1361:22
 		MOVp %1 &.s_Nomove4ec:20 	; output(".\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1362:21
 		MOVi $lastMove #-1 	; lastMove = -1
 	.e7:	NOOP
 	.f5:	EQUi $isComputersTurn #FALSE @.f12	; if (isComputersTurn != FALSE) 
-		CALL &getComputerMove %0 *1	; expects getComputerMove() -> int
+		CALL &getComputerMove %0 *1	; expects getComputerMove() -> int @ 1369:39
 		MOVi $lastMove %0 
 	.f12:	MOVi $moveResult #0 	; moveResult = 0
 		EQUi $lastMove #CHECKMATE @.t13	; if (lastMove == CHECKMATE || lastMove == STALEMATE) 
@@ -2460,16 +2460,16 @@ main:	FUNC	; signature func main() -> void
 		MOVi $lastMove #-1 	; lastMove = -1
 	.f14:	LEQi $lastMove #0 @.f15	; if (lastMove > 0) 
 		MOVi %1 $lastMove 	; lastFrom = (int) moveFrom(lastMove)
-		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int
+		CALL &moveFrom %0 *2	; expects moveFrom(int) -> int @ 1379:40
 		MOVi $lastFrom %0 
 		MOVi %1 $lastMove 	; lastTo = (int) moveTo(lastMove)
-		CALL &moveTo %0 *2	; expects moveTo(int) -> int
+		CALL &moveTo %0 *2	; expects moveTo(int) -> int @ 1380:36
 		MOVi $lastTo %0 
 		PEEK $lastPiece &board $lastFrom	; lastPiece = (int) global board[lastFrom]
 		PEEK $lastCaptured &board $lastTo	; lastCaptured = (int) global board[lastTo]
 		PEEK $lastXCapture &xCapture 	; lastXCapture = global xCapture
 		MOVi %1 $lastMove 	; moveResult = (int) executeMove(lastMove)
-		CALL &executeMove %0 *2	; expects executeMove(int) -> int
+		CALL &executeMove %0 *2	; expects executeMove(int) -> int @ 1385:45
 		MOVi $moveResult %0 
 		! ADDi <B> #CHECKMATE #1	; switch (moveResult == VALID_MOVE to CHECKMATE + 1) 
 		! SUBi <B> <B> #VALID_MOVE
@@ -2484,7 +2484,7 @@ main:	FUNC	; signature func main() -> void
 		MOVi %2 $lastPiece 
 		MOVi %3 $lastCaptured 
 		MOVi %4 $lastXCapture 
-		CALL &registerMove %0 *5	; expects registerMove(int, int, int, int) -> void
+		CALL &registerMove %0 *5	; expects registerMove(int, int, int, int) -> void @ 1388:68
 		NEQi $moveResult #VALID_MOVE @.f18	; if (moveResult == VALID_MOVE) 
 		SUBi $isComputersTurn #TRUE $isComputersTurn	; isComputersTurn = TRUE - isComputersTurn
 		GOTO @.e17  	; } else 
@@ -2492,31 +2492,31 @@ main:	FUNC	; signature func main() -> void
 	.e19:	GOTO @.e17  	; }
 		! SUBi <B> #IN_CHECK #VALID_MOVE	; case IN_CHECK
 	.s16#<B>:	MOVp %1 &.s_Kingin4ee 	; output("King in check.\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1397:33
 		MOVi $lastMove #-1 	; lastMove = -1
 		GOTO @.e17  	; }
 	.s16:	NEQi $moveResult #INVALID_MOVE @.f15	; if (moveResult == INVALID_MOVE) 
 		MOVp %1 &.s_Invali4ef 	; output("Invalid move.\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1403:33
 		MOVi $lastMove #-1 	; lastMove = -1
 	.e17:	NOOP
 	.f15:	LSSi $lastMove #0 @.f21	; if (lastMove >= 0) 
 		MOVp %1 &.s_Invali4ef:13 	; output("\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1411:17
 		MOVi %1 $lastFrom 	; printBoard(lastFrom, lastTo)
 		MOVi %2 $lastTo 
-		CALL &printBoard %0 *3	; expects printBoard(int, int) -> void
+		CALL &printBoard %0 *3	; expects printBoard(int, int) -> void @ 1412:33
 		EQUi $lastFrom #0 @.f21	; if (lastFrom != 0 && lastTo != 0) 
 		EQUi $lastTo #0 @.f21
 		MOVp %1 $action 	; output(action)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1414:20
 		MOVp %1 &.s_Setcom4ed:21 	; output(" ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1415:17
 		ANDi %1 $lastPiece #PIECE_MASK	; output(global PIECE_NAMES[lastPiece & PIECE_MASK])
 		PEEK %1 &PIECE_NAMES %1
-		CALL ^output %0 *2	; expects function(unknown) -> unknown
+		CALL ^output %0 *2	; expects function(unknown) -> unknown @ 1416:56
 		MOVp %1 &.s_Setcom4ed:21 	; output(" ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1417:17
 		MODi %0 $lastFrom #STRIDE	; buffer[0] = ('A' + (lastFrom % STRIDE - 1))
 		SUBi %0 %0 #1
 		ADDi $buffer:0 #'A' %0
@@ -2525,9 +2525,9 @@ main:	FUNC	; signature func main() -> void
 		ADDi $buffer:1 #'1' %0
 		MOVi $buffer:2 #0 	; buffer[2] = 0
 		ADRL %1 $buffer *0	; output(buffer)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1421:20
 		MOVp %1 &.s_Setcom4ed:18 	; output(" to ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1422:20
 		MODi %0 $lastTo #STRIDE	; buffer[0] = ('A' + (lastTo % STRIDE - 1))
 		SUBi %0 %0 #1
 		ADDi $buffer:0 #'A' %0
@@ -2535,21 +2535,21 @@ main:	FUNC	; signature func main() -> void
 		SUBi %0 %0 #2
 		ADDi $buffer:1 #'1' %0
 		ADRL %1 $buffer *0	; output(buffer)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1425:20
 		MOVp %1 &.s_4f0 	; output(".\n\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1426:21
 	.f21:	NEQi $moveResult #CHECKMATE @.f24	; if (moveResult == CHECKMATE) 
 		MOVp $p &.s_Checkm4f1 	; p = "Checkmate! White wins.\n"
 		PEEK %0 &turnColor 	; if (global turnColor == WHITE) p = "Checkmate! Black wins.\n"
 		NEQi %0 #WHITE @.f25
 		MOVp $p &.s_Checkm4f2 	; p = "Checkmate! Black wins.\n"
 	.f25:	MOVp %1 $p 	; output(p)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1433:14
 		MOVi $lastMove #MATE 	; lastMove = MATE
 		GOTO @.e26  	; } else if (moveResult == STALEMATE) 
 	.f24:	NEQi $moveResult #STALEMATE @.f27	; if (moveResult == STALEMATE) 
 		MOVp %1 &.s_Stalem4f3 	; output("Stalemate!\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 1436:27
 		MOVi $lastMove #MATE 	; lastMove = MATE
 	.f27:	NOOP
 	.e26:	NEQi $lastMove #QUIT @.l2	; } while (lastMove != QUIT)

--- a/tests/impala/golden/crash_code.gazl
+++ b/tests/impala/golden/crash_code.gazl
@@ -1,27 +1,27 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_Sillyr4d2 &.s_4d3 &.s_4d3 &.s_LEFTDE4d4 &.s_4d3
 	DATA &.s_4d3 &.s_4d3 &.s_RINGMO4d5
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 81:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 82:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
+instance:	DATi #0	; signature global instance : int @ 83:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
-EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 86:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 91:1
+EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown @ 91:41
 	DATA #0x0 #0x1 #0x2 #0x3 #0x4 #0x5 #0x6 #0x7 #0x8 #0x9
 	DATA #0xa #0xb #0xc #0xd #0xe #0xf #0x10 #0x11 #0x12 #0x13
 	DATA #0x14 #0x15 #0x16 #0x17 #0x18 #0x19 #0x1a #0x1b #0x1c
@@ -56,19 +56,19 @@ EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unkn
 	DATA #0x7c00 #0x8000 #0x8800 #0x9000 #0x9800 #0xa000
 	DATA #0xa800 #0xb000 #0xb800 #0xc000 #0xc800 #0xd000
 	DATA #0xd800 #0xe000 #0xe800 #0xf000 #0xffff
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 126:1
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 127:1
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 128:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 129:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 130:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 131:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 132:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 134:1
 
 ;-----------------------------------------------------------------------------
 	$a:	OUTp
-stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
+stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr @ 134:17
 	$d:	INPp
 	$s:	INPp
 	$b:	LOCp
@@ -86,7 +86,7 @@ stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr
+intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr @ 153:22
 	$i:	INPi
 	$radix:	INPi
 	$minLength:	INPi
@@ -133,7 +133,7 @@ intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
+traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void @ 171:20
 	$text:	INPp
 	$n:	INPi
 	$ints:	INPp
@@ -147,7 +147,7 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		EQUp $text &NULL @.f0	; if (text != null) p = (pointer) stpcpy(p, text)
 		MOVp %1 $p 	; p = (pointer) stpcpy(p, text)
 		MOVp %2 $text 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 178:49
 		MOVp $p %0 
 	.f0:	POKE $p #0 	; *p = 0
 		MOVi $i #0 	; for (i = 0 to n) 
@@ -160,18 +160,18 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		MOVi %4 #10 
 		MOVi %5 #1 
 		ADRL %6 $buffer *0
-		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr @ 182:62
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 182:63
 		MOVp $p %0 
 		FORi $i $n @.l2	; }
 	.e1:	ADRL %1 $line *0	; trace(line)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 184:13
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
+traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void @ 187:19
 	$text:	INPp
 	$i:	INPi
 	$ints:	LOCA *1
@@ -180,24 +180,24 @@ traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
 		MOVp %1 $text 	; traceInts(text, 1, ints)
 		MOVi %2 #1 
 		ADRL %3 $ints *0
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 191:26
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 194:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 196:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 197:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 200:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -211,16 +211,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 207:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4d7 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 210:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float)trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 211:35
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -228,7 +228,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 225:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -237,7 +237,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 229:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -257,46 +257,46 @@ cos:	FUNC	; signature func cos(float x) -> float
 		MOVf $y #0.0 	; y = 0.0
 	.f1:	RETU   	; }
 
-COS_TABLE_BITS:	! DEFi #12	; signature const COS_TABLE_BITS : int
+COS_TABLE_BITS:	! DEFi #12	; signature const COS_TABLE_BITS : int @ 244:1
 	! SHLi <A> #1 #COS_TABLE_BITS
-COS_TABLE_SIZE:	! DEFi <A>	; signature const COS_TABLE_SIZE : int
-BATCH_SIZE:	! DEFi #77	; signature const BATCH_SIZE : int
+COS_TABLE_SIZE:	! DEFi <A>	; signature const COS_TABLE_SIZE : int @ 245:1
+BATCH_SIZE:	! DEFi #77	; signature const BATCH_SIZE : int @ 245:26
 	! ADDi <A> #COS_TABLE_SIZE #1
-cosTable:	GLOB *<A>	; signature array cosTable[<A>] : unknown
+cosTable:	GLOB *<A>	; signature array cosTable[<A>] : unknown @ 251:1
 	GLOB *1
-doReset:	DATi #FALSE	; signature global doReset : int
+doReset:	DATi #FALSE	; signature global doReset : int @ 252:1
 	GLOB *1
-rate:	DATi #0	; signature global rate : int
+rate:	DATi #0	; signature global rate : int @ 253:1
 	GLOB *1
-diff:	DATi #0	; signature global diff : int
+diff:	DATi #0	; signature global diff : int @ 254:1
 	GLOB *1
-delayL:	DATi #0	; signature global delayL : int
+delayL:	DATi #0	; signature global delayL : int @ 255:1
 	GLOB *1
-delayR:	DATi #0	; signature global delayR : int
+delayR:	DATi #0	; signature global delayR : int @ 256:1
 	GLOB *1
-syncBit:	DATi #0	; signature global syncBit : int
+syncBit:	DATi #0	; signature global syncBit : int @ 263:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 263:15
 	$i:	LOCi
 	$buf:	LOCA *256
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4d8 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 266:15
 		PEEK %2 &instance 	; trace(intToString(global instance, 10, 1, buf))
 		MOVi %3 #10 
 		MOVi %4 #1 
 		ADRL %5 $buf *0
-		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr @ 267:48
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 267:49
 		MOVi $i #0 	; for (i = 0 to COS_TABLE_SIZE) global cosTable[i] = ftoi((float) cos((TWICE_PI / itof(COS_TABLE_SIZE)) * itof(i)) * 2048.0)
 		GEQi #0 #COS_TABLE_SIZE @.e0
 	.l1:	NOOP
 		! iTOf <A> #COS_TABLE_SIZE #1.0	; global cosTable[i] = ftoi((float) cos((TWICE_PI / itof(COS_TABLE_SIZE)) * itof(i)) * 2048.0)
 		! DIVf <A> #TWICE_PI <A>
 		iTOf %1 $i <A>
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 268:115
 		fTOi %0 %0 #2048.0
 		POKE &cosTable $i %0
 		FORi $i #COS_TABLE_SIZE @.l1
@@ -307,21 +307,21 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 276:16
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4d9 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 278:16
 		MOVp %1 &.s_params4da 	; traceInts(" params: ", PARAM_COUNT, global params)
 		MOVi %2 #PARAM_COUNT 
 		MOVp %3 &params 
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 279:52
 		POKE &doReset #TRUE 	; global doReset = TRUE
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int
+displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int @ 283:28
 	$x:	INPi
 ;-----------------------------------------------------------------------------
 		! SUBi <A> #8 #3	; y = 0x1 << (x >> (8 - 3))
@@ -332,34 +332,34 @@ displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 293:17
 	$buf:	LOCA *256
 	$params:	LOCA *PARAM_COUNT
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_update4db 	; trace("update")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 296:17
 		MOVp %1 &.s_params4da 	; traceInts(" params: ", PARAM_COUNT, global params)
 		MOVi %2 #PARAM_COUNT 
 		MOVp %3 &params 
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 297:52
 		ADRL %0 $params *0	; copy (PARAM_COUNT from global params to params)
 		COPY %0 &params *PARAM_COUNT
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_1_HIGH_PARAM_INDEX	; global delayL = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_1_HIGH_PARAM_INDEX]]
 		POKE &delayL %0 
 		MOVi %1 $params:OPERAND_1_HIGH_PARAM_INDEX 	; global displayLEDs[0] = displayDelayValue((int) params[OPERAND_1_HIGH_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 300:85
 		POKE &displayLEDs:0 %0 
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_1_LOW_PARAM_INDEX	; global delayR = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_1_LOW_PARAM_INDEX]]
 		POKE &delayR %0 
 		MOVi %1 $params:OPERAND_1_LOW_PARAM_INDEX 	; global displayLEDs[1] = displayDelayValue((int) params[OPERAND_1_LOW_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 302:84
 		POKE &displayLEDs:1 %0 
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_2_HIGH_PARAM_INDEX	; global rate = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_2_HIGH_PARAM_INDEX]]
 		POKE &rate %0 
 		SHLi %0 $params:OPERAND_2_LOW_PARAM_INDEX #8	; global diff = (int) params[OPERAND_2_LOW_PARAM_INDEX] << 8
 		POKE &diff %0 
 		MOVi %1 $params:OPERAND_2_LOW_PARAM_INDEX 	; global displayLEDs[3] = displayDelayValue((int) params[OPERAND_2_LOW_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 305:84
 		POKE &displayLEDs:3 %0 
 		PEEK %0 &params:SWITCHES_PARAM_INDEX 	; global syncBit = (int) global params[SWITCHES_PARAM_INDEX] & SWITCHES_SYNC_MASK
 		ANDi %0 %0 #SWITCHES_SYNC_MASK
@@ -369,13 +369,13 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 324:18
 	$i:	LOCi
 	$p:	LOCp
 ;-----------------------------------------------------------------------------
 		MOVi $i #0 	; for (i = 0 to 1000000) yield()
 		GEQi #0 #1000000 @.e0
-	.l1:	CALL ^yield %0 *1	; expects function() -> unknown
+	.l1:	CALL ^yield %0 *1	; expects function() -> unknown @ 327:32
 		FORi $i #1000000 @.l1
 	.e0:	MOVp $p &NULL 	; p = null
 		POKE $p #0 	; *p = 0

--- a/tests/impala/golden/crasher.gazl
+++ b/tests/impala/golden/crasher.gazl
@@ -1,26 +1,26 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 11:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 12:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 22:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 22:33
 	DATA &.s_Sillyr4d2 &.s_Sillyr4d2:51 &.s_Sillyr4d2:51
 	DATA &.s_LEFTDE4d3 &.s_LEFTDE4d3:53 &.s_LEFTDE4d3:53
 	DATA &.s_LEFTDE4d3:53 &.s_RINGMO4d4
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 34:1
+; signature extern native trace() -> unknown @ 35:1
+; signature extern native yield() -> unknown @ 36:1
+; signature extern native write() -> unknown @ 37:1
+; signature extern native read() -> unknown @ 39:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-signal:	GLOB *2	; signature array signal[2] : unknown
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 70:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 71:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 72:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 73:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
-EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown
+instance:	DATi #0	; signature global instance : int @ 77:1
+EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown @ 77:41
 	DATA #0x0 #0x1 #0x2 #0x3 #0x4 #0x5 #0x6 #0x7 #0x8 #0x9
 	DATA #0xa #0xb #0xc #0xd #0xe #0xf #0x10 #0x11 #0x12 #0x13
 	DATA #0x14 #0x15 #0x16 #0x17 #0x18 #0x19 #0x1a #0x1b #0x1c
@@ -55,19 +55,19 @@ EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unkn
 	DATA #0x7c00 #0x8000 #0x8800 #0x9000 #0x9800 #0xa000
 	DATA #0xa800 #0xb000 #0xb800 #0xc000 #0xc800 #0xd000
 	DATA #0xd800 #0xe000 #0xe800 #0xf000 #0xffff
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 112:1
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 113:1
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 114:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 115:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 116:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 117:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 118:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 120:1
 
 ;-----------------------------------------------------------------------------
 	$a:	OUTp
-stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
+stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr @ 120:17
 	$d:	INPp
 	$s:	INPp
 	$b:	LOCp
@@ -85,7 +85,7 @@ stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr
+intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr @ 139:22
 	$i:	INPi
 	$radix:	INPi
 	$minLength:	INPi
@@ -132,7 +132,7 @@ intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
+traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void @ 157:20
 	$text:	INPp
 	$n:	INPi
 	$ints:	INPp
@@ -146,7 +146,7 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		EQUp $text &NULL @.f0	; if (text != null) p = (pointer) stpcpy(p, text)
 		MOVp %1 $p 	; p = (pointer) stpcpy(p, text)
 		MOVp %2 $text 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 164:49
 		MOVp $p %0 
 	.f0:	POKE $p #0 	; *p = 0
 		MOVi $i #0 	; for (i = 0 to n) 
@@ -159,18 +159,18 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		MOVi %4 #10 
 		MOVi %5 #1 
 		ADRL %6 $buffer *0
-		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr @ 168:62
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 168:63
 		MOVp $p %0 
 		FORi $i $n @.l2	; }
 	.e1:	ADRL %1 $line *0	; trace(line)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 170:13
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
+traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void @ 173:19
 	$text:	INPp
 	$i:	INPi
 	$ints:	LOCA *1
@@ -179,24 +179,24 @@ traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
 		MOVp %1 $text 	; traceInts(text, 1, ints)
 		MOVi %2 #1 
 		ADRL %3 $ints *0
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 177:26
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 180:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 182:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 183:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 186:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -210,16 +210,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 193:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4d6 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 196:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float)trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 197:35
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -227,7 +227,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 211:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -236,7 +236,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 215:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -256,46 +256,46 @@ cos:	FUNC	; signature func cos(float x) -> float
 		MOVf $y #0.0 	; y = 0.0
 	.f1:	RETU   	; }
 
-COS_TABLE_BITS:	! DEFi #12	; signature const COS_TABLE_BITS : int
+COS_TABLE_BITS:	! DEFi #12	; signature const COS_TABLE_BITS : int @ 230:1
 	! SHLi <A> #1 #COS_TABLE_BITS
-COS_TABLE_SIZE:	! DEFi <A>	; signature const COS_TABLE_SIZE : int
-BATCH_SIZE:	! DEFi #77	; signature const BATCH_SIZE : int
+COS_TABLE_SIZE:	! DEFi <A>	; signature const COS_TABLE_SIZE : int @ 231:1
+BATCH_SIZE:	! DEFi #77	; signature const BATCH_SIZE : int @ 231:26
 	! ADDi <A> #COS_TABLE_SIZE #1
-cosTable:	GLOB *<A>	; signature array cosTable[<A>] : unknown
+cosTable:	GLOB *<A>	; signature array cosTable[<A>] : unknown @ 237:1
 	GLOB *1
-doReset:	DATi #FALSE	; signature global doReset : int
+doReset:	DATi #FALSE	; signature global doReset : int @ 238:1
 	GLOB *1
-rate:	DATi #0	; signature global rate : int
+rate:	DATi #0	; signature global rate : int @ 239:1
 	GLOB *1
-diff:	DATi #0	; signature global diff : int
+diff:	DATi #0	; signature global diff : int @ 240:1
 	GLOB *1
-delayL:	DATi #0	; signature global delayL : int
+delayL:	DATi #0	; signature global delayL : int @ 241:1
 	GLOB *1
-delayR:	DATi #0	; signature global delayR : int
+delayR:	DATi #0	; signature global delayR : int @ 242:1
 	GLOB *1
-syncBit:	DATi #0	; signature global syncBit : int
+syncBit:	DATi #0	; signature global syncBit : int @ 249:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 249:15
 	$i:	LOCi
 	$buf:	LOCA *256
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4d7 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 252:15
 		PEEK %2 &instance 	; trace(intToString(global instance, 10, 1, buf))
 		MOVi %3 #10 
 		MOVi %4 #1 
 		ADRL %5 $buf *0
-		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr @ 253:48
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 253:49
 		MOVi $i #0 	; for (i = 0 to COS_TABLE_SIZE) global cosTable[i] = ftoi((float) cos((TWICE_PI / itof(COS_TABLE_SIZE)) * itof(i)) * 2048.0)
 		GEQi #0 #COS_TABLE_SIZE @.e0
 	.l1:	NOOP
 		! iTOf <A> #COS_TABLE_SIZE #1.0	; global cosTable[i] = ftoi((float) cos((TWICE_PI / itof(COS_TABLE_SIZE)) * itof(i)) * 2048.0)
 		! DIVf <A> #TWICE_PI <A>
 		iTOf %1 $i <A>
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 254:115
 		fTOi %0 %0 #2048.0
 		POKE &cosTable $i %0
 		FORi $i #COS_TABLE_SIZE @.l1
@@ -306,21 +306,21 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 262:16
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4d8 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 264:16
 		MOVp %1 &.s_params4d9 	; traceInts(" params: ", PARAM_COUNT, global params)
 		MOVi %2 #PARAM_COUNT 
 		MOVp %3 &params 
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 265:52
 		POKE &doReset #TRUE 	; global doReset = TRUE
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int
+displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int @ 269:28
 	$x:	INPi
 ;-----------------------------------------------------------------------------
 		! SUBi <A> #8 #3	; y = 0x1 << (x >> (8 - 3))
@@ -331,7 +331,7 @@ displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 279:17
 	$buf:	LOCA *256
 	$params:	LOCA *PARAM_COUNT
 	$p:	LOCp
@@ -341,12 +341,12 @@ update:	FUNC	; signature func update() -> void
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_1_HIGH_PARAM_INDEX	; global delayL = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_1_HIGH_PARAM_INDEX]]
 		POKE &delayL %0 
 		MOVi %1 $params:OPERAND_1_HIGH_PARAM_INDEX 	; global displayLEDs[0] = displayDelayValue((int) params[OPERAND_1_HIGH_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 286:85
 		POKE &displayLEDs:0 %0 
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_1_LOW_PARAM_INDEX	; global delayR = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_1_LOW_PARAM_INDEX]]
 		POKE &delayR %0 
 		MOVi %1 $params:OPERAND_1_LOW_PARAM_INDEX 	; global displayLEDs[1] = displayDelayValue((int) params[OPERAND_1_LOW_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 288:84
 		POKE &displayLEDs:1 %0 
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_2_HIGH_PARAM_INDEX	; global rate = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_2_HIGH_PARAM_INDEX]]
 		POKE &rate %0 
@@ -356,7 +356,7 @@ update:	FUNC	; signature func update() -> void
 	.f0:	SHLi %0 $params:OPERAND_2_LOW_PARAM_INDEX #8	; global diff = (int) params[OPERAND_2_LOW_PARAM_INDEX] << 8
 		POKE &diff %0 
 		MOVi %1 $params:OPERAND_2_LOW_PARAM_INDEX 	; global displayLEDs[3] = displayDelayValue((int) params[OPERAND_2_LOW_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 292:84
 		POKE &displayLEDs:3 %0 
 		PEEK %0 &params:SWITCHES_PARAM_INDEX 	; global syncBit = (int) global params[SWITCHES_PARAM_INDEX] & SWITCHES_SYNC_MASK
 		ANDi %0 %0 #SWITCHES_SYNC_MASK
@@ -366,7 +366,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 311:18
 	$i:	LOCi
 	$c0:	LOCi
 	$c1:	LOCi
@@ -408,7 +408,7 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $clock 	; write(clock, 1, global signal)
 		MOVi %2 #1 
 		MOVp %3 &signal 
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 329:34
 		ANDi $idx $idx #0xFFFF	; idx = idx & 0xFFFF
 		! SUBi <A> #16 #COS_TABLE_BITS	; p = &global cosTable[idx >> (16 - COS_TABLE_BITS)]
 		SHRi %0 $idx <A>
@@ -443,11 +443,11 @@ process:	FUNC	; signature func process() -> void
 		SUBi %1 $clock $delayL	; read(clock - delayL, 1, leftPair)
 		MOVi %2 #1 
 		ADRL %3 $leftPair *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 342:37
 		SUBi %1 $clock $delayR	; read(clock - delayR, 1, rightPair)
 		MOVi %2 #1 
 		ADRL %3 $rightPair *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 343:38
 		MULi %0 $leftPair:0 $cosL	; global signal[0] = ((int) leftPair[0] * cosL) >> 15
 		SHRi %0 %0 #15
 		POKE &signal:0 %0 
@@ -455,7 +455,7 @@ process:	FUNC	; signature func process() -> void
 		SHRi %0 %0 #15
 		POKE &signal:1 %0 
 		ADDi $idx $idx $rate	; idx = idx + rate
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 347:11
 		FORi $i #BATCH_SIZE @.l4	; }
 		GOTO @.l0  	; }
 		RETU   	; }

--- a/tests/impala/golden/crashesPermut8.gazl
+++ b/tests/impala/golden/crashesPermut8.gazl
@@ -1,25 +1,25 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_stdREV4d2 &.s_fastCR4d3 &.s_slowCH4d4
 	DATA &.s_rndAK44d5 &.s_16164d6 &.s_32164d7 &.s_884d8
 	DATA &.s_168Gat4d9
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 40:1
+; signature extern native trace() -> unknown @ 41:1
+; signature extern native yield() -> unknown @ 42:1
+; signature extern native write() -> unknown @ 43:1
+; signature extern native read() -> unknown @ 45:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 81:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 82:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 84:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 87:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 89:1
 	CNST *1
 	! SHLi <A> #1 #OPERATOR_1_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_1_HIGH_PARAM_INDEX
@@ -34,15 +34,15 @@ signal:	GLOB *2	; signature array signal[2] : unknown
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #SWITCHES_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
-EPSILON_FLOAT:	! DEFf #1.0e-45	; signature const EPSILON_FLOAT : float
-SMALL_FLOAT:	! DEFf #1.0e-5	; signature const SMALL_FLOAT : float
-LARGE_FLOAT:	! DEFf #1.0e+10	; signature const LARGE_FLOAT : float
-HUGE_FLOAT:	! DEFf #1.0e+38	; signature const HUGE_FLOAT : float
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 92:32
+EPSILON_FLOAT:	! DEFf #1.0e-45	; signature const EPSILON_FLOAT : float @ 99:1
+SMALL_FLOAT:	! DEFf #1.0e-5	; signature const SMALL_FLOAT : float @ 100:1
+LARGE_FLOAT:	! DEFf #1.0e+10	; signature const LARGE_FLOAT : float @ 101:1
+HUGE_FLOAT:	! DEFf #1.0e+38	; signature const HUGE_FLOAT : float @ 103:1
 
 ;-----------------------------------------------------------------------------
 	$a:	OUTp
-stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
+stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr @ 103:17
 	$d:	INPp
 	$s:	INPp
 	$b:	LOCp
@@ -60,7 +60,7 @@ stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr
+intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr @ 122:22
 	$i:	INPi
 	$radix:	INPi
 	$minLength:	INPi
@@ -107,7 +107,7 @@ intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, 
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-stringToFloat:	FUNC	; signature func stringToFloat(ptr b, ptr v) -> ptr
+stringToFloat:	FUNC	; signature func stringToFloat(ptr b, ptr v) -> ptr @ 140:24
 	$b:	INPp
 	$v:	INPp
 	$f:	LOCf
@@ -177,7 +177,7 @@ stringToFloat:	FUNC	; signature func stringToFloat(ptr b, ptr v) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr buffer) -> ptr
+floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr buffer) -> ptr @ 182:24
 	$f:	INPf
 	$precision:	INPi
 	$buffer:	INPp
@@ -312,7 +312,7 @@ floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr b
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
+traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void @ 287:20
 	$text:	INPp
 	$n:	INPi
 	$ints:	INPp
@@ -326,7 +326,7 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		EQUp $text &NULL @.f0	; if (text != null) p = (pointer) stpcpy(p, text)
 		MOVp %1 $p 	; p = (pointer) stpcpy(p, text)
 		MOVp %2 $text 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 294:49
 		MOVp $p %0 
 	.f0:	POKE $p #0 	; *p = 0
 		MOVi $i #0 	; for (i = 0 to n) 
@@ -339,18 +339,18 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		MOVi %4 #10 
 		MOVi %5 #1 
 		ADRL %6 $buffer *0
-		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr @ 298:62
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 298:63
 		MOVp $p %0 
 		FORi $i $n @.l2	; }
 	.e1:	ADRL %1 $line *0	; trace(line)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 300:13
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
+traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void @ 303:19
 	$text:	INPp
 	$i:	INPi
 	$ints:	LOCA *1
@@ -359,13 +359,13 @@ traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
 		MOVp %1 $text 	; traceInts(text, 1, ints)
 		MOVi %2 #1 
 		ADRL %3 $ints *0
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 307:26
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceFloats:	FUNC	; signature func traceFloats(ptr text, int n, ptr floats) -> void
+traceFloats:	FUNC	; signature func traceFloats(ptr text, int n, ptr floats) -> void @ 310:22
 	$text:	INPp
 	$n:	INPi
 	$floats:	INPp
@@ -378,7 +378,7 @@ traceFloats:	FUNC	; signature func traceFloats(ptr text, int n, ptr floats) -> v
 		EQUp $text &NULL @.f0	; if (text != null) p = (pointer) stpcpy(p, text)
 		MOVp %1 $p 	; p = (pointer) stpcpy(p, text)
 		MOVp %2 $text 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 317:49
 		MOVp $p %0 
 	.f0:	POKE $p #0 	; *p = 0
 		MOVi $i #0 	; for (i = 0 to n) 
@@ -390,18 +390,18 @@ traceFloats:	FUNC	; signature func traceFloats(ptr text, int n, ptr floats) -> v
 		PEEK %3 $floats $i
 		MOVi %4 #8 
 		ADRL %5 $buffer *0
-		CALL &floatToString %2 *4	; expects floatToString(float, int, ptr) -> ptr
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &floatToString %2 *4	; expects floatToString(float, int, ptr) -> ptr @ 321:62
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 321:63
 		MOVp $p %0 
 		FORi $i $n @.l2	; }
 	.e1:	ADRL %1 $line *0	; trace(line)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 323:13
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceFloat:	FUNC	; signature func traceFloat(ptr text, float f) -> void
+traceFloat:	FUNC	; signature func traceFloat(ptr text, float f) -> void @ 326:21
 	$text:	INPp
 	$f:	INPf
 	$floats:	LOCA *1
@@ -410,25 +410,25 @@ traceFloat:	FUNC	; signature func traceFloat(ptr text, float f) -> void
 		MOVp %1 $text 	; traceFloats(text, 1, floats)
 		MOVi %2 #1 
 		ADRL %3 $floats *0
-		CALL &traceFloats %0 *4	; expects traceFloats(ptr, int, ptr) -> void
+		CALL &traceFloats %0 *4	; expects traceFloats(ptr, int, ptr) -> void @ 330:30
 		RETU   	; }
 
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 335:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 335:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 337:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 338:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-exp:	FUNC	; signature func exp(float x) -> float
+exp:	FUNC	; signature func exp(float x) -> float @ 366:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -452,13 +452,13 @@ exp:	FUNC	; signature func exp(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sqrt:	FUNC	; signature func sqrt(float x) -> float
+sqrt:	FUNC	; signature func sqrt(float x) -> float @ 386:15
 	$x:	INPf
 	$t:	LOCf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) error("Domain error")
 		MOVp %1 &.s_Domain4dd 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 390:36
 	.f0:	MOVf $y $x 	; y = x
 		MOVf $t #0.0 	; t = 0.0
 	.l1:	EQUf $y $t @.e2	; while (y != t) 
@@ -470,13 +470,13 @@ sqrt:	FUNC	; signature func sqrt(float x) -> float
 	.e2:	RETU   	; }
 
 	GLOB *1
-rndSeedX:	DATi #123456789	; signature global rndSeedX : int
+rndSeedX:	DATi #123456789	; signature global rndSeedX : int @ 399:32
 	GLOB *1
-rndSeedY:	DATi #362436069	; signature global rndSeedY : int
+rndSeedY:	DATi #362436069	; signature global rndSeedY : int @ 400:32
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-seedRandom:	FUNC	; signature func seedRandom(int seed) -> void
+seedRandom:	FUNC	; signature func seedRandom(int seed) -> void @ 402:21
 	$seed:	INPi
 	$x:	LOCi
 ;-----------------------------------------------------------------------------
@@ -495,7 +495,7 @@ seedRandom:	FUNC	; signature func seedRandom(int seed) -> void
 
 ;-----------------------------------------------------------------------------
 	$f:	OUTf
-randomFloat:	FUNC	; signature func randomFloat() -> float
+randomFloat:	FUNC	; signature func randomFloat() -> float @ 413:22
 	$x:	LOCi
 	$y:	LOCi
 	$t:	LOCi
@@ -516,57 +516,57 @@ randomFloat:	FUNC	; signature func randomFloat() -> float
 		POKE &rndSeedY $y 	; global rndSeedY = y
 		RETU   	; }
 
-STEP_COUNT:	! DEFi #32	; signature const STEP_COUNT : int
-REVERSE_FX:	! DEFi #0	; signature const REVERSE_FX : int
-BIT_CRUSH_EFFECT:	! DEFi #1	; signature const BIT_CRUSH_EFFECT : int
-TRANCE_GATE_EFFECT:	! DEFi #2	; signature const TRANCE_GATE_EFFECT : int
-REPEAT_EFFECT:	! DEFi #3	; signature const REPEAT_EFFECT : int
-STRETCH_EFFECT:	! DEFi #4	; signature const STRETCH_EFFECT : int
-PITCH_SHIFT_EFFECT:	! DEFi #5	; signature const PITCH_SHIFT_EFFECT : int
-HALF_SPEED_EFFECT:	! DEFi #6	; signature const HALF_SPEED_EFFECT : int
-TAPE_STOP_FX:	! DEFi #7	; signature const TAPE_STOP_FX : int
-fxRate:	! DEFi #0	; signature const fxRate : int
-FX_PARAM_TAPE_STOP_RATE:	! DEFi #0	; signature const FX_PARAM_TAPE_STOP_RATE : int
-FX_PARAM_TRANCE_GATE_RATE:	! DEFi #1	; signature const FX_PARAM_TRANCE_GATE_RATE : int
-FX_PARAM_BIT_CRUSH_MASK:	! DEFi #2	; signature const FX_PARAM_BIT_CRUSH_MASK : int
-FX_PARAM_REPEAT_MASK:	! DEFi #3	; signature const FX_PARAM_REPEAT_MASK : int
-FX_PARAM_REPEAT_OFF_3:	! DEFi #4	; signature const FX_PARAM_REPEAT_OFF_3 : int
-FX_PARAM_SHIFT_9:	! DEFi #5	; signature const FX_PARAM_SHIFT_9 : int
-FX_PARAM_SHIFT_10:	! DEFi #6	; signature const FX_PARAM_SHIFT_10 : int
-FX_PARAM_1_LSHIFT_9:	! DEFi #7	; signature const FX_PARAM_1_LSHIFT_9 : int
-FX_PARAM_1_LSHIFT_10:	! DEFi #8	; signature const FX_PARAM_1_LSHIFT_10 : int
-FX_PARAM_MASK_10:	! DEFi #9	; signature const FX_PARAM_MASK_10 : int
-FX_PARAM_COUNT:	! DEFi #10	; signature const FX_PARAM_COUNT : int
+STEP_COUNT:	! DEFi #32	; signature const STEP_COUNT : int @ 431:1
+REVERSE_FX:	! DEFi #0	; signature const REVERSE_FX : int @ 431:25
+BIT_CRUSH_EFFECT:	! DEFi #1	; signature const BIT_CRUSH_EFFECT : int @ 432:31
+TRANCE_GATE_EFFECT:	! DEFi #2	; signature const TRANCE_GATE_EFFECT : int @ 433:33
+REPEAT_EFFECT:	! DEFi #3	; signature const REPEAT_EFFECT : int @ 434:28
+STRETCH_EFFECT:	! DEFi #4	; signature const STRETCH_EFFECT : int @ 435:29
+PITCH_SHIFT_EFFECT:	! DEFi #5	; signature const PITCH_SHIFT_EFFECT : int @ 436:33
+HALF_SPEED_EFFECT:	! DEFi #6	; signature const HALF_SPEED_EFFECT : int @ 437:32
+TAPE_STOP_FX:	! DEFi #7	; signature const TAPE_STOP_FX : int @ 438:27
+fxRate:	! DEFi #0	; signature const fxRate : int @ 440:21
+FX_PARAM_TAPE_STOP_RATE:	! DEFi #0	; signature const FX_PARAM_TAPE_STOP_RATE : int @ 441:38
+FX_PARAM_TRANCE_GATE_RATE:	! DEFi #1	; signature const FX_PARAM_TRANCE_GATE_RATE : int @ 442:40
+FX_PARAM_BIT_CRUSH_MASK:	! DEFi #2	; signature const FX_PARAM_BIT_CRUSH_MASK : int @ 443:38
+FX_PARAM_REPEAT_MASK:	! DEFi #3	; signature const FX_PARAM_REPEAT_MASK : int @ 444:35
+FX_PARAM_REPEAT_OFF_3:	! DEFi #4	; signature const FX_PARAM_REPEAT_OFF_3 : int @ 445:36
+FX_PARAM_SHIFT_9:	! DEFi #5	; signature const FX_PARAM_SHIFT_9 : int @ 446:31
+FX_PARAM_SHIFT_10:	! DEFi #6	; signature const FX_PARAM_SHIFT_10 : int @ 447:32
+FX_PARAM_1_LSHIFT_9:	! DEFi #7	; signature const FX_PARAM_1_LSHIFT_9 : int @ 448:34
+FX_PARAM_1_LSHIFT_10:	! DEFi #8	; signature const FX_PARAM_1_LSHIFT_10 : int @ 449:35
+FX_PARAM_MASK_10:	! DEFi #9	; signature const FX_PARAM_MASK_10 : int @ 450:31
+FX_PARAM_COUNT:	! DEFi #10	; signature const FX_PARAM_COUNT : int @ 451:30
 	! MULi <A> #FX_PARAM_COUNT #5
-FX_PARAMS:	GLOB *<A>	; signature array FX_PARAMS[<A>] : unknown
-stepFXs:	GLOB *STEP_COUNT	; signature array stepFXs[STEP_COUNT] : unknown
-stepFXParams:	GLOB *STEP_COUNT	; signature array stepFXParams[STEP_COUNT] : unknown
+FX_PARAMS:	GLOB *<A>	; signature array FX_PARAMS[<A>] : unknown @ 455:43
+stepFXs:	GLOB *STEP_COUNT	; signature array stepFXs[STEP_COUNT] : unknown @ 457:1
+stepFXParams:	GLOB *STEP_COUNT	; signature array stepFXParams[STEP_COUNT] : unknown @ 457:38
 	GLOB *1
-doReset:	DATi #TRUE	; signature global doReset : int
+doReset:	DATi #TRUE	; signature global doReset : int @ 459:1
 	GLOB *1
-updateBits:	DATi #TRUE	; signature global updateBits : int
+updateBits:	DATi #TRUE	; signature global updateBits : int @ 460:1
 	GLOB *1
-clockMask:	DATi #0x1FFFF	; signature global clockMask : int
+clockMask:	DATi #0x1FFFF	; signature global clockMask : int @ 460:31
 	GLOB *1
-clockShift:	DATi #13	; signature global clockShift : int
+clockShift:	DATi #13	; signature global clockShift : int @ 461:27
 	GLOB *1
-fxQuantize:	DATi #0xFFF	; signature global fxQuantize : int
+fxQuantize:	DATi #0xFFF	; signature global fxQuantize : int @ 462:30
 	GLOB *1
-dirXor:	DATi #0x0	; signature global dirXor : int
+dirXor:	DATi #0x0	; signature global dirXor : int @ 463:24
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 473:16
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4de 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 475:16
 		POKE &doReset #TRUE 	; global doReset = TRUE
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 486:17
 	$i:	LOCi
 	$fx:	LOCi
 	$fxRnd:	LOCi
@@ -580,7 +580,7 @@ update:	FUNC	; signature func update() -> void
 	$f:	LOCf
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_update4df 	; trace("update")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 499:17
 		POKE &dirXor #0 	; global dirXor = 0
 		PEEK %0 &params:SWITCHES_PARAM_INDEX 	; if (((int) global params[SWITCHES_PARAM_INDEX] & SWITCHES_REVERSE_MASK) != 0) 
 		ANDi %0 %0 #SWITCHES_REVERSE_MASK
@@ -600,7 +600,7 @@ update:	FUNC	; signature func update() -> void
 	.f4:	FORi $i #8 @.l3	; }
 	.f1:	PEEK %1 &params:OPERAND_1_LOW_PARAM_INDEX 	; seedRandom((int) global params[OPERAND_1_LOW_PARAM_INDEX] + 1283756)
 		ADDi %1 %1 #1283756
-		CALL &seedRandom %0 *2	; expects seedRandom(int) -> void
+		CALL &seedRandom %0 *2	; expects seedRandom(int) -> void @ 518:70
 		PEEK %0 &params:OPERATOR_2_PARAM_INDEX 	; stepRate = (int) global params[OPERATOR_2_PARAM_INDEX] - 1
 		SUBi $stepRate %0 #1
 		GEQi $stepRate #0 @.f5	; if (stepRate < 0) 
@@ -634,16 +634,16 @@ update:	FUNC	; signature func update() -> void
 		MOVi $fx #-1 	; fx = -1
 		MOVi $i #0 	; for (i = 0 to STEP_COUNT) 
 		GEQi #0 #STEP_COUNT @.e12
-	.l13:	CALL &randomFloat %0 *1	; expects randomFloat() -> float
+	.l13:	CALL &randomFloat %0 *1	; expects randomFloat() -> float @ 544:30
 		MOVf $f %0 
 		EQUi $i #0 @.t14	; if (i == 0 || i == 7) 
 		NEQi $i #7 @.f15
 	.t14:	MOVp %1 &.s_s4e0 	; traceInt("s:", i)
 		MOVi %2 $i 
-		CALL &traceInt %0 *3	; expects traceInt(ptr, int) -> void
+		CALL &traceInt %0 *3	; expects traceInt(ptr, int) -> void @ 546:23
 		MOVp %1 &.s_f4e1 	; traceFloat("f:",f)
 		MOVf %2 $f 
-		CALL &traceFloat %0 *3	; expects traceFloat(ptr, float) -> void
+		CALL &traceFloat %0 *3	; expects traceFloat(ptr, float) -> void @ 547:24
 	.f15:	MULf %0 $f $fxCountFloat	; fxRnd = ftoi(f * fxCountFloat)
 		fTOi $fxRnd %0 #1.0
 		LEQi $fxRnd $fxCount @.f16	; if (fxRnd > fxCount) 
@@ -659,7 +659,7 @@ update:	FUNC	; signature func update() -> void
 	.e19:	POKE &stepFXs $i $fx	; global stepFXs[i] = fx
 		FORi $i #STEP_COUNT @.l13	; }
 	.e12:	MOVp %1 &.s_4e2 	; trace("---")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 562:16
 	.e11:	NOOP
 	.e7:	MOVi $i #0 	; for (i = 0 to STEP_COUNT) 
 		GEQi #0 #STEP_COUNT @.e20
@@ -672,7 +672,7 @@ update:	FUNC	; signature func update() -> void
 		GOTO @.e23  
 	.s22#3:	MOVi $fx #0 	; fx = 0
 		GOTO @.e23  
-	.s22#4:	CALL &randomFloat %0 *1	; expects randomFloat() -> float
+	.s22#4:	CALL &randomFloat %0 *1	; expects randomFloat() -> float @ 571:44
 		fTOi $fx %0 #2.9999
 	.s22:	NOOP
 	.e23:	POKE &stepFXParams $i $fx	; global stepFXParams[i] = fx
@@ -680,17 +680,17 @@ update:	FUNC	; signature func update() -> void
 	.e20:	MOVp %1 &.s_steps4e3 	; traceInts("steps: ", 16, global stepFXs)
 		MOVi %2 #16 
 		MOVp %3 &stepFXs 
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 575:42
 		MOVp %1 &.s_params4e4 	; traceInts("params: ", 16, global stepFXParams)
 		MOVi %2 #16 
 		MOVp %3 &stepFXParams 
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 576:48
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 584:15
 	$i:	LOCi
 	$p:	LOCp
 	$fxRate:	LOCi
@@ -698,8 +698,8 @@ init:	FUNC	; signature func init() -> void
 	$t:	LOCi
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4e5 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL &update %0 *1	; expects update() -> void
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 587:15
+		CALL &update %0 *1	; expects update() -> void @ 588:10
 		MOVp $p &FX_PARAMS 	; p = global FX_PARAMS
 		MOVi $i #0 	; for (i = 0 to 3) 
 		GEQi #0 #3 @.e0
@@ -734,7 +734,7 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 622:18
 	$i:	LOCi
 	$x:	LOCi
 	$mask:	LOCi
@@ -805,11 +805,11 @@ process:	FUNC	; signature func process() -> void
 	.f3:	MOVi %1 $clock 	; write(clock, 1, global signal)
 		MOVi %2 #1 
 		MOVp %3 &signal 
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 679:33
 		MOVi %1 $clock 	; read(clock, 1, inp)
 		MOVi %2 #1 
 		ADRL %3 $inp *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 680:22
 		SWCH $held *8 @.s7	; switch (held == 0 to 8) 
 	.s7#REVERSE_FX:	EQUi $trig #FALSE @.f9	; if (trig != FALSE) 
 		MOVi $pos $clock 	; pos = clock
@@ -817,7 +817,7 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $pos 	; read(pos, 1, outp)
 		MOVi %2 #1 
 		ADRL %3 $outp *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 688:23
 		GOTO @.e8  	; }
 	.s7#TAPE_STOP_FX:	EQUi $trig #FALSE @.f10	; if (trig != FALSE) 
 		SHLi $pos $clock #16	; pos = clock << 16
@@ -826,7 +826,7 @@ process:	FUNC	; signature func process() -> void
 		SHRi %1 $pos #16	; read(pos >> 16, 2, samples)
 		MOVi %2 #2 
 		ADRL %3 $samples *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 697:32
 		SUBi %0 $samples:2 $samples:0	; outp[0] = (int) samples[0] + (((int) samples[2] - (int) samples[0]) * x >> 16)
 		MULi %0 %0 $x
 		SHRi %0 %0 #16
@@ -845,7 +845,7 @@ process:	FUNC	; signature func process() -> void
 	.f12:	SHRi %1 $pos #1	; read(pos >> 1, 1, outp)
 		MOVi %2 #1 
 		ADRL %3 $outp *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 711:28
 		ADDi $pos $pos #1	; pos = pos + 1
 		GOTO @.e8  	; }
 	.s7#TRANCE_GATE_EFFECT:	SHRi %0 $clock $fxParams:FX_PARAM_TRANCE_GATE_RATE	; x = (clock >> (int) fxParams[FX_PARAM_TRANCE_GATE_RATE]) & 0x7FF
@@ -873,7 +873,7 @@ process:	FUNC	; signature func process() -> void
 	.s7#BIT_CRUSH_EFFECT:	ANDi %1 $clock $fxParams:FX_PARAM_BIT_CRUSH_MASK	; read(clock & (int) fxParams[FX_PARAM_BIT_CRUSH_MASK], 1, outp)
 		MOVi %2 #1 
 		ADRL %3 $outp *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 731:67
 		! XORi <A> #0x7F #-1	; outp[0] = (int) outp[0] & ~0x7F
 		ANDi $outp:0 $outp:0 <A>
 		! XORi <A> #0x7F #-1	; outp[1] = (int) outp[1] & ~0x7F
@@ -887,7 +887,7 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $pos 	; read(pos, 1, samples)
 		MOVi %2 #1 
 		ADRL %3 $samples *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 740:26
 		ANDi %0 $clock $fxParams:FX_PARAM_REPEAT_OFF_3	; if ((clock & (int) fxParams[FX_PARAM_REPEAT_OFF_3]) == (int) fxParams[FX_PARAM_REPEAT_OFF_3]) 
 		NEQi %0 $fxParams:FX_PARAM_REPEAT_OFF_3 @.f19
 		ADDi $pos $pos $fxParams:FX_PARAM_REPEAT_OFF_3	; pos = pos + (int) fxParams[FX_PARAM_REPEAT_OFF_3]
@@ -905,7 +905,7 @@ process:	FUNC	; signature func process() -> void
 	.e22:	MOVi %1 $pos 	; read(pos, 1, &samples[2])
 		MOVi %2 #1 
 		ADRL %3 $samples:2 *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 752:30
 		SUBi %0 $samples:2 $samples:0	; outp[0] = (int) samples[0] + (((int) samples[2] - (int) samples[0]) * x >> (int) fxParams[FX_PARAM_SHIFT_10])
 		MULi %0 %0 $x
 		SHRi %0 %0 $fxParams:FX_PARAM_SHIFT_10
@@ -920,11 +920,11 @@ process:	FUNC	; signature func process() -> void
 	.f24:	MOVi %1 $pos 	; read(pos, 1, samples)
 		MOVi %2 #1 
 		ADRL %3 $samples *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 761:26
 		SUBi %1 $pos $fxParams:FX_PARAM_1_LSHIFT_9	; read(pos - (int) fxParams[FX_PARAM_1_LSHIFT_9], 1, &samples[2])
 		MOVi %2 #1 
 		ADRL %3 $samples:2 *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 762:68
 		ANDi $x $clock $fxParams:FX_PARAM_MASK_10	; x = clock & (int) fxParams[FX_PARAM_MASK_10]
 		SUBi %0 $samples:2 $samples:0	; outp[0] = (int) samples[0] + (((int) samples[2] - (int) samples[0]) * x >> (int) fxParams[FX_PARAM_SHIFT_10])
 		MULi %0 %0 $x
@@ -948,11 +948,11 @@ process:	FUNC	; signature func process() -> void
 		SUBi %1 $pos $fxParams:FX_PARAM_1_LSHIFT_9	; read(pos - (int) fxParams[FX_PARAM_1_LSHIFT_9], 1, samples)
 		MOVi %2 #1 
 		ADRL %3 $samples *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 775:64
 		SUBi %1 $pos $fxParams:FX_PARAM_1_LSHIFT_10	; read(pos - (int) fxParams[FX_PARAM_1_LSHIFT_10], 1, &samples[2])
 		MOVi %2 #1 
 		ADRL %3 $samples:2 *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 776:69
 		SUBi %0 $samples:2 $samples:0	; outp[0] = (int) samples[0] + (((int) samples[2] - (int) samples[0]) * x >> (int) fxParams[FX_PARAM_SHIFT_9])
 		MULi %0 %0 $x
 		SHRi %0 %0 $fxParams:FX_PARAM_SHIFT_9
@@ -981,7 +981,7 @@ process:	FUNC	; signature func process() -> void
 		SHRi %0 %0 #15
 		ADDi %0 $inp:1 %0
 		POKE &signal:1 %0 
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 796:10
 		ADDi $clock $clock #1	; clock = clock + 1
 		GOTO @.l0  	; }
 		RETU   	; }

--- a/tests/impala/golden/debug.gazl
+++ b/tests/impala/golden/debug.gazl
@@ -1,4 +1,4 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-DEBUG:	! DEFi #0	; signature const DEBUG : int
+DEBUG:	! DEFi #0	; signature const DEBUG : int @ 2:1

--- a/tests/impala/golden/disasm.gazl
+++ b/tests/impala/golden/disasm.gazl
@@ -1,29 +1,29 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-FILE_BUFFER_SIZE:	! DEFi #8192	; signature const FILE_BUFFER_SIZE : int
-TERMINAL_COLUMNS:	! DEFi #80	; signature const TERMINAL_COLUMNS : int
-TERMINAL_ROWS:	! DEFi #25	; signature const TERMINAL_ROWS : int
-TERMINAL_TAB_SIZE:	! DEFi #4	; signature const TERMINAL_TAB_SIZE : int
-; signature extern native output() -> unknown
-; signature extern native input() -> unknown
-; signature extern native inputEOF() -> unknown
-; signature extern native launch() -> unknown
-; signature extern native loadText() -> unknown
-; signature extern native sleep() -> unknown
-; signature extern array FILE_TYPE_STRINGS[] : unknown
-; signature extern global fileCount : int
-; signature extern array FILES[] : unknown
-; signature extern func strcmp() -> unknown
-; signature extern func findFile() -> unknown
-; signature extern func lower() -> unknown
-; signature extern func initFilesIfNecessary() -> unknown
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
+FILE_BUFFER_SIZE:	! DEFi #8192	; signature const FILE_BUFFER_SIZE : int @ 9:1
+TERMINAL_COLUMNS:	! DEFi #80	; signature const TERMINAL_COLUMNS : int @ 10:1
+TERMINAL_ROWS:	! DEFi #25	; signature const TERMINAL_ROWS : int @ 11:1
+TERMINAL_TAB_SIZE:	! DEFi #4	; signature const TERMINAL_TAB_SIZE : int @ 13:1
+; signature extern native output() -> unknown @ 14:1
+; signature extern native input() -> unknown @ 15:1
+; signature extern native inputEOF() -> unknown @ 16:1
+; signature extern native launch() -> unknown @ 17:1
+; signature extern native loadText() -> unknown @ 18:1
+; signature extern native sleep() -> unknown @ 22:1
+; signature extern array FILE_TYPE_STRINGS[] : unknown @ 30:1
+; signature extern global fileCount : int @ 37:1
+; signature extern array FILES[] : unknown @ 39:1
+; signature extern func strcmp() -> unknown @ 40:1
+; signature extern func findFile() -> unknown @ 41:1
+; signature extern func lower() -> unknown @ 42:1
+; signature extern func initFilesIfNecessary() -> unknown @ 46:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 47:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 49:1
 
 ;-----------------------------------------------------------------------------
 	$l:	OUTi
-strlen:	FUNC	; signature func strlen(ptr s) -> int
+strlen:	FUNC	; signature func strlen(ptr s) -> int @ 49:17
 	$s:	INPp
 	$a:	LOCp
 ;-----------------------------------------------------------------------------
@@ -38,7 +38,7 @@ strlen:	FUNC	; signature func strlen(ptr s) -> int
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTp
-strcat:	FUNC	; signature func strcat(ptr d, ptr s) -> ptr
+strcat:	FUNC	; signature func strcat(ptr d, ptr s) -> ptr @ 58:17
 	$d:	INPp
 	$s:	INPp
 	$a:	LOCp
@@ -62,21 +62,21 @@ strcat:	FUNC	; signature func strcat(ptr d, ptr s) -> ptr
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-outputLine:	FUNC	; signature func outputLine(ptr s) -> void
+outputLine:	FUNC	; signature func outputLine(ptr s) -> void @ 71:21
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; output(s)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 73:11
 		MOVp %1 &.s_4d2 	; output("\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 74:14
 		RETU   	; }
 
 	! ADDi <A> #FILE_BUFFER_SIZE #1
-fileBuffer:	GLOB *<A>	; signature array fileBuffer[<A>] : unknown
+fileBuffer:	GLOB *<A>	; signature array fileBuffer[<A>] : unknown @ 79:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 79:15
 	$s:	LOCA *256
 	$type:	LOCi
 	$offset:	LOCi
@@ -91,23 +91,23 @@ main:	FUNC	; signature func main() -> void
 	$i:	LOCi
 	$yn:	LOCA *64
 ;-----------------------------------------------------------------------------
-		CALL &initFilesIfNecessary %0 *1	; expects initFilesIfNecessary() -> unknown
+		CALL &initFilesIfNecessary %0 *1	; expects initFilesIfNecessary() -> unknown @ 83:24
 		MOVp %1 &.s_GAZLdi4d3 	; outputLine("GAZL disassembler v2.1.")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 84:39
 		MOVp %1 &.s_Disass4d4 	; output("Disassemble file: ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 85:30
 		MOVi %1 #255 	; input(255, s)
 		ADRL %2 $s *0
-		CALL ^input %0 *3	; expects function(int, ptr) -> unknown
+		CALL ^input %0 *3	; expects function(int, ptr) -> unknown @ 86:15
 		EQUi $s:0 #0 @.f0	; if ((int)s[0] != 0) 
 		ADRL %1 $s *0	; lower(s)
-		CALL &lower %0 *2	; expects lower(ptr) -> unknown
+		CALL &lower %0 *2	; expects lower(ptr) -> unknown @ 88:11
 		ADRL %1 $s *0	; if ((file = (int)findFile(s)) < 0) outputLine("File not found")
-		CALL &findFile %0 *2	; expects findFile(ptr) -> unknown
+		CALL &findFile %0 *2	; expects findFile(ptr) -> unknown @ 89:31
 		MOVi $file %0 
 		GEQi %0 #0 @.f1
 		MOVp %1 &.s_Fileno4d5 	; outputLine("File not found")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 89:66
 		GOTO @.e2  
 	.f1:	MULi %0 $file #FILE_FIELD_COUNT	; if ((type = (int)global FILES[file * FILE_FIELD_COUNT + FILE_FIELD_TYPE]) != FILE_TYPE_EXE
 		ADDi %0 %0 #FILE_FIELD_TYPE
@@ -116,21 +116,21 @@ main:	FUNC	; signature func main() -> void
 		EQUi $type #FILE_TYPE_SYS @.f4
 		EQUi $type #FILE_TYPE_BIN @.f4
 		MOVp %1 &.s_Fileis4d6 	; outputLine("File is not GAZL format")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 93:42
 		GOTO @.e5  	; } else if ((int)strcmp(s, "permut8") == 0) 
 	.f4:	ADRL %1 $s *0	; if ((int)strcmp(s, "permut8") == 0) 
 		MOVp %2 &.s_permut4d7 
-		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> unknown
+		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> unknown @ 94:41
 		NEQi %0 #0 @.f6
 		MOVp %1 &.s_Protec4d8 	; outputLine("Protected file")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 95:33
 		GOTO @.e7  	; } else 
 	.f6:	MOVp $p &.s_zl4d9 	; p = ".zl"
 		NEQi $type #FILE_TYPE_BIN @.f8	; if (type == FILE_TYPE_BIN) p = ".gazl"
 		MOVp $p &.s_gazl4da 	; p = ".gazl"
 	.f8:	ADRL %1 $s *0	; strcat(s, p)
 		MOVp %2 $p 
-		CALL &strcat %0 *3	; expects strcat(ptr, ptr) -> ptr
+		CALL &strcat %0 *3	; expects strcat(ptr, ptr) -> ptr @ 99:17
 		MOVi $offset #0 	; offset = 0
 		MOVi $row #0 	; row = 0
 		MOVi $col #0 	; col = 0
@@ -138,11 +138,11 @@ main:	FUNC	; signature func main() -> void
 		MOVi %2 $offset 
 		MOVi %3 #FILE_BUFFER_SIZE 
 		MOVp %4 &fileBuffer 
-		CALL ^loadText %0 *5	; expects function(ptr, int, int, ptr) -> unknown
+		CALL ^loadText %0 *5	; expects function(ptr, int, int, ptr) -> unknown @ 104:79
 		MOVi $readCount %0 
 		GEQi $readCount #0 @.f10	; if (readCount < 0) 
 		MOVp %1 &.s_Reader4db 	; outputLine("Read error")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 106:31
 		GOTO @stopIt  	; goto stopIt
 		GOTO @.e11  	; } else 
 	.f10:	MOVp $p &fileBuffer 	; p = global fileBuffer
@@ -163,14 +163,14 @@ main:	FUNC	; signature func main() -> void
 		PEEK $c $p 	; c = (int)*p
 		POKE $p #0 	; *p = 0
 		MOVp %1 $b 	; output(b)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 121:19
 		POKE $p $c 	; (int)*p = c
 		MOVp $b $p 	; b = p
 		MOVp %1 &.s_Morey4dc 	; output("More (y)? ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 124:30
 		MOVi %1 #63 	; input(63, yn)
 		ADRL %2 $yn *0
-		CALL ^input %0 *3	; expects function(int, ptr) -> unknown
+		CALL ^input %0 *3	; expects function(int, ptr) -> unknown @ 125:23
 		EQUi $yn:0 #'n' @stopIt	; if ((int)yn[0] == 'n' || (int)yn[0] == 'N') goto stopIt
 		NEQi $yn:0 #'N' @.f19
 		GOTO @stopIt  	; goto stopIt
@@ -179,11 +179,11 @@ main:	FUNC	; signature func main() -> void
 		GOTO @.l12  	; }
 	.e13:	POKE $e #0 	; *e = 0
 		MOVp %1 $b 	; output(b)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 133:16
 		ADDi $offset $offset $readCount	; offset = offset + readCount
 	.e11:	GRTi $readCount #0 @.l9	; } while (readCount > 0)
 		MOVp %1 &.s_Morey4dc:10 	; outputLine("")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 137:19
 	.e7:	NOOP
 	.e5:	NOOP
 	.e2:	NOOP

--- a/tests/impala/golden/fileList.gazl
+++ b/tests/impala/golden/fileList.gazl
@@ -1,26 +1,26 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-; signature extern native findFirmwarePatch() -> unknown
-FILE_TYPE_COUNT:	! DEFi #4	; signature const FILE_TYPE_COUNT : int
-FILE_TYPE_EXE:	! DEFi #0	; signature const FILE_TYPE_EXE : int
-FILE_TYPE_SYS:	! DEFi #1	; signature const FILE_TYPE_SYS : int
-FILE_TYPE_TXT:	! DEFi #2	; signature const FILE_TYPE_TXT : int
-FILE_TYPE_BIN:	! DEFi #3	; signature const FILE_TYPE_BIN : int
-FILE_TYPE_STRINGS:	CNST *FILE_TYPE_COUNT	; signature array FILE_TYPE_STRINGS[FILE_TYPE_COUNT] : unknown
+; signature extern native findFirmwarePatch() -> unknown @ 9:1
+FILE_TYPE_COUNT:	! DEFi #4	; signature const FILE_TYPE_COUNT : int @ 10:1
+FILE_TYPE_EXE:	! DEFi #0	; signature const FILE_TYPE_EXE : int @ 11:1
+FILE_TYPE_SYS:	! DEFi #1	; signature const FILE_TYPE_SYS : int @ 12:1
+FILE_TYPE_TXT:	! DEFi #2	; signature const FILE_TYPE_TXT : int @ 13:1
+FILE_TYPE_BIN:	! DEFi #3	; signature const FILE_TYPE_BIN : int @ 14:1
+FILE_TYPE_STRINGS:	CNST *FILE_TYPE_COUNT	; signature array FILE_TYPE_STRINGS[FILE_TYPE_COUNT] : unknown @ 14:51
 	DATA &.s_exe4d2 &.s_sys4d3 &.s_txt4d4 &.s_bin4d5
-FILE_FIELD_NAME:	! DEFi #0	; signature const FILE_FIELD_NAME : int
-FILE_FIELD_TYPE:	! DEFi #1	; signature const FILE_FIELD_TYPE : int
-FILE_FIELD_SIZE:	! DEFi #2	; signature const FILE_FIELD_SIZE : int
-FILE_FIELD_DATE:	! DEFi #3	; signature const FILE_FIELD_DATE : int
-FILE_FIELD_COUNT:	! DEFi #4	; signature const FILE_FIELD_COUNT : int
-MAX_FILE_COUNT:	! DEFi #100	; signature const MAX_FILE_COUNT : int
-MAX_FILE_NAME_LENGTH:	! DEFi #31	; signature const MAX_FILE_NAME_LENGTH : int
-BUILT_IN_FILE_COUNT:	! DEFi #14	; signature const BUILT_IN_FILE_COUNT : int
+FILE_FIELD_NAME:	! DEFi #0	; signature const FILE_FIELD_NAME : int @ 19:1
+FILE_FIELD_TYPE:	! DEFi #1	; signature const FILE_FIELD_TYPE : int @ 20:1
+FILE_FIELD_SIZE:	! DEFi #2	; signature const FILE_FIELD_SIZE : int @ 21:1
+FILE_FIELD_DATE:	! DEFi #3	; signature const FILE_FIELD_DATE : int @ 22:1
+FILE_FIELD_COUNT:	! DEFi #4	; signature const FILE_FIELD_COUNT : int @ 24:1
+MAX_FILE_COUNT:	! DEFi #100	; signature const MAX_FILE_COUNT : int @ 25:1
+MAX_FILE_NAME_LENGTH:	! DEFi #31	; signature const MAX_FILE_NAME_LENGTH : int @ 26:1
+BUILT_IN_FILE_COUNT:	! DEFi #14	; signature const BUILT_IN_FILE_COUNT : int @ 27:1
 	GLOB *1
-fileCount:	DATi #BUILT_IN_FILE_COUNT	; signature global fileCount : int
+fileCount:	DATi #BUILT_IN_FILE_COUNT	; signature global fileCount : int @ 29:1
 	! MULi <A> #MAX_FILE_COUNT #FILE_FIELD_COUNT
-FILES:	GLOB *<A>	; signature array FILES[<A>] : unknown
+FILES:	GLOB *<A>	; signature array FILES[<A>] : unknown @ 29:55
 	DATA &.s_about4d6 #FILE_TYPE_TXT #2 &.s_1113844d7
 	DATA &.s_advent4d8 #FILE_TYPE_EXE #91 &.s_221784d9
 	DATA &.s_blupri4da #FILE_TYPE_TXT #2 &.s_65794db
@@ -37,15 +37,15 @@ FILES:	GLOB *<A>	; signature array FILES[<A>] : unknown
 	DATA &.s_versio4ef #FILE_TYPE_TXT #1 &.s_1113844d7
 	! ADDi <A> #MAX_FILE_NAME_LENGTH #1
 	! MULi <A> #MAX_FILE_COUNT <A>
-FILE_NAMES:	GLOB *<A>	; signature array FILE_NAMES[<A>] : unknown
+FILE_NAMES:	GLOB *<A>	; signature array FILE_NAMES[<A>] : unknown @ 45:69
 	! MULi <A> #MAX_FILE_COUNT #9
-FILE_DATES:	GLOB *<A>	; signature array FILE_DATES[<A>] : unknown
+FILE_DATES:	GLOB *<A>	; signature array FILE_DATES[<A>] : unknown @ 46:44
 	GLOB *1
-filesAreInited:	DATi #0	; signature global filesAreInited : int
+filesAreInited:	DATi #0	; signature global filesAreInited : int @ 48:30
 
 ;-----------------------------------------------------------------------------
 	$d:	OUTi
-strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int
+strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int @ 50:17
 	$s0:	INPp
 	$s1:	INPp
 	$a:	LOCp
@@ -67,7 +67,7 @@ strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-sortFiles:	FUNC	; signature func sortFiles() -> void
+sortFiles:	FUNC	; signature func sortFiles() -> void @ 62:20
 	$i:	LOCi
 	$j:	LOCi
 	$minJ:	LOCi
@@ -92,7 +92,7 @@ sortFiles:	FUNC	; signature func sortFiles() -> void
 		PEEK $s &FILES %3
 		MOVp %3 $s 
 		MOVp %4 $minS 
-		CALL &strcmp %2 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %2 *3	; expects strcmp(ptr, ptr) -> int @ 69:97
 		GEQi %2 #0 @.f4
 		MOVi $minJ $j 	; minJ = j
 		MOVp $minS $s 	; minS = s
@@ -112,7 +112,7 @@ sortFiles:	FUNC	; signature func sortFiles() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-initFilesIfNecessary:	FUNC	; signature func initFilesIfNecessary() -> void
+initFilesIfNecessary:	FUNC	; signature func initFilesIfNecessary() -> void @ 80:31
 	$index:	LOCi
 	$size:	LOCi
 	$filePointer:	LOCp
@@ -136,7 +136,7 @@ initFilesIfNecessary:	FUNC	; signature func initFilesIfNecessary() -> void
 		MOVp %3 $namePointer 
 		ADRL %4 $size *0
 		MOVp %5 $datePointer 
-		CALL ^findFirmwarePatch %0 *6	; expects function(int, int, ptr, ptr, ptr) -> unknown
+		CALL ^findFirmwarePatch %0 *6	; expects function(int, int, ptr, ptr, ptr) -> unknown @ 89:78
 		NEQi %0 #1 @.e3
 		GEQi $index #MAX_FILE_COUNT @.l2	; if (index < MAX_FILE_COUNT) 
 		POKE $filePointer #FILE_FIELD_NAME $namePointer	; filePointer[FILE_FIELD_NAME] = namePointer
@@ -171,17 +171,17 @@ initFilesIfNecessary:	FUNC	; signature func initFilesIfNecessary() -> void
 	.a7:	GOTO @.l2  	; }
 	.e3:	ADDi %0 #BUILT_IN_FILE_COUNT $index	; global fileCount = BUILT_IN_FILE_COUNT + index
 		POKE &fileCount %0 
-		CALL &sortFiles %0 *1	; expects sortFiles() -> void
+		CALL &sortFiles %0 *1	; expects sortFiles() -> void @ 106:14
 		POKE &filesAreInited #1 	; global filesAreInited = 1
 	.f0:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$file:	OUTi
-findFile:	FUNC	; signature func findFile(ptr s0) -> int
+findFile:	FUNC	; signature func findFile(ptr s0) -> int @ 112:19
 	$s0:	INPp
 ;-----------------------------------------------------------------------------
-		CALL &initFilesIfNecessary %0 *1	; expects initFilesIfNecessary() -> void
+		CALL &initFilesIfNecessary %0 *1	; expects initFilesIfNecessary() -> void @ 115:24
 		MOVi $file #0 	; for (file = 0 to global fileCount)
 		PEEK %0 &fileCount 
 		GEQi #0 %0 @.e0
@@ -189,7 +189,7 @@ findFile:	FUNC	; signature func findFile(ptr s0) -> int
 		MULi %3 $file #FILE_FIELD_COUNT
 		ADDi %3 %3 #FILE_FIELD_NAME
 		PEEK %3 &FILES %3
-		CALL &strcmp %1 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %1 *3	; expects strcmp(ptr, ptr) -> int @ 117:80
 		NEQi %1 #0 @.f2
 		GOTO @found  	; goto found
 	.f2:	FORi $file %0 @.l1
@@ -199,7 +199,7 @@ findFile:	FUNC	; signature func findFile(ptr s0) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-lower:	FUNC	; signature func lower(ptr s) -> void
+lower:	FUNC	; signature func lower(ptr s) -> void @ 122:16
 	$s:	INPp
 	$p:	LOCp
 	$c:	LOCi

--- a/tests/impala/golden/flakes_code.gazl
+++ b/tests/impala/golden/flakes_code.gazl
@@ -1,25 +1,25 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_SAMPLE4d2 &.s_SQUARE4d3 &.s_GRAIN4d4
 	DATA &.s_COMBCC4d5 &.s_MIDIMo4d6 &.s_Oct24d7 &.s_ARPTri4d8
 	DATA &.s_RNDEuc4d9
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 81:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 83:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 86:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 88:1
 	CNST *1
 	! SHLi <A> #1 #OPERAND_1_HIGH_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_1_LOW_PARAM_INDEX
@@ -30,23 +30,23 @@ signal:	GLOB *2	; signature array signal[2] : unknown
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #OPERATOR_2_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 97:1
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 99:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 99:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 101:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 102:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-exp:	FUNC	; signature func exp(float x) -> float
+exp:	FUNC	; signature func exp(float x) -> float @ 130:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -70,13 +70,13 @@ exp:	FUNC	; signature func exp(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sqrt:	FUNC	; signature func sqrt(float x) -> float
+sqrt:	FUNC	; signature func sqrt(float x) -> float @ 150:15
 	$x:	INPf
 	$t:	LOCf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) error("Domain error")
 		MOVp %1 &.s_Domain4da 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 154:36
 	.f0:	MOVf $y $x 	; y = x
 		MOVf $t #0.0 	; t = 0.0
 	.l1:	EQUf $y $t @.e2	; while (y != t) 
@@ -88,13 +88,13 @@ sqrt:	FUNC	; signature func sqrt(float x) -> float
 	.e2:	RETU   	; }
 
 	GLOB *1
-rndSeedX:	DATi #123456789	; signature global rndSeedX : int
+rndSeedX:	DATi #123456789	; signature global rndSeedX : int @ 163:32
 	GLOB *1
-rndSeedY:	DATi #362436069	; signature global rndSeedY : int
+rndSeedY:	DATi #362436069	; signature global rndSeedY : int @ 164:32
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-seedRandom:	FUNC	; signature func seedRandom(int seed) -> void
+seedRandom:	FUNC	; signature func seedRandom(int seed) -> void @ 166:21
 	$seed:	INPi
 	$x:	LOCi
 ;-----------------------------------------------------------------------------
@@ -113,7 +113,7 @@ seedRandom:	FUNC	; signature func seedRandom(int seed) -> void
 
 ;-----------------------------------------------------------------------------
 	$f:	OUTf
-randomFloat:	FUNC	; signature func randomFloat() -> float
+randomFloat:	FUNC	; signature func randomFloat() -> float @ 177:22
 	$x:	LOCi
 	$y:	LOCi
 	$t:	LOCi
@@ -134,50 +134,50 @@ randomFloat:	FUNC	; signature func randomFloat() -> float
 		POKE &rndSeedY $y 	; global rndSeedY = y
 		RETU   	; }
 
-C3_FREQUENCY:	! DEFf #261.6255653005986346778499935233	; signature const C3_FREQUENCY : float
-NOP_MODE:	! DEFi #0	; signature const NOP_MODE : int
-SAMPLE_MODE:	! DEFi #1	; signature const SAMPLE_MODE : int
-SQUARE_MODE:	! DEFi #2	; signature const SQUARE_MODE : int
-GRAIN_MODE:	! DEFi #3	; signature const GRAIN_MODE : int
-COMB_MODE:	! DEFi #4	; signature const COMB_MODE : int
-KEY_LOW_MODE:	! DEFi #1	; signature const KEY_LOW_MODE : int
-KEY_HIGH_MODE:	! DEFi #2	; signature const KEY_HIGH_MODE : int
-ARPEG_MODE:	! DEFi #3	; signature const ARPEG_MODE : int
-RANDOM_MODE:	! DEFi #4	; signature const RANDOM_MODE : int
-EUCLIDEAN:	CNST *16	; signature array EUCLIDEAN[16] : unknown
+C3_FREQUENCY:	! DEFf #261.6255653005986346778499935233	; signature const C3_FREQUENCY : float @ 194:1
+NOP_MODE:	! DEFi #0	; signature const NOP_MODE : int @ 195:1
+SAMPLE_MODE:	! DEFi #1	; signature const SAMPLE_MODE : int @ 196:1
+SQUARE_MODE:	! DEFi #2	; signature const SQUARE_MODE : int @ 197:1
+GRAIN_MODE:	! DEFi #3	; signature const GRAIN_MODE : int @ 198:1
+COMB_MODE:	! DEFi #4	; signature const COMB_MODE : int @ 199:1
+KEY_LOW_MODE:	! DEFi #1	; signature const KEY_LOW_MODE : int @ 200:1
+KEY_HIGH_MODE:	! DEFi #2	; signature const KEY_HIGH_MODE : int @ 201:1
+ARPEG_MODE:	! DEFi #3	; signature const ARPEG_MODE : int @ 202:1
+RANDOM_MODE:	! DEFi #4	; signature const RANDOM_MODE : int @ 203:1
+EUCLIDEAN:	CNST *16	; signature array EUCLIDEAN[16] : unknown @ 203:30
 	DATA #0x8000 #0x8080 #0x8420 #0x8888 #0x9248 #0x9494
 	DATA #0x952a #0xaaaa #0xb56a #0xb5b5 #0xb6db #0xbbbb
 	DATA #0xbdef #0xbfbf #0xfffe #0xffff
-GRAIN_DRIFT:	! DEFi #TRUE	; signature const GRAIN_DRIFT : int
-PITCHED_REVERSED:	! DEFi #TRUE	; signature const PITCHED_REVERSED : int
-ALSO_SHIFT_NOTES:	! DEFi #FALSE	; signature const ALSO_SHIFT_NOTES : int
-CROSSFADE_INPUT:	! DEFi #FALSE	; signature const CROSSFADE_INPUT : int
-CROSSFADE_SAMPLES:	! DEFi #FALSE	; signature const CROSSFADE_SAMPLES : int
-SLOW_RELEASE:	! DEFi #0x40	; signature const SLOW_RELEASE : int
-FAST_RELEASE:	! DEFi #0x800	; signature const FAST_RELEASE : int
-STANDARD_ATTACK:	! DEFi #0x2000	; signature const STANDARD_ATTACK : int
-COMB_ATTACK:	! DEFi #0xA000	; signature const COMB_ATTACK : int
-NOTE_RATES:	GLOB *64	; signature array NOTE_RATES[64] : unknown
-SQRT_TABLE:	GLOB *4097	; signature array SQRT_TABLE[4097] : unknown
+GRAIN_DRIFT:	! DEFi #TRUE	; signature const GRAIN_DRIFT : int @ 208:1
+PITCHED_REVERSED:	! DEFi #TRUE	; signature const PITCHED_REVERSED : int @ 209:1
+ALSO_SHIFT_NOTES:	! DEFi #FALSE	; signature const ALSO_SHIFT_NOTES : int @ 210:1
+CROSSFADE_INPUT:	! DEFi #FALSE	; signature const CROSSFADE_INPUT : int @ 211:1
+CROSSFADE_SAMPLES:	! DEFi #FALSE	; signature const CROSSFADE_SAMPLES : int @ 212:1
+SLOW_RELEASE:	! DEFi #0x40	; signature const SLOW_RELEASE : int @ 213:1
+FAST_RELEASE:	! DEFi #0x800	; signature const FAST_RELEASE : int @ 214:1
+STANDARD_ATTACK:	! DEFi #0x2000	; signature const STANDARD_ATTACK : int @ 215:1
+COMB_ATTACK:	! DEFi #0xA000	; signature const COMB_ATTACK : int @ 215:31
+NOTE_RATES:	GLOB *64	; signature array NOTE_RATES[64] : unknown @ 220:1
+SQRT_TABLE:	GLOB *4097	; signature array SQRT_TABLE[4097] : unknown @ 221:1
 	GLOB *1
-doReset:	DATi #TRUE	; signature global doReset : int
+doReset:	DATi #TRUE	; signature global doReset : int @ 222:1
 	GLOB *1
-updateBits:	DATi #TRUE	; signature global updateBits : int
+updateBits:	DATi #TRUE	; signature global updateBits : int @ 231:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 231:15
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4db 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 234:15
 		EQUi #CROSSFADE_SAMPLES #FALSE @.f0	; if (CROSSFADE_SAMPLES != FALSE) 
 		MOVi $i #0 	; for (i = 0 to 4097) 
 		GEQi #0 #4097 @.f0
 	.l2:	NOOP
 		! DIVf <A> #1.0 #4096.0	; global SQRT_TABLE[i] = ftoi((float) sqrt(itof(i) * (1.0 / 4096.0)) * 65536.0)
 		iTOf %1 $i <A>
-		CALL &sqrt %0 *2	; expects sqrt(float) -> float
+		CALL &sqrt %0 *2	; expects sqrt(float) -> float @ 237:71
 		fTOi %0 %0 #65536.0
 		POKE &SQRT_TABLE $i %0
 		FORi $i #4097 @.l2	; }
@@ -186,7 +186,7 @@ init:	FUNC	; signature func init() -> void
 	.l4:	SUBi %1 $i #36	; global NOTE_RATES[i] = (float) exp(itof(i - 36) * (LOG2 / 12.0))
 		! DIVf <A> #LOG2 #12.0
 		iTOf %1 %1 <A>
-		CALL &exp %0 *2	; expects exp(float) -> float
+		CALL &exp %0 *2	; expects exp(float) -> float @ 241:67
 		POKE &NOTE_RATES $i %0
 		FORi $i #64 @.l4	; }
 	.e3:	RETU   	; }
@@ -194,27 +194,27 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 251:16
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4dc 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 253:16
 		POKE &doReset #TRUE 	; global doReset = TRUE
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 264:17
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_update4dd 	; trace("update")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 266:17
 		POKE &updateBits #TRUE 	; global updateBits = TRUE
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 285:18
 	$i:	LOCi
 	$j:	LOCi
 	$l:	LOCi
@@ -321,7 +321,7 @@ process:	FUNC	; signature func process() -> void
 		PEEK %0 &updateBits 	; if (global updateBits != FALSE) 
 		EQUi %0 #FALSE @.f5
 		MOVp %1 &.s_bitsup4de 	; trace("bits update")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 347:24
 		POKE &updateBits #FALSE 	; global updateBits = FALSE
 		MOVi $i #0 	; for (i = 0 to 16) 
 		GEQi #0 #16 @.e6
@@ -405,7 +405,7 @@ process:	FUNC	; signature func process() -> void
 	.e23:	MOVi $euclideanBits #0 	; euclideanBits = 0
 		ANDi %1 $op1LowBits #0xF0	; seedRandom((op1LowBits & 0xF0) + 192837463)
 		ADDi %1 %1 #192837463
-		CALL &seedRandom %0 *2	; expects seedRandom(int) -> void
+		CALL &seedRandom %0 *2	; expects seedRandom(int) -> void @ 413:51
 		MOVf $noteIndexFloat #0.0 	; noteIndexFloat = 0.0
 		MOVf $octaveIndexFloat #0.0 	; octaveIndexFloat = 0.0
 		MOVi $i #0 	; for (i = 0 to 16) 
@@ -433,11 +433,11 @@ process:	FUNC	; signature func process() -> void
 		fTOi %0 %0 #1.0
 		GETL %0 $octsList %0
 		SETL $stepOcts $j %0
-		CALL &randomFloat %0 *1	; expects randomFloat() -> float
+		CALL &randomFloat %0 *1	; expects randomFloat() -> float @ 425:67
 		MULf %0 %0 #2.0
 		SUBf %0 %0 #1.0
 		ADDf $noteIndexFloat $noteIndexFloat %0
-		CALL &randomFloat %0 *1	; expects randomFloat() -> float
+		CALL &randomFloat %0 *1	; expects randomFloat() -> float @ 426:71
 		MULf %0 %0 #2.0
 		SUBf %0 %0 #1.0
 		ADDf $octaveIndexFloat $octaveIndexFloat %0
@@ -445,14 +445,14 @@ process:	FUNC	; signature func process() -> void
 		IORi $euclideanBits $euclideanBits %0
 	.f31:	FORi $i #16 @.l27	; }
 	.e26:	ADDi %1 $op1HighBits #6734261	; seedRandom(op1HighBits + 6734261)
-		CALL &seedRandom %0 *2	; expects seedRandom(int) -> void
+		CALL &seedRandom %0 *2	; expects seedRandom(int) -> void @ 430:41
 		MOVi $l #0 	; l = 0
 		MOVi $i #0 	; for (i = 0 to 17) 
 		GEQi #0 #17 @.e38
 	.l33:	EQUi $i #16 @.t34	; if (i == 16 || (int) stepTrigs[i] != FALSE) 
 		GETL %0 $stepTrigs $i
 		EQUi %0 #FALSE @.f35
-	.t34:	CALL &randomFloat %0 *1	; expects randomFloat() -> float
+	.t34:	CALL &randomFloat %0 *1	; expects randomFloat() -> float @ 434:45
 		SUBi %1 $i $l
 		iTOf %1 %1 #1.0
 		MULf %0 %0 %1
@@ -625,11 +625,11 @@ process:	FUNC	; signature func process() -> void
 	.f69:	MOVi %1 $clock 	; write(clock, 1, global signal)
 		MOVi %2 #1 
 		MOVp %3 &signal 
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 565:33
 		MOVi %1 $clock 	; read(clock, 1, global signal)
 		MOVi %2 #1 
 		MOVp %3 &signal 
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 566:32
 		PEEK $inL &signal:0 	; inL = (int) global signal[0]
 		PEEK $inR &signal:1 	; inR = (int) global signal[1]
 		SUBi %0 $env $g0	; g0 = g0 + ((env - g0) * gk >> 16)
@@ -659,12 +659,12 @@ process:	FUNC	; signature func process() -> void
 	.f81:	MOVi %1 $inPos 	; read(inPos, 1, bSamples)
 		MOVi %2 #1 
 		ADRL %3 $bSamples *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 595:29
 		ADDi $inPos $inPos #1	; inPos = inPos + 1
 		MOVi %1 $outPos 	; read(outPos, 1, aSamples)
 		MOVi %2 #1 
 		ADRL %3 $aSamples *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 597:30
 		ADDi $outPos $outPos #1	; outPos = outPos + 1
 		SUBi %0 $bSamples:0 $aSamples:0	; left = ((int) aSamples[0] + (((int) bSamples[0] - (int) aSamples[0]) * phase >> 16))
 		MULi %0 %0 $phase
@@ -681,7 +681,7 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $i 	; read(i, 2, aSamples)
 		MOVi %2 #2 
 		ADRL %3 $aSamples *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 607:25
 		ANDi $x $pos #0xFFFF	; x = pos & 0xFFFF
 		ADDi $pos $pos $pitchedRate	; pos = pos + pitchedRate
 		SUBi %0 $aSamples:2 $aSamples:0	; left = ((int) aSamples[0] + (((int) aSamples[2] - (int) aSamples[0]) * x >> 16))
@@ -696,7 +696,7 @@ process:	FUNC	; signature func process() -> void
 		SUBi %1 $i #0x8000	; read(i - 0x8000, 2, bSamples)
 		MOVi %2 #2 
 		ADRL %3 $bSamples *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 613:35
 		SUBi %0 $bSamples:2 $bSamples:0	; bL = ((int) bSamples[0] + (((int) bSamples[2] - (int) bSamples[0]) * x >> 16))
 		MULi %0 %0 $x
 		SHRi %0 %0 #16
@@ -727,7 +727,7 @@ process:	FUNC	; signature func process() -> void
 		SUBi %1 %1 %2
 		MOVi %2 #2 
 		ADRL %3 $aSamples *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 629:50
 		ANDi $x $period #0xFFFF	; x = period & 0xFFFF
 		SUBi %0 $aSamples:0 $aSamples:2	; fbL = (int) aSamples[2] + (((int) aSamples[0] - (int) aSamples[2]) * x >> 16)
 		MULi %0 %0 $x
@@ -758,7 +758,7 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $clock 	; write(clock, 1, bSamples)
 		MOVi %2 #1 
 		ADRL %3 $bSamples *0
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 646:30
 	.s78:	NOOP
 	.e79:	EQUi #CROSSFADE_INPUT #FALSE @.f85	; if (CROSSFADE_INPUT != FALSE) 
 		SUBi %0 $left $inL	; left = inL + ((left - inL) * g1 >> 12)
@@ -776,7 +776,7 @@ process:	FUNC	; signature func process() -> void
 		SHRi $right %0 #12
 	.e86:	POKE &signal:0 $left 	; global signal[0] = left
 		POKE &signal:1 $right 	; global signal[1] = right
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 659:10
 		GOTO @.l0  	; }
 		RETU   	; }
 

--- a/tests/impala/golden/floatVerber8.gazl
+++ b/tests/impala/golden/floatVerber8.gazl
@@ -1,72 +1,72 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 11:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 12:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 22:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 22:33
 	DATA &.s_sillyr4d2 &.s_sillyr4d2:51 &.s_sillyr4d2:51
 	DATA &.s_ROOMSI4d3 &.s_ROOMSI4d3:53 &.s_ROOMSI4d3:53
 	DATA &.s_ROOMSI4d3:53 &.s_FEEDBA4d4
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native read() -> unknown
-; signature extern native write() -> unknown
+; signature extern native abort() -> unknown @ 34:1
+; signature extern native trace() -> unknown @ 35:1
+; signature extern native yield() -> unknown @ 36:1
+; signature extern native read() -> unknown @ 37:1
+; signature extern native write() -> unknown @ 39:1
 	GLOB *1
-left:	DATi #0	; signature global left : int
+left:	DATi #0	; signature global left : int @ 70:1
 	GLOB *1
-right:	DATi #0	; signature global right : int
+right:	DATi #0	; signature global right : int @ 71:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 72:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 73:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 74:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
-AND:	! DEFi #32767	; signature const AND : int
-TAPS_COUNT:	! DEFi #10	; signature const TAPS_COUNT : int
-ALLPASS_COUNT:	! DEFi #5	; signature const ALLPASS_COUNT : int
-T0:	! DEFi #0	; signature const T0 : int
-T3:	! DEFi #1	; signature const T3 : int
-T5:	! DEFi #2	; signature const T5 : int
-T7:	! DEFi #3	; signature const T7 : int
-T11:	! DEFi #4	; signature const T11 : int
-T13:	! DEFi #5	; signature const T13 : int
-TFB:	! DEFi #6	; signature const TFB : int
-TL1:	! DEFi #7	; signature const TL1 : int
-TL2:	! DEFi #8	; signature const TL2 : int
-TR:	! DEFi #9	; signature const TR : int
-ALLPASS_PAIRS_A:	CNST *ALLPASS_COUNT	; signature array ALLPASS_PAIRS_A[ALLPASS_COUNT] : unknown
+instance:	DATi #0	; signature global instance : int @ 84:1
+AND:	! DEFi #32767	; signature const AND : int @ 85:1
+TAPS_COUNT:	! DEFi #10	; signature const TAPS_COUNT : int @ 86:1
+ALLPASS_COUNT:	! DEFi #5	; signature const ALLPASS_COUNT : int @ 88:1
+T0:	! DEFi #0	; signature const T0 : int @ 89:1
+T3:	! DEFi #1	; signature const T3 : int @ 90:1
+T5:	! DEFi #2	; signature const T5 : int @ 91:1
+T7:	! DEFi #3	; signature const T7 : int @ 92:1
+T11:	! DEFi #4	; signature const T11 : int @ 93:1
+T13:	! DEFi #5	; signature const T13 : int @ 94:1
+TFB:	! DEFi #6	; signature const TFB : int @ 95:1
+TL1:	! DEFi #7	; signature const TL1 : int @ 96:1
+TL2:	! DEFi #8	; signature const TL2 : int @ 97:1
+TR:	! DEFi #9	; signature const TR : int @ 99:1
+ALLPASS_PAIRS_A:	CNST *ALLPASS_COUNT	; signature array ALLPASS_PAIRS_A[ALLPASS_COUNT] : unknown @ 99:47
 	DATA #T0 #T0 #T3 #T3 #T5
-ALLPASS_PAIRS_B:	CNST *ALLPASS_COUNT	; signature array ALLPASS_PAIRS_B[ALLPASS_COUNT] : unknown
+ALLPASS_PAIRS_B:	CNST *ALLPASS_COUNT	; signature array ALLPASS_PAIRS_B[ALLPASS_COUNT] : unknown @ 100:47
 	DATA #T3 #T13 #T5 #T11 #T7
 	GLOB *1
-roomSize:	DATi #11579	; signature global roomSize : int
+roomSize:	DATi #11579	; signature global roomSize : int @ 103:1
 	GLOB *1
-preDelay:	DATi #0	; signature global preDelay : int
+preDelay:	DATi #0	; signature global preDelay : int @ 104:1
 	GLOB *1
-feedback:	DATf #0.5	; signature global feedback : float
+feedback:	DATf #0.5	; signature global feedback : float @ 105:1
 	GLOB *1
-damping:	DATf #1.0	; signature global damping : float
-taps:	GLOB *TAPS_COUNT	; signature array taps[TAPS_COUNT] : unknown
+damping:	DATf #1.0	; signature global damping : float @ 107:1
+taps:	GLOB *TAPS_COUNT	; signature array taps[TAPS_COUNT] : unknown @ 112:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 112:15
 ;-----------------------------------------------------------------------------
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 120:16
 ;-----------------------------------------------------------------------------
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 128:17
 	$taps:	LOCA *TAPS_COUNT
 	$size:	LOCi
 	$predelay:	LOCi
@@ -109,7 +109,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 169:18
 	$spinner:	LOCi
 	$in:	LOCf
 	$dI:	LOCf
@@ -134,7 +134,7 @@ process:	FUNC	; signature func process() -> void
 		SUBi $index $spinner %0
 		MOVi %1 $index 	; t[i] = itof((int) read(index, 0))
 		MOVi %2 #0 
-		CALL ^read %0 *3	; expects function(int, int) -> unknown
+		CALL ^read %0 *3	; expects function(int, int) -> unknown @ 190:37
 		iTOf %0 %0 #1.0
 		SETL $t $i %0
 		SETL $o $i $index	; o[i] = index
@@ -169,14 +169,14 @@ process:	FUNC	; signature func process() -> void
 		MOVi %2 #0 
 		GETL %3 $t $i
 		fTOi %3 %3 #1.0
-		CALL ^write %0 *4	; expects function(int, int, int) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, int) -> unknown @ 216:68
 		FORi $i <A> @.l6
 	.e5:	SUBf %0 $t:TL1 $t:TL2	; global left = ftoi(((float) t[TL1] - (float) t[TL2]) * 0.75)
 		fTOi %0 %0 #0.75
 		POKE &left %0 
 		fTOi %0 $t:TR #1.0	; global right = ftoi((float) t[TR])
 		POKE &right %0 
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 225:10
 		GOTO @.l0  	; }
 		RETU   	; }
 

--- a/tests/impala/golden/fooBar_code.gazl
+++ b/tests/impala/golden/fooBar_code.gazl
@@ -1,25 +1,25 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_stdREV4d2 &.s_fastCR4d3 &.s_slowCH4d4
 	DATA &.s_rndAK44d5 &.s_16164d6 &.s_32164d7 &.s_884d8
 	DATA &.s_168Gat4d9
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 40:1
+; signature extern native trace() -> unknown @ 41:1
+; signature extern native yield() -> unknown @ 42:1
+; signature extern native write() -> unknown @ 43:1
+; signature extern native read() -> unknown @ 45:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 81:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 82:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 84:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 87:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 89:1
 	CNST *1
 	! SHLi <A> #1 #OPERATOR_1_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_1_HIGH_PARAM_INDEX
@@ -34,15 +34,15 @@ signal:	GLOB *2	; signature array signal[2] : unknown
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #SWITCHES_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 92:32
 	GLOB *1
-rndSeedX:	DATi #1	; signature global rndSeedX : int
+rndSeedX:	DATi #1	; signature global rndSeedX : int @ 98:24
 	GLOB *1
-rndSeedY:	DATi #1	; signature global rndSeedY : int
+rndSeedY:	DATi #1	; signature global rndSeedY : int @ 99:24
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-seedRandom:	FUNC	; signature func seedRandom(int seed) -> void
+seedRandom:	FUNC	; signature func seedRandom(int seed) -> void @ 101:21
 	$seed:	INPi
 	$x:	LOCi
 ;-----------------------------------------------------------------------------
@@ -61,7 +61,7 @@ seedRandom:	FUNC	; signature func seedRandom(int seed) -> void
 
 ;-----------------------------------------------------------------------------
 	$f:	OUTf
-randomFloat:	FUNC	; signature func randomFloat() -> float
+randomFloat:	FUNC	; signature func randomFloat() -> float @ 112:22
 	$x:	LOCi
 	$y:	LOCi
 	$t:	LOCi
@@ -83,56 +83,56 @@ randomFloat:	FUNC	; signature func randomFloat() -> float
 		POKE &rndSeedY $y 	; global rndSeedY = y
 		RETU   	; }
 
-STEP_COUNT:	! DEFi #32	; signature const STEP_COUNT : int
-REVERSE_FX:	! DEFi #0	; signature const REVERSE_FX : int
-BIT_CRUSH_EFFECT:	! DEFi #1	; signature const BIT_CRUSH_EFFECT : int
-TRANCE_GATE_EFFECT:	! DEFi #2	; signature const TRANCE_GATE_EFFECT : int
-REPEAT_EFFECT:	! DEFi #3	; signature const REPEAT_EFFECT : int
-STRETCH_EFFECT:	! DEFi #4	; signature const STRETCH_EFFECT : int
-PITCH_SHIFT_EFFECT:	! DEFi #5	; signature const PITCH_SHIFT_EFFECT : int
-HALF_SPEED_EFFECT:	! DEFi #6	; signature const HALF_SPEED_EFFECT : int
-TAPE_STOP_FX:	! DEFi #7	; signature const TAPE_STOP_FX : int
-FX_PARAM_TAPE_STOP_RATE:	! DEFi #0	; signature const FX_PARAM_TAPE_STOP_RATE : int
-FX_PARAM_TRANCE_GATE_RATE:	! DEFi #1	; signature const FX_PARAM_TRANCE_GATE_RATE : int
-FX_PARAM_BIT_CRUSH_MASK:	! DEFi #2	; signature const FX_PARAM_BIT_CRUSH_MASK : int
-FX_PARAM_REPEAT_MASK:	! DEFi #3	; signature const FX_PARAM_REPEAT_MASK : int
-FX_PARAM_REPEAT_OFF_3:	! DEFi #4	; signature const FX_PARAM_REPEAT_OFF_3 : int
-FX_PARAM_SHIFT_9:	! DEFi #5	; signature const FX_PARAM_SHIFT_9 : int
-FX_PARAM_SHIFT_10:	! DEFi #6	; signature const FX_PARAM_SHIFT_10 : int
-FX_PARAM_1_LSHIFT_9:	! DEFi #7	; signature const FX_PARAM_1_LSHIFT_9 : int
-FX_PARAM_1_LSHIFT_10:	! DEFi #8	; signature const FX_PARAM_1_LSHIFT_10 : int
-FX_PARAM_MASK_10:	! DEFi #9	; signature const FX_PARAM_MASK_10 : int
-FX_PARAM_COUNT:	! DEFi #10	; signature const FX_PARAM_COUNT : int
+STEP_COUNT:	! DEFi #32	; signature const STEP_COUNT : int @ 130:1
+REVERSE_FX:	! DEFi #0	; signature const REVERSE_FX : int @ 130:25
+BIT_CRUSH_EFFECT:	! DEFi #1	; signature const BIT_CRUSH_EFFECT : int @ 131:31
+TRANCE_GATE_EFFECT:	! DEFi #2	; signature const TRANCE_GATE_EFFECT : int @ 132:33
+REPEAT_EFFECT:	! DEFi #3	; signature const REPEAT_EFFECT : int @ 133:28
+STRETCH_EFFECT:	! DEFi #4	; signature const STRETCH_EFFECT : int @ 134:29
+PITCH_SHIFT_EFFECT:	! DEFi #5	; signature const PITCH_SHIFT_EFFECT : int @ 135:33
+HALF_SPEED_EFFECT:	! DEFi #6	; signature const HALF_SPEED_EFFECT : int @ 136:32
+TAPE_STOP_FX:	! DEFi #7	; signature const TAPE_STOP_FX : int @ 137:27
+FX_PARAM_TAPE_STOP_RATE:	! DEFi #0	; signature const FX_PARAM_TAPE_STOP_RATE : int @ 139:38
+FX_PARAM_TRANCE_GATE_RATE:	! DEFi #1	; signature const FX_PARAM_TRANCE_GATE_RATE : int @ 140:40
+FX_PARAM_BIT_CRUSH_MASK:	! DEFi #2	; signature const FX_PARAM_BIT_CRUSH_MASK : int @ 141:38
+FX_PARAM_REPEAT_MASK:	! DEFi #3	; signature const FX_PARAM_REPEAT_MASK : int @ 142:35
+FX_PARAM_REPEAT_OFF_3:	! DEFi #4	; signature const FX_PARAM_REPEAT_OFF_3 : int @ 143:36
+FX_PARAM_SHIFT_9:	! DEFi #5	; signature const FX_PARAM_SHIFT_9 : int @ 144:31
+FX_PARAM_SHIFT_10:	! DEFi #6	; signature const FX_PARAM_SHIFT_10 : int @ 145:32
+FX_PARAM_1_LSHIFT_9:	! DEFi #7	; signature const FX_PARAM_1_LSHIFT_9 : int @ 146:34
+FX_PARAM_1_LSHIFT_10:	! DEFi #8	; signature const FX_PARAM_1_LSHIFT_10 : int @ 147:35
+FX_PARAM_MASK_10:	! DEFi #9	; signature const FX_PARAM_MASK_10 : int @ 148:31
+FX_PARAM_COUNT:	! DEFi #10	; signature const FX_PARAM_COUNT : int @ 149:30
 	! MULi <A> #FX_PARAM_COUNT #3
-FX_PARAMS:	GLOB *<A>	; signature array FX_PARAMS[<A>] : unknown
-stepFXs:	GLOB *STEP_COUNT	; signature array stepFXs[STEP_COUNT] : unknown
-stepFXParams:	GLOB *STEP_COUNT	; signature array stepFXParams[STEP_COUNT] : unknown
+FX_PARAMS:	GLOB *<A>	; signature array FX_PARAMS[<A>] : unknown @ 153:43
+stepFXs:	GLOB *STEP_COUNT	; signature array stepFXs[STEP_COUNT] : unknown @ 155:1
+stepFXParams:	GLOB *STEP_COUNT	; signature array stepFXParams[STEP_COUNT] : unknown @ 155:38
 	GLOB *1
-doReset:	DATi #TRUE	; signature global doReset : int
+doReset:	DATi #TRUE	; signature global doReset : int @ 157:1
 	GLOB *1
-updateBits:	DATi #TRUE	; signature global updateBits : int
+updateBits:	DATi #TRUE	; signature global updateBits : int @ 158:1
 	GLOB *1
-clockMask:	DATi #0x1FFFF	; signature global clockMask : int
+clockMask:	DATi #0x1FFFF	; signature global clockMask : int @ 158:31
 	GLOB *1
-clockShift:	DATi #13	; signature global clockShift : int
+clockShift:	DATi #13	; signature global clockShift : int @ 159:27
 	GLOB *1
-fxQuantize:	DATi #0xFFF	; signature global fxQuantize : int
+fxQuantize:	DATi #0xFFF	; signature global fxQuantize : int @ 160:30
 	GLOB *1
-dirXor:	DATi #0x0	; signature global dirXor : int
+dirXor:	DATi #0x0	; signature global dirXor : int @ 161:24
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 171:16
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4da 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 173:16
 		POKE &doReset #TRUE 	; global doReset = TRUE
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 184:17
 	$i:	LOCi
 	$fx:	LOCi
 	$fxRnd:	LOCi
@@ -145,7 +145,7 @@ update:	FUNC	; signature func update() -> void
 	$fxCountFloat:	LOCf
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_update4db 	; trace("update")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 196:17
 		POKE &dirXor #0 	; global dirXor = 0
 		PEEK %0 &params:SWITCHES_PARAM_INDEX 	; if (((int) global params[SWITCHES_PARAM_INDEX] & SWITCHES_REVERSE_MASK) != 0) 
 		ANDi %0 %0 #SWITCHES_REVERSE_MASK
@@ -165,7 +165,7 @@ update:	FUNC	; signature func update() -> void
 	.f4:	FORi $i #8 @.l3	; }
 	.f1:	PEEK %1 &params:OPERAND_1_LOW_PARAM_INDEX 	; seedRandom((int) global params[OPERAND_1_LOW_PARAM_INDEX] + 1)
 		ADDi %1 %1 #1
-		CALL &seedRandom %0 *2	; expects seedRandom(int) -> void
+		CALL &seedRandom %0 *2	; expects seedRandom(int) -> void @ 215:64
 		PEEK %0 &params:OPERATOR_2_PARAM_INDEX 	; stepRate = (int) global params[OPERATOR_2_PARAM_INDEX] - 1
 		SUBi $stepRate %0 #1
 		GEQi $stepRate #0 @.f5	; if (stepRate < 0) 
@@ -199,7 +199,7 @@ update:	FUNC	; signature func update() -> void
 		MOVi $fx #-1 	; fx = -1
 		MOVi $i #0 	; for (i = 0 to STEP_COUNT) 
 		GEQi #0 #STEP_COUNT @.e12
-	.l13:	CALL &randomFloat %0 *1	; expects randomFloat() -> float
+	.l13:	CALL &randomFloat %0 *1	; expects randomFloat() -> float @ 241:40
 		MULf %0 %0 $fxCountFloat
 		fTOi $fxRnd %0 #1.0
 		LEQi $fxRnd $fxCount @.f14	; if (fxRnd > fxCount) 
@@ -227,7 +227,7 @@ update:	FUNC	; signature func update() -> void
 		GOTO @.e21  
 	.s20#3:	MOVi $fx #0 	; fx = 0
 		GOTO @.e21  
-	.s20#4:	CALL &randomFloat %0 *1	; expects randomFloat() -> float
+	.s20#4:	CALL &randomFloat %0 *1	; expects randomFloat() -> float @ 262:44
 		fTOi $fx %0 #2.9999
 	.s20:	NOOP
 	.e21:	POKE &stepFXParams $i $fx	; global stepFXParams[i] = fx
@@ -237,7 +237,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 273:15
 	$i:	LOCi
 	$p:	LOCp
 	$fxRate:	LOCi
@@ -245,8 +245,8 @@ init:	FUNC	; signature func init() -> void
 	$t:	LOCi
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4dc 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL &update %0 *1	; expects update() -> void
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 276:15
+		CALL &update %0 *1	; expects update() -> void @ 277:10
 		MOVp $p &FX_PARAMS 	; p = global FX_PARAMS
 		MOVi $i #0 	; for (i = 0 to 3) 
 		GEQi #0 #3 @.e0
@@ -281,7 +281,7 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 311:18
 	$i:	LOCi
 	$x:	LOCi
 	$mask:	LOCi
@@ -352,11 +352,11 @@ process:	FUNC	; signature func process() -> void
 	.f3:	MOVi %1 $clock 	; write(clock, 1, global signal)
 		MOVi %2 #1 
 		MOVp %3 &signal 
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 368:33
 		MOVi %1 $clock 	; read(clock, 1, inp)
 		MOVi %2 #1 
 		ADRL %3 $inp *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 369:22
 		SWCH $held *8 @.s7	; switch (held == 0 to 8) 
 	.s7#REVERSE_FX:	EQUi $trig #FALSE @.f9	; if (trig != FALSE) 
 		MOVi $pos $clock 	; pos = clock
@@ -364,7 +364,7 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $pos 	; read(pos, 1, outp)
 		MOVi %2 #1 
 		ADRL %3 $outp *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 377:23
 		GOTO @.e8  	; }
 	.s7#TAPE_STOP_FX:	EQUi $trig #FALSE @.f10	; if (trig != FALSE) 
 		SHLi $pos $clock #16	; pos = clock << 16
@@ -373,7 +373,7 @@ process:	FUNC	; signature func process() -> void
 		SHRi %1 $pos #16	; read(pos >> 16, 2, samples)
 		MOVi %2 #2 
 		ADRL %3 $samples *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 386:32
 		SUBi %0 $samples:2 $samples:0	; outp[0] = (int) samples[0] + (((int) samples[2] - (int) samples[0]) * x >> 16)
 		MULi %0 %0 $x
 		SHRi %0 %0 #16
@@ -392,7 +392,7 @@ process:	FUNC	; signature func process() -> void
 	.f12:	SHRi %1 $pos #1	; read(pos >> 1, 1, outp)
 		MOVi %2 #1 
 		ADRL %3 $outp *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 400:28
 		ADDi $pos $pos #1	; pos = pos + 1
 		GOTO @.e8  	; }
 	.s7#TRANCE_GATE_EFFECT:	SHRi %0 $clock $fxParams:FX_PARAM_TRANCE_GATE_RATE	; x = (clock >> (int) fxParams[FX_PARAM_TRANCE_GATE_RATE]) & 0x7FF
@@ -420,7 +420,7 @@ process:	FUNC	; signature func process() -> void
 	.s7#BIT_CRUSH_EFFECT:	ANDi %1 $clock $fxParams:FX_PARAM_BIT_CRUSH_MASK	; read(clock & (int) fxParams[FX_PARAM_BIT_CRUSH_MASK], 1, outp)
 		MOVi %2 #1 
 		ADRL %3 $outp *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 420:67
 		! XORi <A> #0x7F #-1	; outp[0] = (int) outp[0] & ~0x7F
 		ANDi $outp:0 $outp:0 <A>
 		! XORi <A> #0x7F #-1	; outp[1] = (int) outp[1] & ~0x7F
@@ -434,7 +434,7 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $pos 	; read(pos, 1, samples)
 		MOVi %2 #1 
 		ADRL %3 $samples *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 429:26
 		ANDi %0 $clock $fxParams:FX_PARAM_REPEAT_OFF_3	; if ((clock & (int) fxParams[FX_PARAM_REPEAT_OFF_3]) == (int) fxParams[FX_PARAM_REPEAT_OFF_3]) 
 		NEQi %0 $fxParams:FX_PARAM_REPEAT_OFF_3 @.f19
 		ADDi $pos $pos $fxParams:FX_PARAM_REPEAT_OFF_3	; pos = pos + (int) fxParams[FX_PARAM_REPEAT_OFF_3]
@@ -452,7 +452,7 @@ process:	FUNC	; signature func process() -> void
 	.e22:	MOVi %1 $pos 	; read(pos, 1, &samples[2])
 		MOVi %2 #1 
 		ADRL %3 $samples:2 *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 441:30
 		SUBi %0 $samples:2 $samples:0	; outp[0] = (int) samples[0] + (((int) samples[2] - (int) samples[0]) * x >> (int) fxParams[FX_PARAM_SHIFT_10])
 		MULi %0 %0 $x
 		SHRi %0 %0 $fxParams:FX_PARAM_SHIFT_10
@@ -467,11 +467,11 @@ process:	FUNC	; signature func process() -> void
 	.f24:	MOVi %1 $pos 	; read(pos, 1, samples)
 		MOVi %2 #1 
 		ADRL %3 $samples *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 450:26
 		SUBi %1 $pos $fxParams:FX_PARAM_1_LSHIFT_9	; read(pos - (int) fxParams[FX_PARAM_1_LSHIFT_9], 1, &samples[2])
 		MOVi %2 #1 
 		ADRL %3 $samples:2 *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 451:68
 		ANDi $x $clock $fxParams:FX_PARAM_MASK_10	; x = clock & (int) fxParams[FX_PARAM_MASK_10]
 		SUBi %0 $samples:2 $samples:0	; outp[0] = (int) samples[0] + (((int) samples[2] - (int) samples[0]) * x >> (int) fxParams[FX_PARAM_SHIFT_10])
 		MULi %0 %0 $x
@@ -495,11 +495,11 @@ process:	FUNC	; signature func process() -> void
 		SUBi %1 $pos $fxParams:FX_PARAM_1_LSHIFT_9	; read(pos - (int) fxParams[FX_PARAM_1_LSHIFT_9], 1, samples)
 		MOVi %2 #1 
 		ADRL %3 $samples *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 464:64
 		SUBi %1 $pos $fxParams:FX_PARAM_1_LSHIFT_10	; read(pos - (int) fxParams[FX_PARAM_1_LSHIFT_10], 1, &samples[2])
 		MOVi %2 #1 
 		ADRL %3 $samples:2 *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 465:69
 		SUBi %0 $samples:2 $samples:0	; outp[0] = (int) samples[0] + (((int) samples[2] - (int) samples[0]) * x >> (int) fxParams[FX_PARAM_SHIFT_9])
 		MULi %0 %0 $x
 		SHRi %0 %0 $fxParams:FX_PARAM_SHIFT_9
@@ -528,7 +528,7 @@ process:	FUNC	; signature func process() -> void
 		SHRi %0 %0 #15
 		ADDi %0 $inp:1 %0
 		POKE &signal:1 %0 
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 485:10
 		ADDi $clock $clock #1	; clock = clock + 1
 		GOTO @.l0  	; }
 		RETU   	; }

--- a/tests/impala/golden/impalaBug1.gazl
+++ b/tests/impala/golden/impalaBug1.gazl
@@ -1,12 +1,12 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
+FALSE:	! DEFi #0	; signature const FALSE : int @ 1:20
+TRUE:	! DEFi #1	; signature const TRUE : int @ 2:19
 
 ;-----------------------------------------------------------------------------
 	$result:	OUTi
-fTSTBIT:	FUNC	; signature func fTSTBIT(int mask, int bit) -> int
+fTSTBIT:	FUNC	; signature func fTSTBIT(int mask, int bit) -> int @ 4:18
 	$mask:	INPi
 	$bit:	INPi
 	$i:	LOCi

--- a/tests/impala/golden/inputTest.gazl
+++ b/tests/impala/golden/inputTest.gazl
@@ -1,27 +1,27 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-; signature extern native print() -> unknown
-; signature extern native printLF() -> unknown
-; signature extern native input() -> unknown
-; signature extern native printInt() -> unknown
+; signature extern native print() -> unknown @ 1:20
+; signature extern native printLF() -> unknown @ 2:22
+; signature extern native input() -> unknown @ 3:20
+; signature extern native printInt() -> unknown @ 4:23
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 6:15
 	$buffer:	LOCA *1024
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_HEJ4d2 	; print("HEJ")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
-		CALL ^printLF %0 *1	; expects function() -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 9:14
+		CALL ^printLF %0 *1	; expects function() -> unknown @ 9:25
 		MOVi %2 #10 	; printInt((int) input(10, buffer))
 		ADRL %3 $buffer *0
-		CALL ^input %1 *3	; expects function(int, ptr) -> unknown
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
-		CALL ^printLF %0 *1	; expects function() -> unknown
+		CALL ^input %1 *3	; expects function(int, ptr) -> unknown @ 10:34
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 10:35
+		CALL ^printLF %0 *1	; expects function() -> unknown @ 10:46
 		ADRL %1 $buffer *0	; print(buffer)
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
-		CALL ^printLF %0 *1	; expects function() -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 11:15
+		CALL ^printLF %0 *1	; expects function() -> unknown @ 11:26
 		RETU   	; }
 
 .s_HEJ4d2:	CNST *4

--- a/tests/impala/golden/jingleBalls.gazl
+++ b/tests/impala/golden/jingleBalls.gazl
@@ -1,41 +1,41 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-DEBUG:	! DEFi #1	; signature const DEBUG : int
-MAX_GRAVITY:	! DEFf #40.0	; signature const MAX_GRAVITY : float
-MIN_SPEED:	! DEFf #0.01	; signature const MIN_SPEED : float
-MAX_SPEED:	! DEFf #20.0	; signature const MAX_SPEED : float
-GRAVITY_PARAM:	! DEFi #0	; signature const GRAVITY_PARAM : int
-BUMPER_FORCE_PARAM:	! DEFi #1	; signature const BUMPER_FORCE_PARAM : int
-PARAM_COUNT:	! DEFi #2	; signature const PARAM_COUNT : int
-BALL_COUNT:	! DEFi #3	; signature const BALL_COUNT : int
-BALL_ACTIVE_PARAM:	! DEFi #0	; signature const BALL_ACTIVE_PARAM : int
-BALL_X_PARAM:	! DEFi #1	; signature const BALL_X_PARAM : int
-BALL_Y_PARAM:	! DEFi #2	; signature const BALL_Y_PARAM : int
-BALL_DX_PARAM:	! DEFi #3	; signature const BALL_DX_PARAM : int
-BALL_DY_PARAM:	! DEFi #4	; signature const BALL_DY_PARAM : int
-BALL_PARAMS_COUNT:	! DEFi #5	; signature const BALL_PARAMS_COUNT : int
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
-; signature extern native printLF() -> unknown
-; signature extern native abort() -> unknown
-; signature extern native atan2() -> unknown
-; signature extern native log() -> unknown
-; signature extern native sqrt() -> unknown
+DEBUG:	! DEFi #1	; signature const DEBUG : int @ 2:1
+MAX_GRAVITY:	! DEFf #40.0	; signature const MAX_GRAVITY : float @ 3:1
+MIN_SPEED:	! DEFf #0.01	; signature const MIN_SPEED : float @ 4:1
+MAX_SPEED:	! DEFf #20.0	; signature const MAX_SPEED : float @ 5:1
+GRAVITY_PARAM:	! DEFi #0	; signature const GRAVITY_PARAM : int @ 6:1
+BUMPER_FORCE_PARAM:	! DEFi #1	; signature const BUMPER_FORCE_PARAM : int @ 7:1
+PARAM_COUNT:	! DEFi #2	; signature const PARAM_COUNT : int @ 8:1
+BALL_COUNT:	! DEFi #3	; signature const BALL_COUNT : int @ 9:1
+BALL_ACTIVE_PARAM:	! DEFi #0	; signature const BALL_ACTIVE_PARAM : int @ 10:1
+BALL_X_PARAM:	! DEFi #1	; signature const BALL_X_PARAM : int @ 11:1
+BALL_Y_PARAM:	! DEFi #2	; signature const BALL_Y_PARAM : int @ 12:1
+BALL_DX_PARAM:	! DEFi #3	; signature const BALL_DX_PARAM : int @ 13:1
+BALL_DY_PARAM:	! DEFi #4	; signature const BALL_DY_PARAM : int @ 14:1
+BALL_PARAMS_COUNT:	! DEFi #5	; signature const BALL_PARAMS_COUNT : int @ 16:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 18:1
+; signature extern native printLF() -> unknown @ 18:22
+; signature extern native abort() -> unknown @ 19:20
+; signature extern native atan2() -> unknown @ 21:20
+; signature extern native log() -> unknown @ 22:18
+; signature extern native sqrt() -> unknown @ 23:19
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 25:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; printLF(s)
-		CALL ^printLF %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^printLF %0 *2	; expects function(ptr) -> unknown @ 27:12
+		CALL ^abort %0 *1	; expects function() -> unknown @ 28:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cube:	FUNC	; signature func cube(float x) -> float
+cube:	FUNC	; signature func cube(float x) -> float @ 31:15
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		MULf %0 $x $x	; y = x * x * x
@@ -45,7 +45,7 @@ cube:	FUNC	; signature func cube(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-clamp:	FUNC	; signature func clamp(float x, float min, float max) -> float
+clamp:	FUNC	; signature func clamp(float x, float min, float max) -> float @ 37:16
 	$x:	INPf
 	$min:	INPf
 	$max:	INPf
@@ -62,7 +62,7 @@ clamp:	FUNC	; signature func clamp(float x, float min, float max) -> float
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTf
-floorMod:	FUNC	; signature func floorMod(float a, float n) -> float
+floorMod:	FUNC	; signature func floorMod(float a, float n) -> float @ 45:19
 	$a:	INPf
 	$n:	INPf
 ;-----------------------------------------------------------------------------
@@ -75,20 +75,20 @@ floorMod:	FUNC	; signature func floorMod(float a, float n) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-round:	FUNC	; signature func round(float x) -> float
+round:	FUNC	; signature func round(float x) -> float @ 51:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		ADDf %0 $x #0.5	; y = floor(x + 0.5)
 		FLOf $y %0 
 		RETU   	; }
 
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 58:1
 	! MULi <A> #BALL_COUNT #BALL_PARAMS_COUNT
-balls:	GLOB *<A>	; signature array balls[<A>] : unknown
+balls:	GLOB *<A>	; signature array balls[<A>] : unknown @ 60:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-tick:	FUNC	; signature func tick(int sampleFrames, float sampleRate) -> void
+tick:	FUNC	; signature func tick(int sampleFrames, float sampleRate) -> void @ 60:15
 	$sampleFrames:	INPi
 	$sampleRate:	INPf
 	$rsr16:	LOCf
@@ -111,7 +111,7 @@ tick:	FUNC	; signature func tick(int sampleFrames, float sampleRate) -> void
 ;-----------------------------------------------------------------------------
 		DIVf $rsr16 #16.0 $sampleRate	; rsr16 = 16.0 / sampleRate
 		PEEK %1 &params:GRAVITY_PARAM 	; gravity = (float) cube((float) global params[GRAVITY_PARAM]) * MAX_GRAVITY
-		CALL &cube %0 *2	; expects cube(float) -> float
+		CALL &cube %0 *2	; expects cube(float) -> float @ 67:63
 		MULf $gravity %0 #MAX_GRAVITY
 		PEEK %0 &params:BUMPER_FORCE_PARAM 	; bumperForce = (float) global params[BUMPER_FORCE_PARAM] * 2.0
 		MULf $bumperForce %0 #2.0
@@ -161,23 +161,23 @@ tick:	FUNC	; signature func tick(int sampleFrames, float sampleRate) -> void
 		DIVf $ballParams:BALL_DY_PARAM %1 $d
 		MOVf %1 $ballParams:BALL_Y_PARAM 	; a = (float) atan2((float) ballParams[BALL_Y_PARAM], (float) ballParams[BALL_X_PARAM])
 		MOVf %2 $ballParams:BALL_X_PARAM 
-		CALL ^atan2 %0 *3	; expects function(float, float) -> unknown
+		CALL ^atan2 %0 *3	; expects function(float, float) -> unknown @ 86:91
 		MOVf $a %0 
 		MULf %1 $ballParams:BALL_DX_PARAM $ballParams:BALL_DX_PARAM	; v = (float) sqrt((float) ballParams[BALL_DX_PARAM] * (float) ballParams[BALL_DX_PARAM] + (float) ballParams[BALL_DY_PARAM] * (float) ballParams[BALL_DY_PARAM])
 		MULf %2 $ballParams:BALL_DY_PARAM $ballParams:BALL_DY_PARAM
 		ADDf %1 %1 %2
-		CALL ^sqrt %0 *2	; expects function(float) -> unknown
+		CALL ^sqrt %0 *2	; expects function(float) -> unknown @ 87:165
 		MOVf $v %0 
 		MOVi $midiVel #0 	; midiVel = 0
 		LEQf $v #0.00001 @.f7	; if (v > 0.00001) midiVel = ftoi((float) clamp((float) round(50.0 * (float) log(v) + 127.0), 0.0, 127.0))
 		MOVf %3 $v 	; midiVel = ftoi((float) clamp((float) round(50.0 * (float) log(v) + 127.0), 0.0, 127.0))
-		CALL ^log %2 *2	; expects function(float) -> unknown
+		CALL ^log %2 *2	; expects function(float) -> unknown @ 89:88
 		MULf %2 #50.0 %2
 		ADDf %2 %2 #127.0
-		CALL &round %1 *2	; expects round(float) -> float
+		CALL &round %1 *2	; expects round(float) -> float @ 89:96
 		MOVf %2 #0.0 
 		MOVf %3 #127.0 
-		CALL &clamp %0 *4	; expects clamp(float, float, float) -> float
+		CALL &clamp %0 *4	; expects clamp(float, float, float) -> float @ 89:109
 		fTOi $midiVel %0 #1.0
 	.f7:	LEQi $midiVel #0 @.f8	; if (midiVel > 0) 
 		ADDi %0 $i #1	; octave = 4 + (i + 1) % 3
@@ -187,9 +187,9 @@ tick:	FUNC	; signature func tick(int sampleFrames, float sampleRate) -> void
 		! DIVf <A> #12.0 <A>
 		MULf %2 $a <A>
 		ADDf %2 %2 #9.0
-		CALL &round %1 *2	; expects round(float) -> float
+		CALL &round %1 *2	; expects round(float) -> float @ 92:80
 		MOVf %2 #12.0 
-		CALL &floorMod %0 *3	; expects floorMod(float, float) -> float
+		CALL &floorMod %0 *3	; expects floorMod(float, float) -> float @ 92:87
 		fTOi %0 %0 #1.0
 		MULi %1 $octave #12
 		ADDi $note %0 %1
@@ -221,7 +221,7 @@ tick:	FUNC	; signature func tick(int sampleFrames, float sampleRate) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 136:15
 	$i:	LOCi
 	$o:	LOCi
 ;-----------------------------------------------------------------------------
@@ -249,14 +249,14 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 151:15
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
-		CALL &init %0 *1	; expects init() -> void
+		CALL &init %0 *1	; expects init() -> void @ 154:8
 		MOVi $i #0 	; for (i = 0 to 100000000) tick(64, 44100.0)
 		GEQi #0 #100000000 @.e0
 	.l1:	MOVi %1 #64 	; tick(64, 44100.0)
 		MOVf %2 #44100.0 
-		CALL &tick %0 *3	; expects tick(int, float) -> void
+		CALL &tick %0 *3	; expects tick(int, float) -> void @ 155:44
 		FORi $i #100000000 @.l1
 	.e0:	RETU   	; }

--- a/tests/impala/golden/life.gazl
+++ b/tests/impala/golden/life.gazl
@@ -1,24 +1,24 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-; signature extern native output() -> unknown
-; signature extern native abort() -> unknown
-; signature extern native input() -> unknown
-; signature extern native inputEOF() -> unknown
-; signature extern native launch() -> unknown
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-MAX_DIM_X:	! DEFi #76	; signature const MAX_DIM_X : int
-MAX_DIM_Y:	! DEFi #23	; signature const MAX_DIM_Y : int
-MAX_GENERATIONS:	! DEFi #1000	; signature const MAX_GENERATIONS : int
+; signature extern native output() -> unknown @ 9:21
+; signature extern native abort() -> unknown @ 10:20
+; signature extern native input() -> unknown @ 11:20
+; signature extern native inputEOF() -> unknown @ 12:23
+; signature extern native launch() -> unknown @ 13:21
+FALSE:	! DEFi #0	; signature const FALSE : int @ 15:20
+TRUE:	! DEFi #1	; signature const TRUE : int @ 16:19
+MAX_DIM_X:	! DEFi #76	; signature const MAX_DIM_X : int @ 18:25
+MAX_DIM_Y:	! DEFi #23	; signature const MAX_DIM_Y : int @ 19:25
+MAX_GENERATIONS:	! DEFi #1000	; signature const MAX_GENERATIONS : int @ 20:33
 	GLOB *1
-xorShiftRandomSeedX:	DATi #123456789	; signature global xorShiftRandomSeedX : int
+xorShiftRandomSeedX:	DATi #123456789	; signature global xorShiftRandomSeedX : int @ 22:43
 	GLOB *1
-xorShiftRandomSeedY:	DATi #362436069	; signature global xorShiftRandomSeedY : int
+xorShiftRandomSeedY:	DATi #362436069	; signature global xorShiftRandomSeedY : int @ 23:43
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-xorShiftRandom:	FUNC	; signature func xorShiftRandom() -> int
+xorShiftRandom:	FUNC	; signature func xorShiftRandom() -> int @ 24:25
 	$x:	LOCi
 	$t:	LOCi
 ;-----------------------------------------------------------------------------
@@ -39,7 +39,7 @@ xorShiftRandom:	FUNC	; signature func xorShiftRandom() -> int
 
 ;-----------------------------------------------------------------------------
 	$q:	OUTp
-eatWhite:	FUNC	; signature func eatWhite(ptr p) -> ptr
+eatWhite:	FUNC	; signature func eatWhite(ptr p) -> ptr @ 38:19
 	$p:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp $q $p 	; q = p
@@ -52,19 +52,19 @@ eatWhite:	FUNC	; signature func eatWhite(ptr p) -> ptr
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-outputLine:	FUNC	; signature func outputLine(ptr s) -> void
+outputLine:	FUNC	; signature func outputLine(ptr s) -> void @ 45:21
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; output(s)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 47:11
 		MOVp %1 &.s_4d2 	; output("\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 48:14
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$d:	OUTi
-strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int
+strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int @ 51:17
 	$s0:	INPp
 	$s1:	INPp
 	$a:	LOCp
@@ -86,7 +86,7 @@ strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int
 
 ;-----------------------------------------------------------------------------
 	$d:	OUTi
-strncmp:	FUNC	; signature func strncmp(ptr s0, ptr s1, int n) -> int
+strncmp:	FUNC	; signature func strncmp(ptr s0, ptr s1, int n) -> int @ 65:18
 	$s0:	INPp
 	$s1:	INPp
 	$n:	INPi
@@ -116,7 +116,7 @@ strncmp:	FUNC	; signature func strncmp(ptr s0, ptr s1, int n) -> int
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr
+intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr @ 90:22
 	$i:	INPi
 	$radix:	INPi
 	$minLength:	INPi
@@ -163,7 +163,7 @@ intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-outputInt:	FUNC	; signature func outputInt(int i) -> void
+outputInt:	FUNC	; signature func outputInt(int i) -> void @ 108:20
 	$i:	INPi
 	! ADDi <A> #GAZL_WORD_SIZE #2
 	$buffer:	LOCA *<A>
@@ -172,14 +172,14 @@ outputInt:	FUNC	; signature func outputInt(int i) -> void
 		MOVi %3 #10 
 		MOVi %4 #1 
 		ADRL %5 $buffer *0
-		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr @ 111:38
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 111:39
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$i:	OUTi
-parseInt:	FUNC	; signature func parseInt(ptr s, int defaultValue) -> int
+parseInt:	FUNC	; signature func parseInt(ptr s, int defaultValue) -> int @ 114:19
 	$s:	INPp
 	$defaultValue:	INPi
 	$p:	LOCp
@@ -189,7 +189,7 @@ parseInt:	FUNC	; signature func parseInt(ptr s, int defaultValue) -> int
 		MOVi $i #0 	; i = 0
 		MOVi $sign #1 	; sign = 1
 		MOVp %1 $s 	; p = (pointer)eatWhite(s)
-		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr
+		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr @ 123:26
 		MOVp $p %0 
 		PEEK $c $p 	; if ((c = (int)*p) == '+') p = p + 1
 		NEQi $c #'+' @.f0
@@ -209,7 +209,7 @@ parseInt:	FUNC	; signature func parseInt(ptr s, int defaultValue) -> int
 		ADDp $p $p #1	; p = p + 1
 		GOTO @.l3  	; }
 	.e5:	MOVp %1 $p 	; p = (pointer)eatWhite(p)
-		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr
+		CALL &eatWhite %0 *2	; expects eatWhite(ptr) -> ptr @ 135:26
 		MOVp $p %0 
 		PEEK %0 $p 	; if ((int)*p != 0) i = defaultValue
 		EQUi %0 #0 @.f6
@@ -221,7 +221,7 @@ parseInt:	FUNC	; signature func parseInt(ptr s, int defaultValue) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-parseXY:	FUNC	; signature func parseXY(ptr s, ptr x, ptr y) -> void
+parseXY:	FUNC	; signature func parseXY(ptr s, ptr x, ptr y) -> void @ 141:18
 	$s:	INPp
 	$x:	INPp
 	$y:	INPp
@@ -243,43 +243,43 @@ parseXY:	FUNC	; signature func parseXY(ptr s, ptr x, ptr y) -> void
 		ADDp $yp $yp #1	; yp = yp + 1
 		MOVp %1 $s 	; *x = parseInt(s, -1)
 		MOVi %2 #-1 
-		CALL &parseInt %0 *3	; expects parseInt(ptr, int) -> int
+		CALL &parseInt %0 *3	; expects parseInt(ptr, int) -> int @ 153:23
 		POKE $x %0 
 		MOVp %1 $yp 	; *y = parseInt(yp, -1)
 		MOVi %2 #-1 
-		CALL &parseInt %0 *3	; expects parseInt(ptr, int) -> int
+		CALL &parseInt %0 *3	; expects parseInt(ptr, int) -> int @ 154:24
 		POKE $y %0 
 	.f3:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-help:	FUNC	; signature func help() -> void
+help:	FUNC	; signature func help() -> void @ 158:15
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_fedcba4d3:31 	; outputLine("")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 160:16
 		MOVp %1 &.s_Comman4d4 	; outputLine("Commands are:")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 161:29
 		MOVp %1 &.s_xytogg4d5 	; outputLine("    <x>,<y> (toggle cell)")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 162:41
 		MOVp %1 &.s_nrunng4d6 	; outputLine("    <n> (run <n> generations)")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 163:45
 		MOVp %1 &.s_enterd4d7 	; outputLine("    enter (draw grid)")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 164:37
 		MOVp %1 &.s_clear4d8 	; outputLine("    'clear'")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 165:27
 		MOVp %1 &.s_randis4d9 	; outputLine("    'rand %' (% is likelihood of setting a cell from 0 to 100 %)")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 166:80
 		MOVp %1 &.s_quit4da 	; outputLine("    'quit'")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 167:27
 		MOVp %1 &.s_quit4da:10 	; outputLine("")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 168:16
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-run:	FUNC	; signature func run(int dimX, int dimY, ptr cells, int generations) -> void
+run:	FUNC	; signature func run(int dimX, int dimY, ptr cells, int generations) -> void @ 171:14
 	$dimX:	INPi
 	$dimY:	INPi
 	$cells:	INPp
@@ -370,7 +370,7 @@ run:	FUNC	; signature func run(int dimX, int dimY, ptr cells, int generations) -
 
 ;-----------------------------------------------------------------------------
 	$n:	OUTi
-outputCellsAlive:	FUNC	; signature func outputCellsAlive(int dimX, int dimY, ptr cells) -> int
+outputCellsAlive:	FUNC	; signature func outputCellsAlive(int dimX, int dimY, ptr cells) -> int @ 222:27
 	$dimX:	INPi
 	$dimY:	INPi
 	$cells:	INPp
@@ -385,17 +385,17 @@ outputCellsAlive:	FUNC	; signature func outputCellsAlive(int dimX, int dimY, ptr
 		ADDi $n $n #1	; n = n + 1
 	.f2:	FORi $i %0 @.l1
 	.e0:	MOVp %1 &.s_4db 	; output("(")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 228:13
 		MOVi %1 $n 	; outputInt(n)
-		CALL &outputInt %0 *2	; expects outputInt(int) -> void
+		CALL &outputInt %0 *2	; expects outputInt(int) -> void @ 228:27
 		MOVp %1 &.s_cellsa4dc 	; outputLine(" cells alive)")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 228:56
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-randomize:	FUNC	; signature func randomize(int dimX, int dimY, ptr cells, int percentage) -> void
+randomize:	FUNC	; signature func randomize(int dimX, int dimY, ptr cells, int percentage) -> void @ 231:20
 	$dimX:	INPi
 	$dimY:	INPi
 	$cells:	INPp
@@ -405,7 +405,7 @@ randomize:	FUNC	; signature func randomize(int dimX, int dimY, ptr cells, int pe
 		MOVi $i #0 	; for (i = 0 to dimX * dimY) 
 		MULi %0 $dimX $dimY
 		GEQi #0 %0 @.e0
-	.l1:	CALL &xorShiftRandom %1 *1	; expects xorShiftRandom() -> int
+	.l1:	CALL &xorShiftRandom %1 *1	; expects xorShiftRandom() -> int @ 235:30
 		ANDi %1 %1 #0x7FFFFFFF
 		MODi %1 %1 #100
 		GRTi %1 $percentage @.f2
@@ -416,7 +416,7 @@ randomize:	FUNC	; signature func randomize(int dimX, int dimY, ptr cells, int pe
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 239:15
 	! MULi <A> #MAX_DIM_X #MAX_DIM_Y
 	$dimX:	LOCi
 	$dimY:	LOCi
@@ -433,31 +433,31 @@ main:	FUNC	; signature func main() -> void
 	$redraw:	LOCi
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_Enterd4dd 	; output("Enter dimensions (X,Y): ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 254:36
 		MOVi %1 #255 	; input(255, s)
 		ADRL %2 $s *0
-		CALL ^input %0 *3	; expects function(int, ptr) -> unknown
+		CALL ^input %0 *3	; expects function(int, ptr) -> unknown @ 255:15
 		ADRL %1 $s *0	; parseXY(s, &dimX, &dimY)
 		ADRL %2 $dimX *0
 		ADRL %3 $dimY *0
-		CALL &parseXY %0 *4	; expects parseXY(ptr, ptr, ptr) -> void
+		CALL &parseXY %0 *4	; expects parseXY(ptr, ptr, ptr) -> void @ 256:26
 		LEQi $dimX #0 @.t0	; if (dimX <= 0 || dimY <= 0) outputLine("Invalid dimensions. Bye!")
 		GRTi $dimY #0 @.f1
 	.t0:	MOVp %1 &.s_Invali4de 	; outputLine("Invalid dimensions. Bye!")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 257:68
 		GOTO @.e2  
 	.f1:	GRTi $dimX #MAX_DIM_X @.t3	; if (dimX > MAX_DIM_X || dimY > MAX_DIM_Y) 
 		LEQi $dimY #MAX_DIM_Y @.f4
 	.t3:	MOVp %1 &.s_Toolar4df 	; output("Too large. Max dimensions are ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 259:43
 		MOVi %1 #MAX_DIM_X 	; outputInt(MAX_DIM_X)
-		CALL &outputInt %0 *2	; expects outputInt(int) -> void
+		CALL &outputInt %0 *2	; expects outputInt(int) -> void @ 260:23
 		MOVp %1 &.s_4e0 	; output(",")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 261:14
 		MOVi %1 #MAX_DIM_Y 	; outputInt(MAX_DIM_Y)
-		CALL &outputInt %0 *2	; expects outputInt(int) -> void
+		CALL &outputInt %0 *2	; expects outputInt(int) -> void @ 262:23
 		MOVp %1 &.s_4e1 	; outputLine(".")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 263:18
 		GOTO @.e5  	; } else 
 	.f4:	MOVi $i #0 	; for (i = 0 to (dimX * dimY)) cells[i] = 0
 		MULi %0 $dimX $dimY
@@ -469,7 +469,7 @@ main:	FUNC	; signature func main() -> void
 	.l8:	MOVi $s:0 #12 	; s[0] = 12
 		MOVi $s:1 #0 	; s[1] = 0
 		ADRL %1 $s *0	; output(s)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 272:13
 		MOVi $i #0 	; for (i = 0 to 3) s[i] = ' '
 		GEQi #0 #3 @.e9
 	.l10:	SETL $s $i #' '	; s[i] = ' '
@@ -487,7 +487,7 @@ main:	FUNC	; signature func main() -> void
 	.e11:	ADDi %1 $dimX #3	; s[dimX + 3] = 0
 		SETL $s %1 #0
 		ADRL %1 $s *0	; outputLine(s)
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 280:17
 		MOVi $i #0 	; for (i = 0 to dimX) s[i + 3] = '0' + i % 10
 		GEQi #0 $dimX @.e14
 	.l15:	ADDi %0 $i #3	; s[i + 3] = '0' + i % 10
@@ -496,7 +496,7 @@ main:	FUNC	; signature func main() -> void
 		SETL $s %0 %1
 		FORi $i $dimX @.l15
 	.e14:	ADRL %1 $s *0	; outputLine(s)
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 283:17
 		MOVi $i #0 	; for (i = 0 to dimY) 
 		GEQi #0 $dimY @.e16
 	.l17:	LSSi $i #10 @.f18	; if (i >= 10) s[0] = '0' + i / 10
@@ -518,20 +518,20 @@ main:	FUNC	; signature func main() -> void
 	.e19:	ADDi %0 $j #3	; s[j + 3] = 0
 		SETL $s %0 #0
 		ADRL %1 $s *0	; outputLine(s)
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 294:18
 		FORi $i $dimY @.l17	; }
 	.e16:	EQUi $firstTime #FALSE @.f22	; if (firstTime != FALSE) 
-		CALL &help %0 *1	; expects help() -> void
+		CALL &help %0 *1	; expects help() -> void @ 298:11
 		MOVi $firstTime #FALSE 	; firstTime = FALSE
 	.f22:	MOVi $redraw #FALSE 	; redraw = FALSE
 	.l23:	MOVp %1 &.s_life4e2 	; output("life> ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 304:21
 		MOVi %1 #255 	; input(255, s)
 		ADRL %2 $s *0
-		CALL ^input %0 *3	; expects function(int, ptr) -> unknown
+		CALL ^input %0 *3	; expects function(int, ptr) -> unknown @ 305:18
 		ADRL %1 $s *0	; if ((int)strcmp(s, "quit") == 0) 
 		MOVp %2 &.s_quit4e3 
-		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int @ 306:32
 		NEQi %0 #0 @.f24
 		MOVi $quit #TRUE 	; quit = TRUE
 		GOTO @.e25  	; } else if ((int)s[0] == 0) 
@@ -540,7 +540,7 @@ main:	FUNC	; signature func main() -> void
 		GOTO @.e27  	; } else if ((int)strcmp(s, "clear") == 0) 
 	.f26:	ADRL %1 $s *0	; if ((int)strcmp(s, "clear") == 0) 
 		MOVp %2 &.s_clear4e4 
-		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int @ 310:40
 		NEQi %0 #0 @.f28
 		MOVi $i #0 	; for (i = 0 to dimX * dimY) cells[i] = 0
 		MULi %0 $dimX $dimY
@@ -548,40 +548,40 @@ main:	FUNC	; signature func main() -> void
 	.l30:	SETL $cells $i #0	; cells[i] = 0
 		FORi $i %0 @.l30
 	.e29:	MOVp %1 &.s_Cleare4e5 	; outputLine("Cleared all cells.")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 312:38
 		GOTO @.e31  	; } else if ((int)strncmp(s, "rand ", 5) == 0) 
 	.f28:	ADRL %1 $s *0	; if ((int)strncmp(s, "rand ", 5) == 0) 
 		MOVp %2 &.s_rand4e6 
 		MOVi %3 #5 
-		CALL &strncmp %0 *4	; expects strncmp(ptr, ptr, int) -> int
+		CALL &strncmp %0 *4	; expects strncmp(ptr, ptr, int) -> int @ 313:44
 		NEQi %0 #0 @.f32
 		ADRL %1 $s:5 *0	; i = (int)parseInt(&s[5], -10000)
 		MOVi %2 #-10000 
-		CALL &parseInt %0 *3	; expects parseInt(ptr, int) -> int
+		CALL &parseInt %0 *3	; expects parseInt(ptr, int) -> int @ 314:38
 		MOVi $i %0 
 		LSSi $i #0 @.t33	; if (i < 0 || i > 100) help()
 		LEQi $i #100 @.f34
-	.t33:	CALL &help %0 *1	; expects help() -> void
+	.t33:	CALL &help %0 *1	; expects help() -> void @ 315:34
 		GOTO @.e36  
 	.f34:	MOVi %1 $dimX 	; randomize(dimX, dimY, cells, i)
 		MOVi %2 $dimY 
 		ADRL %3 $cells *0
 		MOVi %4 $i 
-		CALL &randomize %0 *5	; expects randomize(int, int, ptr, int) -> void
+		CALL &randomize %0 *5	; expects randomize(int, int, ptr, int) -> void @ 317:38
 		MOVp %1 &.s_Random4e7 	; output("Randomized with ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 318:33
 		MOVi %1 $i 	; outputInt(i)
-		CALL &outputInt %0 *2	; expects outputInt(int) -> void
+		CALL &outputInt %0 *2	; expects outputInt(int) -> void @ 319:19
 		MOVp %1 &.s_4e8 	; output(" %. ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 320:21
 		MOVi %1 $dimX 	; outputCellsAlive(dimX, dimY, cells)
 		MOVi %2 $dimY 
 		ADRL %3 $cells *0
-		CALL &outputCellsAlive %0 *4	; expects outputCellsAlive(int, int, ptr) -> int
+		CALL &outputCellsAlive %0 *4	; expects outputCellsAlive(int, int, ptr) -> int @ 321:42
 	.e35:	GOTO @.e36  	; } else 
 	.f32:	ADRL %1 $s *0	; i = (int)parseInt(s, -10000)
 		MOVi %2 #-10000 
-		CALL &parseInt %0 *3	; expects parseInt(ptr, int) -> int
+		CALL &parseInt %0 *3	; expects parseInt(ptr, int) -> int @ 324:34
 		MOVi $i %0 
 		LSSi $i #0 @.f37	; if (i >= 0) 
 		GRTi $i #MAX_GENERATIONS @.f38	; if (i <= MAX_GENERATIONS) 
@@ -589,29 +589,29 @@ main:	FUNC	; signature func main() -> void
 		MOVi %2 $dimY 
 		ADRL %3 $cells *0
 		MOVi %4 $i 
-		CALL &run %0 *5	; expects run(int, int, ptr, int) -> void
+		CALL &run %0 *5	; expects run(int, int, ptr, int) -> void @ 327:33
 		MOVp %1 &.s_Ran4e9 	; output("Ran ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 328:22
 		MOVi %1 $i 	; outputInt(i)
-		CALL &outputInt %0 *2	; expects outputInt(int) -> void
+		CALL &outputInt %0 *2	; expects outputInt(int) -> void @ 329:20
 		MOVp %1 &.s_genera4ea 	; output(" generations. ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 330:32
 		MOVi %1 $dimX 	; outputCellsAlive(dimX, dimY, cells)
 		MOVi %2 $dimY 
 		ADRL %3 $cells *0
-		CALL &outputCellsAlive %0 *4	; expects outputCellsAlive(int, int, ptr) -> int
+		CALL &outputCellsAlive %0 *4	; expects outputCellsAlive(int, int, ptr) -> int @ 331:43
 		GOTO @.e40  	; } else 
 	.f38:	MOVp %1 &.s_Maxgen4eb 	; output("Max generations is ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 333:37
 		MOVi %1 #MAX_GENERATIONS 	; outputInt(MAX_GENERATIONS)
-		CALL &outputInt %0 *2	; expects outputInt(int) -> void
+		CALL &outputInt %0 *2	; expects outputInt(int) -> void @ 334:34
 		MOVp %1 &.s_Cleare4e5:17 	; outputLine(".")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 335:23
 	.e39:	GOTO @.e40  	; } else 
 	.f37:	ADRL %1 $s *0	; parseXY(s, &x, &y)
 		ADRL %2 $x *0
 		ADRL %3 $y *0
-		CALL &parseXY %0 *4	; expects parseXY(ptr, ptr, ptr) -> void
+		CALL &parseXY %0 *4	; expects parseXY(ptr, ptr, ptr) -> void @ 338:25
 		LSSi $x #0 @.f42	; if (x >= 0 && y >= 0) 
 		LSSi $y #0 @.f42
 		GEQi $x $dimX @.f44	; if (x < dimX && y < dimY) 
@@ -623,29 +623,29 @@ main:	FUNC	; signature func main() -> void
 		SETL $cells $i $c	; cells[i] = c
 		EQUi $c #0 @.f45	; if (c != 0) output("Set ")
 		MOVp %1 &.s_Set4ec 	; output("Set ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 344:35
 		GOTO @.e46  
 	.f45:	MOVp %1 &.s_Reset4ed 	; output("Reset ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 345:30
 	.e46:	MOVp %1 &.s_cell4ee 	; output("cell ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 346:24
 		MOVi %1 $x 	; outputInt(x)
-		CALL &outputInt %0 *2	; expects outputInt(int) -> void
+		CALL &outputInt %0 *2	; expects outputInt(int) -> void @ 347:21
 		MOVp %1 &.s_4e0 	; output(",")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 348:20
 		MOVi %1 $y 	; outputInt(y)
-		CALL &outputInt %0 *2	; expects outputInt(int) -> void
+		CALL &outputInt %0 *2	; expects outputInt(int) -> void @ 349:21
 		MOVp %1 &.s_genera4ea:12 	; output(". ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 350:21
 		MOVi %1 $dimX 	; outputCellsAlive(dimX, dimY, cells)
 		MOVi %2 $dimY 
 		ADRL %3 $cells *0
-		CALL &outputCellsAlive %0 *4	; expects outputCellsAlive(int, int, ptr) -> int
+		CALL &outputCellsAlive %0 *4	; expects outputCellsAlive(int, int, ptr) -> int @ 351:44
 		GOTO @.e48  	; } else 
 	.f44:	MOVp %1 &.s_Invali4ef 	; outputLine("Invalid coordinates.")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 353:43
 	.e47:	GOTO @.e48  	; } else 
-	.f42:	CALL &help %0 *1	; expects help() -> void
+	.f42:	CALL &help %0 *1	; expects help() -> void @ 356:14
 	.e48:	NOOP
 	.e40:	NOOP
 	.e36:	NOOP
@@ -655,11 +655,11 @@ main:	FUNC	; signature func main() -> void
 		EQUi $quit #FALSE @.l23
 	.f49:	EQUi $quit #FALSE @.l8	; } while (quit == FALSE)
 		MOVp %1 &.s_Invali4ef:20 	; outputLine("")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 363:17
 		MOVp %1 &.s_Byebye4f0 	; outputLine("Bye bye!")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 364:25
 		MOVp %1 &.s_Byebye4f0:8 	; outputLine("")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 365:17
 	.e5:	NOOP
 	.e2:	RETU   	; }
 

--- a/tests/impala/golden/linsub_code.gazl
+++ b/tests/impala/golden/linsub_code.gazl
@@ -1,38 +1,38 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_4d2 &.s_SUB16B4d3 &.s_SUB16B4d3:53
 	DATA &.s_SUB16B4d3:53 &.s_SUB16B4d3:53 &.s_SUB16B4d3:53
 	DATA &.s_SUB16B4d3:53 &.s_SUB16B4d3:53
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 81:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 82:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
-positions:	GLOB *2	; signature array positions[2] : unknown
+instance:	DATi #0	; signature global instance : int @ 86:1
+positions:	GLOB *2	; signature array positions[2] : unknown @ 87:1
 	CNST *1
 	! SHLi <A> #1 #OPERATOR_1_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_1_HIGH_PARAM_INDEX
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #OPERAND_1_LOW_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 92:1
 	GLOB *1
-subTerm:	DATi #0	; signature global subTerm : int
+subTerm:	DATi #0	; signature global subTerm : int @ 92:19
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 116:17
 	$x:	LOCi
 	$y:	LOCi
 ;-----------------------------------------------------------------------------
@@ -55,7 +55,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-operate1:	FUNC	; signature func operate1(int a) -> int
+operate1:	FUNC	; signature func operate1(int a) -> int @ 136:19
 	$a:	INPi
 	$x:	LOCi
 ;-----------------------------------------------------------------------------

--- a/tests/impala/golden/miditest_code.gazl
+++ b/tests/impala/golden/miditest_code.gazl
@@ -1,26 +1,26 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_4d2 &.s_4d2 &.s_4d2 &.s_LEFTDE4d3 &.s_4d2 &.s_4d2
 	DATA &.s_4d2 &.s_RINGMO4d4
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 81:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 82:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
+instance:	DATi #0	; signature global instance : int @ 83:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 86:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 88:1
 	CNST *1
 	! SHLi <A> #1 #OPERAND_1_HIGH_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_1_LOW_PARAM_INDEX
@@ -31,8 +31,8 @@ signal:	GLOB *2	; signature array signal[2] : unknown
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #SWITCHES_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
-EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 95:1
+EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown @ 95:41
 	DATA #0x0 #0x1 #0x2 #0x3 #0x4 #0x5 #0x6 #0x7 #0x8 #0x9
 	DATA #0xa #0xb #0xc #0xd #0xe #0xf #0x10 #0x11 #0x12 #0x13
 	DATA #0x14 #0x15 #0x16 #0x17 #0x18 #0x19 #0x1a #0x1b #0x1c
@@ -67,19 +67,19 @@ EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unkn
 	DATA #0x7c00 #0x8000 #0x8800 #0x9000 #0x9800 #0xa000
 	DATA #0xa800 #0xb000 #0xb800 #0xc000 #0xc800 #0xd000
 	DATA #0xd800 #0xe000 #0xe800 #0xf000 #0xffff
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 130:1
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 131:1
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 132:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 133:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 134:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 135:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 136:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 138:1
 
 ;-----------------------------------------------------------------------------
 	$a:	OUTp
-stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
+stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr @ 138:17
 	$d:	INPp
 	$s:	INPp
 	$b:	LOCp
@@ -97,7 +97,7 @@ stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr
+intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr @ 157:22
 	$i:	INPi
 	$radix:	INPi
 	$minLength:	INPi
@@ -144,7 +144,7 @@ intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
+traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void @ 175:20
 	$text:	INPp
 	$n:	INPi
 	$ints:	INPp
@@ -158,7 +158,7 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		EQUp $text &NULL @.f0	; if (text != null) p = (pointer) stpcpy(p, text)
 		MOVp %1 $p 	; p = (pointer) stpcpy(p, text)
 		MOVp %2 $text 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 182:49
 		MOVp $p %0 
 	.f0:	POKE $p #0 	; *p = 0
 		MOVi $i #0 	; for (i = 0 to n) 
@@ -171,18 +171,18 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		MOVi %4 #10 
 		MOVi %5 #1 
 		ADRL %6 $buffer *0
-		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr @ 186:62
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 186:63
 		MOVp $p %0 
 		FORi $i $n @.l2	; }
 	.e1:	ADRL %1 $line *0	; trace(line)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 188:13
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
+traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void @ 191:19
 	$text:	INPp
 	$i:	INPi
 	$ints:	LOCA *1
@@ -191,24 +191,24 @@ traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
 		MOVp %1 $text 	; traceInts(text, 1, ints)
 		MOVi %2 #1 
 		ADRL %3 $ints *0
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 195:26
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 198:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 200:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 201:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 204:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -222,16 +222,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 211:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4d6 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 214:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float)trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 215:35
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -239,7 +239,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 229:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -248,7 +248,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 233:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -271,7 +271,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-exp:	FUNC	; signature func exp(float x) -> float
+exp:	FUNC	; signature func exp(float x) -> float @ 270:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -292,47 +292,47 @@ exp:	FUNC	; signature func exp(float x) -> float
 		DIVf $y #1.0 $y	; y = 1.0 / y
 	.f1:	RETU   	; }
 
-COS_TABLE_BITS:	! DEFi #12	; signature const COS_TABLE_BITS : int
+COS_TABLE_BITS:	! DEFi #12	; signature const COS_TABLE_BITS : int @ 293:1
 	! SHLi <A> #1 #COS_TABLE_BITS
-COS_TABLE_SIZE:	! DEFi <A>	; signature const COS_TABLE_SIZE : int
-BATCH_SIZE:	! DEFi #77	; signature const BATCH_SIZE : int
+COS_TABLE_SIZE:	! DEFi <A>	; signature const COS_TABLE_SIZE : int @ 294:1
+BATCH_SIZE:	! DEFi #77	; signature const BATCH_SIZE : int @ 294:26
 	! ADDi <A> #COS_TABLE_SIZE #1
-cosTable:	GLOB *<A>	; signature array cosTable[<A>] : unknown
-pitchTable:	GLOB *32	; signature array pitchTable[32] : unknown
+cosTable:	GLOB *<A>	; signature array cosTable[<A>] : unknown @ 299:1
+pitchTable:	GLOB *32	; signature array pitchTable[32] : unknown @ 299:28
 	GLOB *1
-doReset:	DATi #FALSE	; signature global doReset : int
+doReset:	DATi #FALSE	; signature global doReset : int @ 302:1
 	GLOB *1
-rate:	DATi #0	; signature global rate : int
+rate:	DATi #0	; signature global rate : int @ 303:1
 	GLOB *1
-diff:	DATi #0	; signature global diff : int
+diff:	DATi #0	; signature global diff : int @ 304:1
 	GLOB *1
-delayL:	DATi #0	; signature global delayL : int
+delayL:	DATi #0	; signature global delayL : int @ 305:1
 	GLOB *1
-delayR:	DATi #0	; signature global delayR : int
+delayR:	DATi #0	; signature global delayR : int @ 306:1
 	GLOB *1
-syncBit:	DATi #0	; signature global syncBit : int
+syncBit:	DATi #0	; signature global syncBit : int @ 315:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 315:15
 	$i:	LOCi
 	$buf:	LOCA *256
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4d7 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 318:15
 		PEEK %2 &instance 	; trace(intToString(global instance, 10, 1, buf))
 		MOVi %3 #10 
 		MOVi %4 #1 
 		ADRL %5 $buf *0
-		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr @ 319:48
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 319:49
 		MOVi $i #0 	; for (i = 0 to COS_TABLE_SIZE) global cosTable[i] = ftoi((float) cos((TWICE_PI / itof(COS_TABLE_SIZE)) * itof(i)) * 2048.0)
 		GEQi #0 #COS_TABLE_SIZE @.e0
 	.l1:	NOOP
 		! iTOf <A> #COS_TABLE_SIZE #1.0	; global cosTable[i] = ftoi((float) cos((TWICE_PI / itof(COS_TABLE_SIZE)) * itof(i)) * 2048.0)
 		! DIVf <A> #TWICE_PI <A>
 		iTOf %1 $i <A>
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 320:115
 		fTOi %0 %0 #2048.0
 		POKE &cosTable $i %0
 		FORi $i #COS_TABLE_SIZE @.l1
@@ -344,7 +344,7 @@ init:	FUNC	; signature func init() -> void
 		! DIVf <A> #1.0 #12.0	; global pitchTable[i] = ftoi((float) exp(LOG2 * (itof(i) * (1.0 / 12.0))) * 1.011179191599226e+07)
 		iTOf %1 $i <A>
 		MULf %1 #LOG2 %1
-		CALL &exp %0 *2	; expects exp(float) -> float
+		CALL &exp %0 *2	; expects exp(float) -> float @ 324:76
 		fTOi %0 %0 #1.011179191599226e+07
 		POKE &pitchTable $i %0
 		FORi $i #32 @.l3	; }
@@ -353,21 +353,21 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 334:16
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4d8 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 336:16
 		MOVp %1 &.s_params4d9 	; traceInts(" params: ", PARAM_COUNT, global params)
 		MOVi %2 #PARAM_COUNT 
 		MOVp %3 &params 
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 337:52
 		POKE &doReset #TRUE 	; global doReset = TRUE
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int
+displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int @ 341:28
 	$x:	INPi
 ;-----------------------------------------------------------------------------
 		! SUBi <A> #8 #3	; y = 0x1 << (x >> (8 - 3))
@@ -378,34 +378,34 @@ displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 354:17
 	$buf:	LOCA *256
 	$params:	LOCA *PARAM_COUNT
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_update4da 	; trace("update")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 357:17
 		MOVp %1 &.s_params4d9 	; traceInts(" params: ", PARAM_COUNT, global params)
 		MOVi %2 #PARAM_COUNT 
 		MOVp %3 &params 
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 358:52
 		ADRL %0 $params *0	; copy (PARAM_COUNT from global params to params)
 		COPY %0 &params *PARAM_COUNT
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_1_HIGH_PARAM_INDEX	; global delayL = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_1_HIGH_PARAM_INDEX]]
 		POKE &delayL %0 
 		MOVi %1 $params:OPERAND_1_HIGH_PARAM_INDEX 	; global displayLEDs[0] = displayDelayValue((int) params[OPERAND_1_HIGH_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 361:85
 		POKE &displayLEDs:0 %0 
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_1_LOW_PARAM_INDEX	; global delayR = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_1_LOW_PARAM_INDEX]]
 		POKE &delayR %0 
 		MOVi %1 $params:OPERAND_1_LOW_PARAM_INDEX 	; global displayLEDs[1] = displayDelayValue((int) params[OPERAND_1_LOW_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 363:84
 		POKE &displayLEDs:1 %0 
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_2_HIGH_PARAM_INDEX	; global rate = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_2_HIGH_PARAM_INDEX]]
 		POKE &rate %0 
 		SHLi %0 $params:OPERAND_2_LOW_PARAM_INDEX #8	; global diff = (int) params[OPERAND_2_LOW_PARAM_INDEX] << 8
 		POKE &diff %0 
 		MOVi %1 $params:OPERAND_2_LOW_PARAM_INDEX 	; global displayLEDs[3] = displayDelayValue((int) params[OPERAND_2_LOW_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 366:84
 		POKE &displayLEDs:3 %0 
 		PEEK %0 &params:SWITCHES_PARAM_INDEX 	; global syncBit = (int) global params[SWITCHES_PARAM_INDEX] & SWITCHES_SYNC_MASK
 		ANDi %0 %0 #SWITCHES_SYNC_MASK
@@ -415,7 +415,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 385:18
 	$i:	LOCi
 	$s:	LOCi
 	$b:	LOCi
@@ -450,7 +450,7 @@ process:	FUNC	; signature func process() -> void
 		POKE &signal:1 $s 	; global signal[1] = s
 		ADDi $i $i #1	; i = i + 1
 		ADDi $j $j #0x10000	; j = j + 0x10000
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 405:10
 		GOTO @.l0  	; }
 		RETU   	; }
 

--- a/tests/impala/golden/mozaik_code.gazl
+++ b/tests/impala/golden/mozaik_code.gazl
@@ -1,24 +1,24 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 10:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 11:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 13:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 13:33
 	DATA &.s_4d2 &.s_4d2 &.s_CRUSH4d3 &.s_BLOCKR4d4 &.s_4d2
 	DATA &.s_4d2 &.s_4d5 &.s_BLOCKS4d6
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 25:1
+; signature extern native trace() -> unknown @ 26:1
+; signature extern native yield() -> unknown @ 27:1
+; signature extern native write() -> unknown @ 28:1
+; signature extern native read() -> unknown @ 30:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 49:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 50:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 51:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 52:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 53:1
 	CNST *1
 	! SHLi <A> #1 #SWITCHES_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_1_HIGH_PARAM_INDEX
@@ -29,23 +29,23 @@ signal:	GLOB *2	; signature array signal[2] : unknown
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #OPERAND_2_LOW_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 119:1
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 121:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 121:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 123:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 124:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-exp:	FUNC	; signature func exp(float x) -> float
+exp:	FUNC	; signature func exp(float x) -> float @ 127:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -69,7 +69,7 @@ exp:	FUNC	; signature func exp(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-log:	FUNC	; signature func log(float x) -> float
+log:	FUNC	; signature func log(float x) -> float @ 147:14
 	$x:	INPf
 	$a:	LOCf
 	$b:	LOCf
@@ -80,7 +80,7 @@ log:	FUNC	; signature func log(float x) -> float
 		LEQf $x #0.0 @.t0	; if (x <= 0.0 || x >= 1.0e38) error("Domain error")
 		LSSf $x #1.0e38 @.f1
 	.t0:	MOVp %1 &.s_Domain4d7 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 155:52
 		GOTO @.e2  
 	.f1:	MOVf $b #0.0 	; b = 0.0
 		MOVf $m $x 	; m = x
@@ -109,7 +109,7 @@ log:	FUNC	; signature func log(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-pow:	FUNC	; signature func pow(float x, float y) -> float
+pow:	FUNC	; signature func pow(float x, float y) -> float @ 175:14
 	$x:	INPf
 	$y:	INPf
 	$a:	LOCf
@@ -122,15 +122,15 @@ pow:	FUNC	; signature func pow(float x, float y) -> float
 		SUBf $a #0.0 $a	; a = -a
 	.f1:	LEQf $a #0.0 @.f2	; if (a > 0.0) z = (float) exp((float) log(a) * y)
 		MOVf %2 $a 	; z = (float) exp((float) log(a) * y)
-		CALL &log %1 *2	; expects log(float) -> float
+		CALL &log %1 *2	; expects log(float) -> float @ 182:46
 		MULf %1 %1 $y
-		CALL &exp %0 *2	; expects exp(float) -> float
+		CALL &exp %0 *2	; expects exp(float) -> float @ 182:50
 		MOVf $z %0 
 		GOTO @.e3  
 	.f2:	LSSf $a #0.0 @.t4	; if (a < 0.0 || y <= 0.0) error("Domain error")
 		GRTf $y #0.0 @.f5
 	.t4:	MOVp %1 &.s_Domain4d7 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 183:53
 	.f5:	NOOP
 	.e3:	EQUf $a $x @.f7	; if (a != x && (y * 0.5) != floor(y * 0.5)) z = -z
 		MULf %0 $y #0.5
@@ -143,46 +143,46 @@ pow:	FUNC	; signature func pow(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-logScale:	FUNC	; signature func logScale(float x, float outFrom, float outTo) -> float
+logScale:	FUNC	; signature func logScale(float x, float outFrom, float outTo) -> float @ 187:19
 	$x:	INPf
 	$outFrom:	INPf
 	$outTo:	INPf
 ;-----------------------------------------------------------------------------
 		DIVf %1 $outTo $outFrom	; y = outFrom * (float) pow(outTo / outFrom, x)
 		MOVf %2 $x 
-		CALL &pow %0 *3	; expects pow(float, float) -> float
+		CALL &pow %0 *3	; expects pow(float, float) -> float @ 190:47
 		MULf $y $outFrom %0
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$factor:	OUTf
-decayConstant:	FUNC	; signature func decayConstant(float time, float reach) -> float
+decayConstant:	FUNC	; signature func decayConstant(float time, float reach) -> float @ 193:24
 	$time:	INPf
 	$reach:	INPf
 ;-----------------------------------------------------------------------------
 		DIVf %2 #1.0 $reach	; factor = (float) exp(-1.0 / time * (float) log(1.0 / reach))
-		CALL &log %1 *2	; expects log(float) -> float
+		CALL &log %1 *2	; expects log(float) -> float @ 196:61
 		DIVf %2 #-1.0 $time
 		MULf %1 %2 %1
-		CALL &exp %0 *2	; expects exp(float) -> float
+		CALL &exp %0 *2	; expects exp(float) -> float @ 196:62
 		MOVf $factor %0 
 		RETU   	; }
 
-HP_EPSILON:	! DEFf #1.0e-011	; signature const HP_EPSILON : float
-HP_K:	! DEFf #0.0056828256022101	; signature const HP_K : float
+HP_EPSILON:	! DEFf #1.0e-011	; signature const HP_EPSILON : float @ 201:34
+HP_K:	! DEFf #0.0056828256022101	; signature const HP_K : float @ 202:38
 	GLOB *1
-wantsReset:	DATi #FALSE	; signature global wantsReset : int
+wantsReset:	DATi #FALSE	; signature global wantsReset : int @ 206:30
 	GLOB *1
-breakLoop:	DATi #FALSE	; signature global breakLoop : int
-readRates:	GLOB *256	; signature array readRates[256] : unknown
-blockLens:	GLOB *256	; signature array blockLens[256] : unknown
-minCycles:	GLOB *256	; signature array minCycles[256] : unknown
-thresDKs:	GLOB *256	; signature array thresDKs[256] : unknown
+breakLoop:	DATi #FALSE	; signature global breakLoop : int @ 207:29
+readRates:	GLOB *256	; signature array readRates[256] : unknown @ 208:28
+blockLens:	GLOB *256	; signature array blockLens[256] : unknown @ 209:28
+minCycles:	GLOB *256	; signature array minCycles[256] : unknown @ 210:28
+thresDKs:	GLOB *256	; signature array thresDKs[256] : unknown @ 211:27
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 218:15
 	$i:	LOCi
 	$x:	LOCf
 	$minCycle:	LOCi
@@ -197,27 +197,27 @@ init:	FUNC	; signature func init() -> void
 		MOVf %1 $x 	; global readRates[i] = ftoi((float) logScale(x, 32768.0, 131072.0) + 0.5)
 		MOVf %2 #32768.0 
 		MOVf %3 #131072.0 
-		CALL &logScale %0 *4	; expects logScale(float, float, float) -> float
+		CALL &logScale %0 *4	; expects logScale(float, float, float) -> float @ 226:69
 		ADDf %0 %0 #0.5
 		fTOi %0 %0 #1.0
 		POKE &readRates $i %0
 		MOVf %1 $x 	; global blockLens[i] = ftoi((float) logScale(x, 128.0, 32768.0) + 0.5)
 		MOVf %2 #128.0 
 		MOVf %3 #32768.0 
-		CALL &logScale %0 *4	; expects logScale(float, float, float) -> float
+		CALL &logScale %0 *4	; expects logScale(float, float, float) -> float @ 227:66
 		ADDf %0 %0 #0.5
 		fTOi %0 %0 #1.0
 		POKE &blockLens $i %0
 		MOVf %1 $x 	; minCycle = ftoi((float) logScale(x, 10.0, 2000.0) + 0.5)
 		MOVf %2 #10.0 
 		MOVf %3 #2000.0 
-		CALL &logScale %0 *4	; expects logScale(float, float, float) -> float
+		CALL &logScale %0 *4	; expects logScale(float, float, float) -> float @ 228:53
 		ADDf %0 %0 #0.5
 		fTOi $minCycle %0 #1.0
 		POKE &minCycles $i $minCycle	; global minCycles[i] = minCycle
 		iTOf %1 $minCycle #1.0	; global thresDKs[i] = (float) decayConstant(itof(minCycle), 0.6666666)
 		MOVf %2 #0.6666666 
-		CALL &decayConstant %0 *3	; expects decayConstant(float, float) -> float
+		CALL &decayConstant %0 *3	; expects decayConstant(float, float) -> float @ 230:72
 		POKE &thresDKs $i %0
 		FORi $i #256 @.l1	; }
 	.e0:	POKE &blockLens:0 #0 	; global blockLens[0] = 0
@@ -226,7 +226,7 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 239:17
 ;-----------------------------------------------------------------------------
 		POKE &breakLoop #TRUE 	; global breakLoop = TRUE
 		RETU   	; }
@@ -234,7 +234,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 244:18
 	$inL:	LOCf
 	$inR:	LOCf
 	$yL:	LOCf
@@ -366,7 +366,7 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $clock 	; write(clock, 1, y2)
 		MOVi %2 #1 
 		ADRL %3 $y2 *0
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 300:23
 		MULf $thresPosL $thresPosL $thresDK	; thresPosL = thresPosL * thresDK
 		MULf $thresNegL $thresNegL $thresDK	; thresNegL = thresNegL * thresDK
 		MULf $thresPosR $thresPosR $thresDK	; thresPosR = thresPosR * thresDK
@@ -424,7 +424,7 @@ process:	FUNC	; signature func process() -> void
 		ADDi %1 $rcStartL %1
 		MOVi %2 #1 
 		ADRL %3 $y2 *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 354:76
 		ANDi %0 $y2:0 $bitCrushMask	; global signal[0] = (int) y2[0] & bitCrushMask
 		POKE &signal:0 %0 
 		SHRi %1 $playPosR #16	; read(rcStartR + ((playPosR >> 16) & rateCrushMask ^ reverseMask), 1, y2)
@@ -433,7 +433,7 @@ process:	FUNC	; signature func process() -> void
 		ADDi %1 $rcStartR %1
 		MOVi %2 #1 
 		ADRL %3 $y2 *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 356:76
 		ANDi %0 $y2:1 $bitCrushMask	; global signal[1] = (int) y2[1] & bitCrushMask
 		POKE &signal:1 %0 
 		ADDi $playPosL $playPosL $readRate	; playPosL = playPosL + readRate
@@ -454,7 +454,7 @@ process:	FUNC	; signature func process() -> void
 		SHLi $rcLenR $ccLenR #16	; rcLenR = ccLenR << 16
 		MOVi $newRCR #FALSE 	; newRCR = FALSE
 	.f31:	MOVi $playPosR #0 	; playPosR = 0
-	.f29:	CALL ^yield %0 *1	; expects function() -> unknown
+	.f29:	CALL ^yield %0 *1	; expects function() -> unknown @ 379:11
 		GOTO @.l3  	; }
 		GOTO @.l0  	; }
 		RETU   	; }

--- a/tests/impala/golden/multitap_code.gazl
+++ b/tests/impala/golden/multitap_code.gazl
@@ -1,49 +1,49 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 10:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 11:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 13:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 13:33
 	DATA &.s_BITSCL4d2 &.s_SINSAM4d3 &.s_ROTSRA4d4
 	DATA &.s_DLYLEF4d5 &.s_SHARPS4d6 &.s_SHARPF4d7
 	DATA &.s_SMOOTH4d8 &.s_SMOOTH4d9
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 25:1
+; signature extern native trace() -> unknown @ 26:1
+; signature extern native yield() -> unknown @ 27:1
+; signature extern native write() -> unknown @ 28:1
+; signature extern native read() -> unknown @ 30:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 49:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 50:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 51:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 52:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 58:1
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 59:1
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 60:1
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 61:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 62:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 63:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 64:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 65:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 67:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 67:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 69:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 70:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 73:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -57,16 +57,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 80:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4da 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 83:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float)trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 84:35
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -74,7 +74,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 98:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -83,7 +83,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 102:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -106,32 +106,32 @@ cos:	FUNC	; signature func cos(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sin:	FUNC	; signature func sin(float x) -> float
+sin:	FUNC	; signature func sin(float x) -> float @ 114:14
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		SUBf %1 $x #HALF_PI	; y = (float) cos(x - HALF_PI)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 117:30
 		MOVf $y %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 130:15
 ;-----------------------------------------------------------------------------
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 138:17
 ;-----------------------------------------------------------------------------
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 142:18
 	$tapped:	LOCA *2
 	$mix:	LOCA *2
 	$localClock:	LOCi
@@ -151,7 +151,7 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $localClock 	; write(localClock, 1, global signal)
 		MOVi %2 #1 
 		MOVp %3 &signal 
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 148:37
 		MOVf $mix:0 #0.0 	; mix[0] = 0.0
 		MOVf $mix:1 #0.0 	; mix[1] = 0.0
 		MOVi $i #0 	; for (i = 0 to 16) 
@@ -163,7 +163,7 @@ process:	FUNC	; signature func process() -> void
 		SUBi %1 $localClock %1
 		MOVi %2 #1 
 		ADRL %3 $tapped *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 153:44
 		! DIVf <A> #1.0 #2048.0	; tapped[0] = itof((int) tapped[0]) * (1.0 / 2048.0)
 		iTOf $tapped:0 $tapped:0 <A>
 		ADDf $mix:0 $mix:0 $tapped:0	; mix[0] = (float) mix[0] + (float) tapped[0]
@@ -174,7 +174,7 @@ process:	FUNC	; signature func process() -> void
 		SUBi %1 $localClock %1
 		MOVi %2 #1 
 		ADRL %3 $tapped *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 158:44
 		! DIVf <A> #1.0 #2048.0	; tapped[1] = itof((int) tapped[1]) * (1.0 / 2048.0)
 		iTOf $tapped:1 $tapped:1 <A>
 		ADDf $mix:1 $mix:1 $tapped:1	; mix[1] = (float) mix[1] + (float) tapped[1]

--- a/tests/impala/golden/nobuffer.gazl
+++ b/tests/impala/golden/nobuffer.gazl
@@ -1,51 +1,51 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-PANEL_TEXT_ROWS:	CNST *8	; signature array PANEL_TEXT_ROWS[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 8:1
+PANEL_TEXT_ROWS:	CNST *8	; signature array PANEL_TEXT_ROWS[8] : unknown @ 16:35
 	DATA &.s_ABC8884d2 &.s_ABC8884d2 &.s_RM4d3 &.s_AMRATE4d4
 	DATA &.s_notuse4d5 &.s_toollo4d6 &.s_74d7 &.s_ILOVEP4d8
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
+; signature extern native abort() -> unknown @ 28:1
+; signature extern native trace() -> unknown @ 29:1
+; signature extern native yield() -> unknown @ 31:1
 	GLOB *1
-left:	DATi #0	; signature global left : int
+left:	DATi #0	; signature global left : int @ 51:1
 	GLOB *1
-right:	DATi #0	; signature global right : int
+right:	DATi #0	; signature global right : int @ 52:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
+clock:	DATi #0	; signature global clock : int @ 53:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 54:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+instance:	DATi #0	; signature global instance : int @ 58:1
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 59:1
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 60:1
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 61:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 62:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 63:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 64:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
-SQRT_2:	! DEFf #1.41421356237309504880	; signature const SQRT_2 : float
-EPSILON_FLOAT:	! DEFf #1.0e-45	; signature const EPSILON_FLOAT : float
-SMALL_FLOAT:	! DEFf #1.0e-5	; signature const SMALL_FLOAT : float
-LARGE_FLOAT:	! DEFf #1.0e+10	; signature const LARGE_FLOAT : float
-HUGE_FLOAT:	! DEFf #1.0e+38	; signature const HUGE_FLOAT : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 65:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 66:1
+SQRT_2:	! DEFf #1.41421356237309504880	; signature const SQRT_2 : float @ 68:1
+EPSILON_FLOAT:	! DEFf #1.0e-45	; signature const EPSILON_FLOAT : float @ 69:1
+SMALL_FLOAT:	! DEFf #1.0e-5	; signature const SMALL_FLOAT : float @ 70:1
+LARGE_FLOAT:	! DEFf #1.0e+10	; signature const LARGE_FLOAT : float @ 71:1
+HUGE_FLOAT:	! DEFf #1.0e+38	; signature const HUGE_FLOAT : float @ 73:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 73:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 75:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 76:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 79:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -59,16 +59,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 86:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4d9 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 89:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float) trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 90:36
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -76,7 +76,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 104:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -85,7 +85,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 108:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -108,18 +108,18 @@ cos:	FUNC	; signature func cos(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sin:	FUNC	; signature func sin(float x) -> float
+sin:	FUNC	; signature func sin(float x) -> float @ 121:14
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		SUBf %1 $x #HALF_PI	; y = (float) cos(x - HALF_PI)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 124:30
 		MOVf $y %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr
+intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr @ 132:22
 	$i:	INPi
 	$radix:	INPi
 	$minLength:	INPi
@@ -166,7 +166,7 @@ intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, 
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr buffer) -> ptr
+floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr buffer) -> ptr @ 151:24
 	$f:	INPf
 	$precision:	INPi
 	$buffer:	INPp
@@ -303,7 +303,7 @@ floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr b
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInt:	FUNC	; signature func traceInt(int i) -> void
+traceInt:	FUNC	; signature func traceInt(int i) -> void @ 260:19
 	$i:	INPi
 	! ADDi <A> #GAZL_WORD_SIZE #2
 	$buffer:	LOCA *<A>
@@ -312,58 +312,58 @@ traceInt:	FUNC	; signature func traceInt(int i) -> void
 		MOVi %3 #10 
 		MOVi %4 #1 
 		ADRL %5 $buffer *0
-		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr @ 263:37
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 263:38
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceFloat:	FUNC	; signature func traceFloat(float f) -> void
+traceFloat:	FUNC	; signature func traceFloat(float f) -> void @ 266:21
 	$f:	INPf
 	$buffer:	LOCA *32
 ;-----------------------------------------------------------------------------
 		MOVf %2 $f 	; trace(floatToString(f, 6, buffer))
 		MOVi %3 #6 
 		ADRL %4 $buffer *0
-		CALL &floatToString %1 *4	; expects floatToString(float, int, ptr) -> ptr
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL &floatToString %1 *4	; expects floatToString(float, int, ptr) -> ptr @ 269:35
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 269:36
 		RETU   	; }
 
-BUFFER_SIZE:	! DEFi #256	; signature const BUFFER_SIZE : int
+BUFFER_SIZE:	! DEFi #256	; signature const BUFFER_SIZE : int @ 275:1
 	GLOB *1
-lpx:	DATf #0.0	; signature global lpx : float
+lpx:	DATf #0.0	; signature global lpx : float @ 276:1
 	GLOB *1
-lpy:	DATf #0.0	; signature global lpy : float
+lpy:	DATf #0.0	; signature global lpy : float @ 277:1
 	GLOB *1
-rpx:	DATf #0.0	; signature global rpx : float
+rpx:	DATf #0.0	; signature global rpx : float @ 278:1
 	GLOB *1
-rpy:	DATf #0.0	; signature global rpy : float
+rpy:	DATf #0.0	; signature global rpy : float @ 279:1
 	GLOB *1
-lrx:	DATf #0.0	; signature global lrx : float
+lrx:	DATf #0.0	; signature global lrx : float @ 280:1
 	GLOB *1
-lry:	DATf #0.0	; signature global lry : float
+lry:	DATf #0.0	; signature global lry : float @ 281:1
 	GLOB *1
-rrx:	DATf #0.0	; signature global rrx : float
+rrx:	DATf #0.0	; signature global rrx : float @ 282:1
 	GLOB *1
-rry:	DATf #0.0	; signature global rry : float
+rry:	DATf #0.0	; signature global rry : float @ 283:1
 	GLOB *1
-bufferIndex:	DATi #BUFFER_SIZE	; signature global bufferIndex : int
-lbuffer:	GLOB *4096	; signature array lbuffer[4096] : unknown
-rbuffer:	GLOB *4096	; signature array rbuffer[4096] : unknown
+bufferIndex:	DATi #BUFFER_SIZE	; signature global bufferIndex : int @ 284:1
+lbuffer:	GLOB *4096	; signature array lbuffer[4096] : unknown @ 285:1
+rbuffer:	GLOB *4096	; signature array rbuffer[4096] : unknown @ 292:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 292:15
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4dd 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 294:15
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 301:16
 	$a:	LOCf
 	$lr:	LOCf
 	$rr:	LOCf
@@ -372,7 +372,7 @@ reset:	FUNC	; signature func reset() -> void
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4de 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 304:16
 		MOVf $a #1024.0 	; a = 1024.0
 		! MULf <A> #TWICE_PI #440.0	; lr = TWICE_PI * 440.0 / 44100.0
 		! DIVf <A> <A> #44100.0
@@ -382,36 +382,36 @@ reset:	FUNC	; signature func reset() -> void
 		MOVf $rr <A> 
 		MOVf $p0 #0.0 	; p0 = 0.0
 		MOVf %1 $p0 	; global lpx = (float) cos(p0) * a
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 309:31
 		MULf %0 %0 $a
 		POKE &lpx %0 
 		MOVf %1 $p0 	; global lpy = (float) sin(p0) * a
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 310:31
 		MULf %0 %0 $a
 		POKE &lpy %0 
 		MULf %1 $lr #0.5	; t = SQRT_2 * (float) sin(lr * 0.5)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 311:36
 		MULf $t #SQRT_2 %0
 		MULf %0 $t $t	; global lrx = t * t
 		POKE &lrx %0 
 		MOVf %1 $lr 	; global lry = (float) sin(lr)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 313:30
 		POKE &lry %0 
 		MOVf %1 $p0 	; global rpx = (float) cos(p0) * a
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 314:31
 		MULf %0 %0 $a
 		POKE &rpx %0 
 		MOVf %1 $p0 	; global rpy = (float) sin(p0) * a
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 315:31
 		MULf %0 %0 $a
 		POKE &rpy %0 
 		MULf %1 $rr #0.5	; t = SQRT_2 * (float) sin(rr * 0.5)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 316:36
 		MULf $t #SQRT_2 %0
 		MULf %0 $t $t	; global rrx = t * t
 		POKE &rrx %0 
 		MOVf %1 $rr 	; global rry = (float) sin(rr)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 318:30
 		POKE &rry %0 
 		POKE &bufferIndex #BUFFER_SIZE 	; global bufferIndex = BUFFER_SIZE
 		RETU   	; }
@@ -419,23 +419,23 @@ reset:	FUNC	; signature func reset() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 326:17
 	$buf:	LOCA *34
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_update4df 	; trace("update")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 329:17
 		PEEK %2 &params:OPERAND_2_PARAM_INDEX 	; trace(intToString(global params[OPERAND_2_PARAM_INDEX], 16, 1, buf))
 		MOVi %3 #16 
 		MOVi %4 #1 
 		ADRL %5 $buf *0
-		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr @ 330:69
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 330:70
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 341:18
 	$nx:	LOCf
 	$lpx:	LOCf
 	$lpy:	LOCf

--- a/tests/impala/golden/patch.gazl
+++ b/tests/impala/golden/patch.gazl
@@ -1,33 +1,33 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-; signature extern native output() -> unknown
-; signature extern native input() -> unknown
-; signature extern native inputEOF() -> unknown
-; signature extern native sleep() -> unknown
-; signature extern native findFirmwarePatch() -> unknown
-; signature extern native patchFirmware() -> unknown
-; signature extern native readGUIVariable() -> unknown
-; signature extern native writeGUIVariable() -> unknown
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-MAX_PATCHES:	! DEFi #64	; signature const MAX_PATCHES : int
-MAX_PATCH_NAME_LENGTH:	! DEFi #31	; signature const MAX_PATCH_NAME_LENGTH : int
-FILE_MEMORY_SIZE:	! DEFi #8000	; signature const FILE_MEMORY_SIZE : int
-lastPatch:	GLOB *256	; signature array lastPatch[256] : unknown
-lastConfig:	GLOB *256	; signature array lastConfig[256] : unknown
+; signature extern native output() -> unknown @ 8:1
+; signature extern native input() -> unknown @ 9:1
+; signature extern native inputEOF() -> unknown @ 10:1
+; signature extern native sleep() -> unknown @ 11:1
+; signature extern native findFirmwarePatch() -> unknown @ 12:1
+; signature extern native patchFirmware() -> unknown @ 13:1
+; signature extern native readGUIVariable() -> unknown @ 14:1
+; signature extern native writeGUIVariable() -> unknown @ 16:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 17:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 19:1
+MAX_PATCHES:	! DEFi #64	; signature const MAX_PATCHES : int @ 20:1
+MAX_PATCH_NAME_LENGTH:	! DEFi #31	; signature const MAX_PATCH_NAME_LENGTH : int @ 21:1
+FILE_MEMORY_SIZE:	! DEFi #8000	; signature const FILE_MEMORY_SIZE : int @ 23:1
+lastPatch:	GLOB *256	; signature array lastPatch[256] : unknown @ 24:1
+lastConfig:	GLOB *256	; signature array lastConfig[256] : unknown @ 25:1
 	GLOB *1
-patchCount:	DATi #-1	; signature global patchCount : int
+patchCount:	DATi #-1	; signature global patchCount : int @ 26:1
 	! ADDi <A> #MAX_PATCH_NAME_LENGTH #1
 	! MULi <A> #MAX_PATCHES <A>
-patchNames:	GLOB *<A>	; signature array patchNames[<A>] : unknown
+patchNames:	GLOB *<A>	; signature array patchNames[<A>] : unknown @ 27:1
 	GLOB *1
-displayedPatchingInfo:	DATi #FALSE	; signature global displayedPatchingInfo : int
-fileMemory:	GLOB *FILE_MEMORY_SIZE	; signature array fileMemory[FILE_MEMORY_SIZE] : unknown
+displayedPatchingInfo:	DATi #FALSE	; signature global displayedPatchingInfo : int @ 29:1
+fileMemory:	GLOB *FILE_MEMORY_SIZE	; signature array fileMemory[FILE_MEMORY_SIZE] : unknown @ 31:1
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTp
-strcpy:	FUNC	; signature func strcpy(ptr d, ptr s) -> ptr
+strcpy:	FUNC	; signature func strcpy(ptr d, ptr s) -> ptr @ 31:17
 	$d:	INPp
 	$s:	INPp
 	$a:	LOCp
@@ -47,7 +47,7 @@ strcpy:	FUNC	; signature func strcpy(ptr d, ptr s) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$d:	OUTi
-strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int
+strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int @ 43:17
 	$s0:	INPp
 	$s1:	INPp
 	$a:	LOCp
@@ -69,7 +69,7 @@ strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int
 
 ;-----------------------------------------------------------------------------
 	$d:	OUTi
-stricmp:	FUNC	; signature func stricmp(ptr s0, ptr s1) -> int
+stricmp:	FUNC	; signature func stricmp(ptr s0, ptr s1) -> int @ 55:18
 	$s0:	INPp
 	$s1:	INPp
 	$a:	LOCp
@@ -101,7 +101,7 @@ stricmp:	FUNC	; signature func stricmp(ptr s0, ptr s1) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-upper:	FUNC	; signature func upper(ptr s) -> void
+upper:	FUNC	; signature func upper(ptr s) -> void @ 74:16
 	$s:	INPp
 	$p:	LOCp
 	$c:	LOCi
@@ -121,46 +121,46 @@ upper:	FUNC	; signature func upper(ptr s) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-outputLF:	FUNC	; signature func outputLF() -> void
+outputLF:	FUNC	; signature func outputLF() -> void @ 84:19
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_4d2 	; output("\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 86:14
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-outputLine:	FUNC	; signature func outputLine(ptr s) -> void
+outputLine:	FUNC	; signature func outputLine(ptr s) -> void @ 89:21
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; output(s)
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
-		CALL &outputLF %0 *1	; expects outputLF() -> void
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 91:11
+		CALL &outputLF %0 *1	; expects outputLF() -> void @ 92:12
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-help:	FUNC	; signature func help() -> void
+help:	FUNC	; signature func help() -> void @ 95:15
 ;-----------------------------------------------------------------------------
-		CALL &outputLF %0 *1	; expects outputLF() -> void
+		CALL &outputLF %0 *1	; expects outputLF() -> void @ 97:12
 		MOVp %1 &.s_Typeli4d3 	; outputLine("Type \"list\" to list available firmware patches.")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 98:65
 		MOVp %1 &.s_Enterp4d4 	; outputLine("Enter patch name to begin firmware patching.")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 99:60
 		MOVp %1 &.s_Presse4d5 	; outputLine("Press enter only to retry last patching.")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 100:56
 		MOVp %1 &.s_Typere4d6 	; outputLine("Type \"restore\" to restore factory firmware.")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 101:61
 		MOVp %1 &.s_Typequ4d7 	; outputLine("Type \"quit\" to quit.")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
-		CALL &outputLF %0 *1	; expects outputLF() -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 102:38
+		CALL &outputLF %0 *1	; expects outputLF() -> void @ 103:12
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-refreshPatchList:	FUNC	; signature func refreshPatchList() -> void
+refreshPatchList:	FUNC	; signature func refreshPatchList() -> void @ 106:27
 	! ADDi <A> #MAX_PATCH_NAME_LENGTH #1
 	! ADDi <A> #8 #1
 	$p:	LOCp
@@ -182,7 +182,7 @@ refreshPatchList:	FUNC	; signature func refreshPatchList() -> void
 		MOVp %3 $p 
 		ADRL %4 $size *0
 		ADRL %5 $modDate *0
-		CALL ^findFirmwarePatch %0 *6	; expects function(int, int, ptr, ptr, ptr) -> unknown
+		CALL ^findFirmwarePatch %0 *6	; expects function(int, int, ptr, ptr, ptr) -> unknown @ 114:83
 		NEQi %0 #FALSE @.l0
 		LEQi $index #MAX_PATCHES @.f3	; if (index > MAX_PATCHES) index = MAX_PATCHES
 		MOVi $index #MAX_PATCHES 	; index = MAX_PATCHES
@@ -192,12 +192,12 @@ refreshPatchList:	FUNC	; signature func refreshPatchList() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-list:	FUNC	; signature func list() -> void
+list:	FUNC	; signature func list() -> void @ 119:15
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
-		CALL &refreshPatchList %0 *1	; expects refreshPatchList() -> void
+		CALL &refreshPatchList %0 *1	; expects refreshPatchList() -> void @ 122:20
 		MOVp %1 &.s_Availa4d8 	; output("Available firmwares: ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 123:33
 		MOVi $i #0 	; for (i = 0 to global patchCount) 
 		PEEK %0 &patchCount 
 		GEQi #0 %0 @.e0
@@ -205,49 +205,49 @@ list:	FUNC	; signature func list() -> void
 		! ADDi <A> #MAX_PATCH_NAME_LENGTH #1	; output(&global patchNames[i * (MAX_PATCH_NAME_LENGTH + 1)])
 		MULi %2 $i <A>
 		ADDp %2 &patchNames %2
-		CALL ^output %1 *2	; expects function(ptr) -> unknown
+		CALL ^output %1 *2	; expects function(ptr) -> unknown @ 125:62
 		MOVp %2 &.s_Availa4d8:20 	; output(" ")
-		CALL ^output %1 *2	; expects function(ptr) -> unknown
+		CALL ^output %1 *2	; expects function(ptr) -> unknown @ 126:14
 		FORi $i %0 @.l1	; }
-	.e0:	CALL &outputLF %0 *1	; expects outputLF() -> void
-		CALL &outputLF %0 *1	; expects outputLF() -> void
+	.e0:	CALL &outputLF %0 *1	; expects outputLF() -> void @ 128:12
+		CALL &outputLF %0 *1	; expects outputLF() -> void @ 129:12
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-restore:	FUNC	; signature func restore() -> void
+restore:	FUNC	; signature func restore() -> void @ 132:18
 	$error:	LOCA *256
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_Restor4d9 	; outputLine("Restoring factory firmware. Do not power off...")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 135:63
 		MOVp %1 &NULL 	; if ((int)patchFirmware(null, null, 255, error) != 0) 
 		MOVp %2 &NULL 
 		MOVi %3 #255 
 		ADRL %4 $error *0
-		CALL ^patchFirmware %0 *5	; expects function(ptr, ptr, int, ptr) -> unknown
+		CALL ^patchFirmware %0 *5	; expects function(ptr, ptr, int, ptr) -> unknown @ 137:49
 		EQUi %0 #0 @.f0
 		MOVi %1 #500 	; sleep(500)
-		CALL ^sleep %0 *2	; expects function(int) -> unknown
+		CALL ^sleep %0 *2	; expects function(int) -> unknown @ 138:13
 		MOVp %1 &.s_Patchi4da 	; outputLine("Patching failed.")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 139:33
 		ADRL %1 $error *0	; outputLine(error)
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 140:20
 		GOTO @.e1  	; } else 
 	.f0:	MOVi %1 #500 	; sleep(500)
-		CALL ^sleep %0 *2	; expects function(int) -> unknown
+		CALL ^sleep %0 *2	; expects function(int) -> unknown @ 142:13
 		MOVp %1 &.s_Restor4db 	; outputLine("Restore successful.")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 143:36
 		MOVp %1 &.s_aboutd4dc 	; writeGUIVariable("about.displayedCRC", "0")
 		MOVp %2 &.s_04dd 
-		CALL ^writeGUIVariable %0 *3	; expects function(ptr, ptr) -> unknown
-	.e1:	CALL &outputLF %0 *1	; expects outputLF() -> void
+		CALL ^writeGUIVariable %0 *3	; expects function(ptr, ptr) -> unknown @ 144:46
+	.e1:	CALL &outputLF %0 *1	; expects outputLF() -> void @ 146:12
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-patch:	FUNC	; signature func patch(ptr name, ptr config) -> void
+patch:	FUNC	; signature func patch(ptr name, ptr config) -> void @ 149:16
 	$name:	INPp
 	$config:	INPp
 	$buffer1:	LOCA *256
@@ -257,7 +257,7 @@ patch:	FUNC	; signature func patch(ptr name, ptr config) -> void
 ;-----------------------------------------------------------------------------
 		PEEK %0 &patchCount 	; if (global patchCount < 0) refreshPatchList()
 		GEQi %0 #0 @.f0
-		CALL &refreshPatchList %0 *1	; expects refreshPatchList() -> void
+		CALL &refreshPatchList %0 *1	; expects refreshPatchList() -> void @ 152:47
 	.f0:	MOVi $i #0 	; for (i = 0 to global patchCount) 
 		PEEK %0 &patchCount 
 		GEQi #0 %0 @.e1
@@ -267,129 +267,129 @@ patch:	FUNC	; signature func patch(ptr name, ptr config) -> void
 		ADDp $p &patchNames %1
 		MOVp %2 $name 	; if ((int)stricmp(name, p) == 0) 
 		MOVp %3 $p 
-		CALL &stricmp %1 *3	; expects stricmp(ptr, ptr) -> int
+		CALL &stricmp %1 *3	; expects stricmp(ptr, ptr) -> int @ 156:29
 		NEQi %1 #0 @.f3
 		MOVp %2 &.s_Patchi4de 	; outputLine("Patching firmware. Do not power off...")
-		CALL &outputLine %1 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %1 *2	; expects outputLine(ptr) -> void @ 157:56
 		MOVp %2 $p 	; if ((int)patchFirmware(p, config, 255, buffer1) != 0) 
 		MOVp %3 $config 
 		MOVi %4 #255 
 		ADRL %5 $buffer1 *0
-		CALL ^patchFirmware %1 *5	; expects function(ptr, ptr, int, ptr) -> unknown
+		CALL ^patchFirmware %1 *5	; expects function(ptr, ptr, int, ptr) -> unknown @ 158:52
 		EQUi %1 #0 @.f4
 		MOVi %2 #500 	; sleep(500)
-		CALL ^sleep %1 *2	; expects function(int) -> unknown
+		CALL ^sleep %1 *2	; expects function(int) -> unknown @ 159:15
 		MOVp %2 &.s_Patchi4df 	; output("Patching failed: ")
-		CALL ^output %1 *2	; expects function(ptr) -> unknown
+		CALL ^output %1 *2	; expects function(ptr) -> unknown @ 160:32
 		ADRL %2 $buffer1 *0	; outputLine(buffer1)
-		CALL &outputLine %1 *2	; expects outputLine(ptr) -> void
-		CALL &outputLF %1 *1	; expects outputLF() -> void
+		CALL &outputLine %1 *2	; expects outputLine(ptr) -> void @ 161:24
+		CALL &outputLF %1 *1	; expects outputLF() -> void @ 162:15
 		GOTO @.e5  	; } else 
 	.f4:	MOVi %2 #500 	; sleep(500)
-		CALL ^sleep %1 *2	; expects function(int) -> unknown
+		CALL ^sleep %1 *2	; expects function(int) -> unknown @ 164:15
 		MOVp %2 &.s_Patchi4e0 	; outputLine("Patching successful.")
-		CALL &outputLine %1 *2	; expects outputLine(ptr) -> void
-		CALL &outputLF %1 *1	; expects outputLF() -> void
+		CALL &outputLine %1 *2	; expects outputLine(ptr) -> void @ 165:39
+		CALL &outputLF %1 *1	; expects outputLF() -> void @ 166:15
 		MOVp %2 &.s_firmwa4e1 	; readGUIVariable("firmware.aboutCRC", 255, buffer1)
 		MOVi %3 #255 
 		ADRL %4 $buffer1 *0
-		CALL ^readGUIVariable %1 *4	; expects function(ptr, int, ptr) -> unknown
+		CALL ^readGUIVariable %1 *4	; expects function(ptr, int, ptr) -> unknown @ 167:55
 		MOVp %2 &.s_aboutd4dc 	; readGUIVariable("about.displayedCRC", 255, buffer2)
 		MOVi %3 #255 
 		ADRL %4 $buffer2 *0
-		CALL ^readGUIVariable %1 *4	; expects function(ptr, int, ptr) -> unknown
+		CALL ^readGUIVariable %1 *4	; expects function(ptr, int, ptr) -> unknown @ 168:56
 		ADRL %2 $buffer1 *0	; if ((int) strcmp(buffer1, buffer2) != 0) 
 		ADRL %3 $buffer2 *0
-		CALL &strcmp %1 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %1 *3	; expects strcmp(ptr, ptr) -> int @ 169:40
 		EQUi %1 #0 @.f6
 		MOVp %2 &.s_aboutd4dc 	; writeGUIVariable("about.displayedCRC", buffer1)
 		ADRL %3 $buffer1 *0
-		CALL ^writeGUIVariable %1 *3	; expects function(ptr, ptr) -> unknown
+		CALL ^writeGUIVariable %1 *3	; expects function(ptr, ptr) -> unknown @ 170:53
 		MOVp %2 &.s_firmwa4e2 	; readGUIVariable("firmware.about", FILE_MEMORY_SIZE - 1, global fileMemory)
 		SUBi %3 #FILE_MEMORY_SIZE #1
 		MOVp %4 &fileMemory 
-		CALL ^readGUIVariable %1 *4	; expects function(ptr, int, ptr) -> unknown
+		CALL ^readGUIVariable %1 *4	; expects function(ptr, int, ptr) -> unknown @ 171:80
 		PEEK %1 &fileMemory:0 	; if ((int) global fileMemory[0] != 0) 
 		EQUi %1 #0 @.f6
 		MOVp %2 &fileMemory 	; output(global fileMemory)
-		CALL ^output %1 *2	; expects function(ptr) -> unknown
-		CALL &outputLF %1 *1	; expects outputLF() -> void
+		CALL ^output %1 *2	; expects function(ptr) -> unknown @ 173:32
+		CALL &outputLF %1 *1	; expects outputLF() -> void @ 174:17
 	.f6:	PEEK %1 &displayedPatchingInfo 	; if (global displayedPatchingInfo == FALSE) 
 		NEQi %1 #FALSE @.f8
 		POKE &displayedPatchingInfo #TRUE 	; global displayedPatchingInfo = TRUE
 		MOVp %2 &.s_Ifyous4e3 	; outputLine("If you save the Permut8 Program Bank this firmware code will be included.")
-		CALL &outputLine %1 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %1 *2	; expects outputLine(ptr) -> void @ 179:93
 		MOVp %2 &.s_Ifyoum4e4 	; outputLine("If you modify the .gazl file, the firmware will auto-update until GUI is closed.")
-		CALL &outputLine %1 *2	; expects outputLine(ptr) -> void
+		CALL &outputLine %1 *2	; expects outputLine(ptr) -> void @ 180:100
 	.f8:	NOOP
 	.e5:	MOVp %2 &lastPatch 	; strcpy(global lastPatch, p)
 		MOVp %3 $p 
-		CALL &strcpy %1 *3	; expects strcpy(ptr, ptr) -> ptr
+		CALL &strcpy %1 *3	; expects strcpy(ptr, ptr) -> ptr @ 183:31
 		MOVp %2 &lastConfig 	; strcpy(global lastConfig, config)
 		MOVp %3 $config 
-		CALL &strcpy %1 *3	; expects strcpy(ptr, ptr) -> ptr
+		CALL &strcpy %1 *3	; expects strcpy(ptr, ptr) -> ptr @ 184:37
 		GOTO @found  	; goto found
 	.f3:	FORi $i %0 @.l2	; }
 	.e1:	MOVp %1 &.s_Firmwa4e5 	; outputLine("Firmware not found.")
-		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void
-		CALL &list %0 *1	; expects list() -> void
+		CALL &outputLine %0 *2	; expects outputLine(ptr) -> void @ 189:35
+		CALL &list %0 *1	; expects list() -> void @ 190:8
 	found:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-repatch:	FUNC	; signature func repatch() -> void
+repatch:	FUNC	; signature func repatch() -> void @ 195:18
 ;-----------------------------------------------------------------------------
 		PEEK %0 &lastPatch:0 	; if ((int)global lastPatch[0] == 0) help()
 		NEQi %0 #0 @.f0
-		CALL &help %0 *1	; expects help() -> void
+		CALL &help %0 *1	; expects help() -> void @ 197:43
 		GOTO @.e1  
 	.f0:	MOVp %1 &lastPatch 	; patch(global lastPatch, global lastConfig)
 		MOVp %2 &lastConfig 
-		CALL &patch %0 *3	; expects patch(ptr, ptr) -> void
+		CALL &patch %0 *3	; expects patch(ptr, ptr) -> void @ 198:49
 	.e1:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 201:15
 	$s:	LOCA *256
 	$p:	LOCp
 	$c:	LOCi
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_Permut4e6 	; output("\nPermut8 firmware patch utility v1.0.\n\n")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 204:54
 	.l0:	MOVp %1 &.s_patch4e7 	; output("patch> ")
-		CALL ^output %0 *2	; expects function(ptr) -> unknown
+		CALL ^output %0 *2	; expects function(ptr) -> unknown @ 207:20
 		MOVi %1 #255 	; input(255, s)
 		ADRL %2 $s *0
-		CALL ^input %0 *3	; expects function(int, ptr) -> unknown
+		CALL ^input %0 *3	; expects function(int, ptr) -> unknown @ 208:16
 		ADRL %1 $s *0	; if ((int)stricmp(s, "QUIT") == 0) goto quit
 		MOVp %2 &.s_QUIT4e8 
-		CALL &stricmp %0 *3	; expects stricmp(ptr, ptr) -> int
+		CALL &stricmp %0 *3	; expects stricmp(ptr, ptr) -> int @ 209:31
 		NEQi %0 #0 @.f1
 		GOTO @quit  	; goto quit
 		GOTO @.l0  
 	.f1:	ADRL %1 $s *0	; if ((int)stricmp(s, "LIST") == 0) list()
 		MOVp %2 &.s_LIST4e9 
-		CALL &stricmp %0 *3	; expects stricmp(ptr, ptr) -> int
+		CALL &stricmp %0 *3	; expects stricmp(ptr, ptr) -> int @ 210:36
 		NEQi %0 #0 @.f3
-		CALL &list %0 *1	; expects list() -> void
+		CALL &list %0 *1	; expects list() -> void @ 210:48
 		GOTO @.l0  
 	.f3:	ADRL %1 $s *0	; if ((int)stricmp(s, "RESTORE") == 0) restore()
 		MOVp %2 &.s_RESTOR4ea 
-		CALL &stricmp %0 *3	; expects stricmp(ptr, ptr) -> int
+		CALL &stricmp %0 *3	; expects stricmp(ptr, ptr) -> int @ 211:39
 		NEQi %0 #0 @.f5
-		CALL &restore %0 *1	; expects restore() -> void
+		CALL &restore %0 *1	; expects restore() -> void @ 211:54
 		GOTO @.l0  
 	.f5:	NEQi $s:0 #0 @.f7	; if ((int)s[0] == 0) repatch()
-		CALL &repatch %0 *1	; expects repatch() -> void
+		CALL &repatch %0 *1	; expects repatch() -> void @ 212:37
 		GOTO @.l0  
 	.f7:	ADRL %1 $s *0	; if ((int)stricmp(s, "HELP") == 0) help()
 		MOVp %2 &.s_HELP4eb 
-		CALL &stricmp %0 *3	; expects stricmp(ptr, ptr) -> int
+		CALL &stricmp %0 *3	; expects stricmp(ptr, ptr) -> int @ 213:36
 		NEQi %0 #0 @.f9
-		CALL &help %0 *1	; expects help() -> void
+		CALL &help %0 *1	; expects help() -> void @ 213:48
 		GOTO @.l0  
 	.f9:	ADRL $p $s *0	; p = s
 	.l11:	PEEK $c $p 	; while ((c = (int)*p) != 0 && c != ' ') p = p + 1
@@ -405,7 +405,7 @@ main:	FUNC	; signature func main() -> void
 		GOTO @.l14  	; }
 	.e15:	ADRL %1 $s *0	; patch(s, p)
 		MOVp %2 $p 
-		CALL &patch %0 *3	; expects patch(ptr, ptr) -> void
+		CALL &patch %0 *3	; expects patch(ptr, ptr) -> void @ 221:15
 	.e10:	NOOP
 	.e8:	NOOP
 	.e6:	NOOP

--- a/tests/impala/golden/patchDemo1.gazl
+++ b/tests/impala/golden/patchDemo1.gazl
@@ -1,32 +1,32 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-; signature extern native sin() -> unknown
-; signature extern native cos() -> unknown
-; signature extern native tan() -> unknown
-; signature extern native asin() -> unknown
-; signature extern native acos() -> unknown
-; signature extern native atan() -> unknown
-; signature extern native exp() -> unknown
-; signature extern native log() -> unknown
-; signature extern native pow() -> unknown
-; signature extern native sqrt() -> unknown
-; signature extern native fillArray() -> unknown
-; signature extern native multiplyArray() -> unknown
-; signature extern native multiplyArrays() -> unknown
-; signature extern native addArray() -> unknown
-; signature extern native addArrays() -> unknown
-; signature extern native updateParameters() -> unknown
-; signature extern native getFrame() -> unknown
-; signature extern native putFrame() -> unknown
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
+; signature extern native sin() -> unknown @ 1:18
+; signature extern native cos() -> unknown @ 2:18
+; signature extern native tan() -> unknown @ 3:18
+; signature extern native asin() -> unknown @ 4:19
+; signature extern native acos() -> unknown @ 5:19
+; signature extern native atan() -> unknown @ 6:19
+; signature extern native exp() -> unknown @ 7:18
+; signature extern native log() -> unknown @ 8:18
+; signature extern native pow() -> unknown @ 9:18
+; signature extern native sqrt() -> unknown @ 10:19
+; signature extern native fillArray() -> unknown @ 11:24
+; signature extern native multiplyArray() -> unknown @ 12:28
+; signature extern native multiplyArrays() -> unknown @ 13:29
+; signature extern native addArray() -> unknown @ 14:23
+; signature extern native addArrays() -> unknown @ 15:24
+; signature extern native updateParameters() -> unknown @ 16:31
+; signature extern native getFrame() -> unknown @ 17:23
+; signature extern native putFrame() -> unknown @ 18:23
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 20:42
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 42:40
+FALSE:	! DEFi #0	; signature const FALSE : int @ 44:20
+TRUE:	! DEFi #1	; signature const TRUE : int @ 45:19
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 47:15
 	$r:	LOCf
 	$k:	LOCf
 	$g0:	LOCf
@@ -69,7 +69,7 @@ main:	FUNC	; signature func main() -> void
 		MOVf $d0zR #0.0 
 		MOVf $dxzR #0.0 
 	.l0:	ADRL %1 $params *0	; if ((int)updateParameters(params) != FALSE) 
-		CALL ^updateParameters %0 *2	; expects function(ptr) -> unknown
+		CALL ^updateParameters %0 *2	; expects function(ptr) -> unknown @ 60:37
 		EQUi %0 #FALSE @.f1
 		! DIVf <A> #1.0 #255.0	; rq = itof((int)params[OPERAND_1_HIGH_PARAM_INDEX]) * (1.0 / 255.0 * 2.0)
 		! MULf <A> <A> #2.0
@@ -82,11 +82,11 @@ main:	FUNC	; signature func main() -> void
 		ADDf %1 #1.0 $rq
 		DIVf $r %0 %1
 		MOVf %1 $fpi 	; k = ((float) sin(fpi)) / ((float) cos(fpi) + (float) sin(fpi))
-		CALL ^sin %0 *2	; expects function(float) -> unknown
+		CALL ^sin %0 *2	; expects function(float) -> unknown @ 64:25
 		MOVf %2 $fpi 
-		CALL ^cos %1 *2	; expects function(float) -> unknown
+		CALL ^cos %1 *2	; expects function(float) -> unknown @ 64:47
 		MOVf %3 $fpi 
-		CALL ^sin %2 *2	; expects function(float) -> unknown
+		CALL ^sin %2 *2	; expects function(float) -> unknown @ 64:65
 		ADDf %1 %1 %2
 		DIVf $k %0 %1
 		MULf %0 $r $k	; g0 = r / (1.0 + r * k * k * k * k)
@@ -98,7 +98,7 @@ main:	FUNC	; signature func main() -> void
 		ADDf $r #1.0 $r	; r = (1.0 + r)
 	.f1:	ADRL %1 $left *0	; getFrame(&left, &right)
 		ADRL %2 $right *0
-		CALL ^getFrame %0 *3	; expects function(ptr, ptr) -> unknown
+		CALL ^getFrame %0 *3	; expects function(ptr, ptr) -> unknown @ 69:26
 		MULf %0 $left $r	; dxL = 0.5 * (dxzL + left * r)
 		ADDf %0 $dxzL %0
 		MULf $dxL #0.5 %0
@@ -175,6 +175,6 @@ main:	FUNC	; signature func main() -> void
 		SUBf $d3zR %0 $gR
 		MOVf %1 $d3zL 	; putFrame(d3zL, d3zR)
 		MOVf %2 $d3zR 
-		CALL ^putFrame %0 *3	; expects function(float, float) -> unknown
+		CALL ^putFrame %0 *3	; expects function(float, float) -> unknown @ 93:23
 		GOTO @.l0  	; }
 		RETU   	; }

--- a/tests/impala/golden/patchTapeTest_code.gazl
+++ b/tests/impala/golden/patchTapeTest_code.gazl
@@ -1,16 +1,16 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-panelTextRows:	GLOB *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 3:1
+panelTextRows:	GLOB *8	; signature array panelTextRows[8] : unknown @ 3:31
 	DATA &.s_4d2 &.s_4d2 &.s_4d2 &.s_4d2 &.s_4d2 &.s_4d2
 	DATA &.s_4d2 &.s_4d2
-config:	GLOB *80	; signature array config[80] : unknown
-positions:	GLOB *2	; signature array positions[2] : unknown
+config:	GLOB *80	; signature array config[80] : unknown @ 9:1
+positions:	GLOB *2	; signature array positions[2] : unknown @ 11:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 11:15
 	$i:	LOCi
 	$p:	LOCp
 ;-----------------------------------------------------------------------------
@@ -27,7 +27,7 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-operate1:	FUNC	; signature func operate1() -> int
+operate1:	FUNC	; signature func operate1() -> int @ 21:19
 ;-----------------------------------------------------------------------------
 		MOVi $r #0 	; r = 0
 		RETU   	; }

--- a/tests/impala/golden/perfTest.gazl
+++ b/tests/impala/golden/perfTest.gazl
@@ -1,38 +1,38 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-; signature extern native print() -> unknown
-; signature extern native abort() -> unknown
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+; signature extern native print() -> unknown @ 1:20
+; signature extern native abort() -> unknown @ 2:20
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 4:42
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 6:42
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 7:43
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 8:44
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 9:39
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 10:45
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 11:40
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 12:32
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 13:33
+FALSE:	! DEFi #0	; signature const FALSE : int @ 15:20
+TRUE:	! DEFi #1	; signature const TRUE : int @ 16:19
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 18:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		EQUp $s &NULL @.f0	; if (s != null) 
 		MOVp %1 &.s_Error4d2 	; print("Error: ")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 21:19
 		MOVp %1 $s 	; print(s)
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 22:11
+		CALL ^abort %0 *1	; expects function() -> unknown @ 23:10
 	.f0:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-exp:	FUNC	; signature func exp(float x) -> float
+exp:	FUNC	; signature func exp(float x) -> float @ 52:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -56,7 +56,7 @@ exp:	FUNC	; signature func exp(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-log:	FUNC	; signature func log(float x) -> float
+log:	FUNC	; signature func log(float x) -> float @ 85:14
 	$x:	INPf
 	$a:	LOCf
 	$b:	LOCf
@@ -67,7 +67,7 @@ log:	FUNC	; signature func log(float x) -> float
 		LEQf $x #0.0 @.t0	; if (x <= 0.0 || x >= 1.0e38) error("Domain error")
 		LSSf $x #1.0e38 @.f1
 	.t0:	MOVp %1 &.s_Domain4d3 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 93:52
 		GOTO @.e2  
 	.f1:	MOVf $b #0.0 	; b = 0.0
 		MOVf $m $x 	; m = x
@@ -96,29 +96,29 @@ log:	FUNC	; signature func log(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-log2:	FUNC	; signature func log2(float x) -> float
+log2:	FUNC	; signature func log2(float x) -> float @ 113:15
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; y = (float)log(x) * LOG2R
-		CALL &log %0 *2	; expects log(float) -> float
+		CALL &log %0 *2	; expects log(float) -> float @ 116:20
 		MULf $y %0 #LOG2R
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-log10:	FUNC	; signature func log10(float x) -> float
+log10:	FUNC	; signature func log10(float x) -> float @ 119:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; y = (float)log(x) * LOG10R
-		CALL &log %0 *2	; expects log(float) -> float
+		CALL &log %0 *2	; expects log(float) -> float @ 122:20
 		MULf $y %0 #LOG10R
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 125:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -132,16 +132,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 132:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4d4 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 135:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float)trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 136:35
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -149,7 +149,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 150:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -158,7 +158,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float)fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 157:30
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -181,38 +181,38 @@ cos:	FUNC	; signature func cos(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sin:	FUNC	; signature func sin(float x) -> float
+sin:	FUNC	; signature func sin(float x) -> float @ 171:14
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		SUBf %1 $x #HALF_PI	; y = (float)cos(x - HALF_PI)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 174:29
 		MOVf $y %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-tan:	FUNC	; signature func tan(float x) -> float
+tan:	FUNC	; signature func tan(float x) -> float @ 177:14
 	$x:	INPf
 	$c:	LOCf
 ;-----------------------------------------------------------------------------
 		MOVf $y #0.0 	; y = 0.0
 		MOVf %1 $x 	; c = (float)cos(x)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 182:19
 		MOVf $c %0 
 		NEQf $c #0.0 @.f0	; if (c == 0.0) error("Domain error")
 		MOVp %1 &.s_Domain4d3 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 183:37
 		GOTO @.e1  
 	.f0:	MOVf %1 $x 	; y = (float)sin(x) / c
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 184:25
 		DIVf $y %0 $c
 	.e1:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-pow:	FUNC	; signature func pow(float x, float y) -> float
+pow:	FUNC	; signature func pow(float x, float y) -> float @ 187:14
 	$x:	INPf
 	$y:	INPf
 	$a:	LOCf
@@ -225,15 +225,15 @@ pow:	FUNC	; signature func pow(float x, float y) -> float
 		SUBf $a #0.0 $a	; a = -a
 	.f1:	LEQf $a #0.0 @.f2	; if (a > 0.0) z = (float)exp((float)log(a) * y)
 		MOVf %2 $a 	; z = (float)exp((float)log(a) * y)
-		CALL &log %1 *2	; expects log(float) -> float
+		CALL &log %1 *2	; expects log(float) -> float @ 194:44
 		MULf %1 %1 $y
-		CALL &exp %0 *2	; expects exp(float) -> float
+		CALL &exp %0 *2	; expects exp(float) -> float @ 194:48
 		MOVf $z %0 
 		GOTO @.e3  
 	.f2:	LSSf $a #0.0 @.t4	; if (a < 0.0 || y <= 0.0) error("Domain error")
 		GRTf $y #0.0 @.f5
 	.t4:	MOVp %1 &.s_Domain4d3 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 195:53
 	.f5:	NOOP
 	.e3:	EQUf $a $x @.f7	; if (a != x && (y * 0.5) != floor(y * 0.5)) z = -z
 		MULf %0 $y #0.5
@@ -246,7 +246,7 @@ pow:	FUNC	; signature func pow(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-ceil:	FUNC	; signature func ceil(float x) -> float
+ceil:	FUNC	; signature func ceil(float x) -> float @ 199:15
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		SUBf %1 #0.0 $x	; y = -floor(-x)
@@ -257,20 +257,20 @@ ceil:	FUNC	; signature func ceil(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sqrt:	FUNC	; signature func sqrt(float x) -> float
+sqrt:	FUNC	; signature func sqrt(float x) -> float @ 205:15
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; y = (float)pow(x, 0.5)
 		MOVf %2 #0.5 
-		CALL &pow %0 *3	; expects pow(float, float) -> float
+		CALL &pow %0 *3	; expects pow(float, float) -> float @ 208:24
 		MOVf $y %0 
 		RETU   	; }
 
-gGlobalState:	GLOB *14	; signature array gGlobalState[14] : unknown
+gGlobalState:	GLOB *14	; signature array gGlobalState[14] : unknown @ 211:30
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 213:15
 	$fpi:	LOCf
 	$rq:	LOCf
 	$dxL:	LOCf
@@ -325,11 +325,11 @@ main:	FUNC	; signature func main() -> void
 		ADDf %1 #1.0 $rq
 		DIVf $r %0 %1
 		MOVf %1 $fpi 	; k = ((float) sin(fpi)) / ((float) cos(fpi) + (float) sin(fpi))
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 229:23
 		MOVf %2 $fpi 
-		CALL &cos %1 *2	; expects cos(float) -> float
+		CALL &cos %1 *2	; expects cos(float) -> float @ 229:45
 		MOVf %3 $fpi 
-		CALL &sin %2 *2	; expects sin(float) -> float
+		CALL &sin %2 *2	; expects sin(float) -> float @ 229:63
 		ADDf %1 %1 %2
 		DIVf $k %0 %1
 		MULf %0 $r $k	; g0 = r / (1.0 + r * k * k * k * k)

--- a/tests/impala/golden/perfTest1.gazl
+++ b/tests/impala/golden/perfTest1.gazl
@@ -1,15 +1,15 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-; signature extern native printInt() -> unknown
-; signature extern native printLF() -> unknown
-; signature extern native print() -> unknown
+; signature extern native printInt() -> unknown @ 1:23
+; signature extern native printLF() -> unknown @ 2:22
+; signature extern native print() -> unknown @ 3:20
 	GLOB *1
-seed:	DATi #2463534242	; signature global seed : int
+seed:	DATi #2463534242	; signature global seed : int @ 5:29
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-myrand:	FUNC	; signature func myrand() -> int
+myrand:	FUNC	; signature func myrand() -> int @ 7:17
 ;-----------------------------------------------------------------------------
 		PEEK $y &seed 	; y = global seed
 		SHLi %0 $y #13	; y = y ^ (y << 13)
@@ -21,18 +21,18 @@ myrand:	FUNC	; signature func myrand() -> int
 		POKE &seed $y 	; global seed = y
 		RETU   	; }
 
-a:	GLOB *20000	; signature array a[20000] : unknown
+a:	GLOB *20000	; signature array a[20000] : unknown @ 17:22
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 19:15
 	$i:	LOCi
 	$j:	LOCi
 	$minj:	LOCi
 ;-----------------------------------------------------------------------------
 		MOVi $i #0 	; for (i = 0 to 20000) global a[i] = (int) myrand()
 		GEQi #0 #20000 @.e0
-	.l1:	CALL &myrand %0 *1	; expects myrand() -> int
+	.l1:	CALL &myrand %0 *1	; expects myrand() -> int @ 22:51
 		POKE &a $i %0
 		FORi $i #20000 @.l1
 	.e0:	MOVi $i #0 	; for (i = 0 to 2000) 
@@ -47,12 +47,12 @@ main:	FUNC	; signature func main() -> void
 	.f6:	FORi $j #20000 @.l5	; }
 	.e4:	FORi $i #2000 @.l3	; }
 	.e2:	MOVi %1 $minj 	; printInt(minj)
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 29:16
 		MOVp %1 &.s_4d2 	; print(": ")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 30:13
 		PEEK %1 &a $minj	; printInt(global a[minj])
-		CALL ^printInt %0 *2	; expects function(unknown) -> unknown
-		CALL ^printLF %0 *1	; expects function() -> unknown
+		CALL ^printInt %0 *2	; expects function(unknown) -> unknown @ 31:26
+		CALL ^printLF %0 *1	; expects function() -> unknown @ 32:11
 		RETU   	; }
 
 .s_4d2:	CNST *3

--- a/tests/impala/golden/perfTest2.gazl
+++ b/tests/impala/golden/perfTest2.gazl
@@ -1,18 +1,18 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-; signature extern native printInt() -> unknown
+; signature extern native printInt() -> unknown @ 1:23
 
 ;-----------------------------------------------------------------------------
 	$x:	OUTi
-fib:	FUNC	; signature func fib(int y) -> int
+fib:	FUNC	; signature func fib(int y) -> int @ 3:14
 	$y:	INPi
 ;-----------------------------------------------------------------------------
 		LSSi $y #2 @.f0	; if (y >= 2) 
 		SUBi %1 $y #1	; x = (int) fib(y - 1) + (int) fib(y - 2)
-		CALL &fib %0 *2	; expects fib(int) -> int
+		CALL &fib %0 *2	; expects fib(int) -> int @ 7:24
 		SUBi %2 $y #2
-		CALL &fib %1 *2	; expects fib(int) -> int
+		CALL &fib %1 *2	; expects fib(int) -> int @ 7:42
 		ADDi $x %0 %1
 		GOTO @.e1  	; } else 
 	.f0:	MOVi $x $y 	; x = y
@@ -21,9 +21,9 @@ fib:	FUNC	; signature func fib(int y) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 13:15
 ;-----------------------------------------------------------------------------
 		MOVi %2 #35 	; printInt(fib(35))
-		CALL &fib %1 *2	; expects fib(int) -> int
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
+		CALL &fib %1 *2	; expects fib(int) -> int @ 15:18
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 15:19
 		RETU   	; }

--- a/tests/impala/golden/phaser_code.gazl
+++ b/tests/impala/golden/phaser_code.gazl
@@ -1,27 +1,27 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_4d2 &.s_4d2 &.s_4d2 &.s_LEFTDE4d3 &.s_4d2 &.s_4d2
 	DATA &.s_4d2 &.s_RINGMO4d4
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 81:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 82:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
+instance:	DATi #0	; signature global instance : int @ 83:1
 	CNST *1
-clockFreqLimit:	DATi #44100	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
-EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown
+clockFreqLimit:	DATi #44100	; signature readonly clockFreqLimit : int @ 86:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 95:1
+EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown @ 95:41
 	DATA #0x0 #0x1 #0x2 #0x3 #0x4 #0x5 #0x6 #0x7 #0x8 #0x9
 	DATA #0xa #0xb #0xc #0xd #0xe #0xf #0x10 #0x11 #0x12 #0x13
 	DATA #0x14 #0x15 #0x16 #0x17 #0x18 #0x19 #0x1a #0x1b #0x1c
@@ -56,23 +56,23 @@ EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unkn
 	DATA #0x7c00 #0x8000 #0x8800 #0x9000 #0x9800 #0xa000
 	DATA #0xa800 #0xb000 #0xb800 #0xc000 #0xc800 #0xd000
 	DATA #0xd800 #0xe000 #0xe800 #0xf000 #0xffff
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 130:1
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 131:1
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 132:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 133:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 134:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 135:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
-EPSILON_FLOAT:	! DEFf #1.0e-45	; signature const EPSILON_FLOAT : float
-SMALL_FLOAT:	! DEFf #1.0e-5	; signature const SMALL_FLOAT : float
-LARGE_FLOAT:	! DEFf #1.0e+10	; signature const LARGE_FLOAT : float
-HUGE_FLOAT:	! DEFf #1.0e+38	; signature const HUGE_FLOAT : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 136:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 137:1
+EPSILON_FLOAT:	! DEFf #1.0e-45	; signature const EPSILON_FLOAT : float @ 138:1
+SMALL_FLOAT:	! DEFf #1.0e-5	; signature const SMALL_FLOAT : float @ 139:1
+LARGE_FLOAT:	! DEFf #1.0e+10	; signature const LARGE_FLOAT : float @ 140:1
+HUGE_FLOAT:	! DEFf #1.0e+38	; signature const HUGE_FLOAT : float @ 142:1
 
 ;-----------------------------------------------------------------------------
 	$a:	OUTp
-stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
+stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr @ 142:17
 	$d:	INPp
 	$s:	INPp
 	$b:	LOCp
@@ -90,7 +90,7 @@ stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr
+intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr @ 161:22
 	$i:	INPi
 	$radix:	INPi
 	$minLength:	INPi
@@ -137,7 +137,7 @@ intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, 
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr buffer) -> ptr
+floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr buffer) -> ptr @ 181:24
 	$f:	INPf
 	$precision:	INPi
 	$buffer:	INPp
@@ -272,7 +272,7 @@ floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr b
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
+traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void @ 286:20
 	$text:	INPp
 	$n:	INPi
 	$ints:	INPp
@@ -286,7 +286,7 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		EQUp $text &NULL @.f0	; if (text != null) p = (pointer) stpcpy(p, text)
 		MOVp %1 $p 	; p = (pointer) stpcpy(p, text)
 		MOVp %2 $text 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 293:49
 		MOVp $p %0 
 	.f0:	POKE $p #0 	; *p = 0
 		MOVi $i #0 	; for (i = 0 to n) 
@@ -299,18 +299,18 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		MOVi %4 #10 
 		MOVi %5 #1 
 		ADRL %6 $buffer *0
-		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr @ 297:62
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 297:63
 		MOVp $p %0 
 		FORi $i $n @.l2	; }
 	.e1:	ADRL %1 $line *0	; trace(line)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 299:13
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
+traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void @ 302:19
 	$text:	INPp
 	$i:	INPi
 	$ints:	LOCA *1
@@ -319,13 +319,13 @@ traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
 		MOVp %1 $text 	; traceInts(text, 1, ints)
 		MOVi %2 #1 
 		ADRL %3 $ints *0
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 306:26
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceFloats:	FUNC	; signature func traceFloats(ptr text, int n, ptr floats) -> void
+traceFloats:	FUNC	; signature func traceFloats(ptr text, int n, ptr floats) -> void @ 309:22
 	$text:	INPp
 	$n:	INPi
 	$floats:	INPp
@@ -338,7 +338,7 @@ traceFloats:	FUNC	; signature func traceFloats(ptr text, int n, ptr floats) -> v
 		EQUp $text &NULL @.f0	; if (text != null) p = (pointer) stpcpy(p, text)
 		MOVp %1 $p 	; p = (pointer) stpcpy(p, text)
 		MOVp %2 $text 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 316:49
 		MOVp $p %0 
 	.f0:	POKE $p #0 	; *p = 0
 		MOVi $i #0 	; for (i = 0 to n) 
@@ -350,18 +350,18 @@ traceFloats:	FUNC	; signature func traceFloats(ptr text, int n, ptr floats) -> v
 		PEEK %3 $floats $i
 		MOVi %4 #8 
 		ADRL %5 $buffer *0
-		CALL &floatToString %2 *4	; expects floatToString(float, int, ptr) -> ptr
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &floatToString %2 *4	; expects floatToString(float, int, ptr) -> ptr @ 320:62
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 320:63
 		MOVp $p %0 
 		FORi $i $n @.l2	; }
 	.e1:	ADRL %1 $line *0	; trace(line)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 322:13
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceFloat:	FUNC	; signature func traceFloat(ptr text, float f) -> void
+traceFloat:	FUNC	; signature func traceFloat(ptr text, float f) -> void @ 325:21
 	$text:	INPp
 	$f:	INPf
 	$floats:	LOCA *1
@@ -370,24 +370,24 @@ traceFloat:	FUNC	; signature func traceFloat(ptr text, float f) -> void
 		MOVp %1 $text 	; traceFloats(text, 1, floats)
 		MOVi %2 #1 
 		ADRL %3 $floats *0
-		CALL &traceFloats %0 *4	; expects traceFloats(ptr, int, ptr) -> void
+		CALL &traceFloats %0 *4	; expects traceFloats(ptr, int, ptr) -> void @ 329:30
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 332:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 334:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 335:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 338:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -401,16 +401,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 345:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4d8 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 348:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float)trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 349:35
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -418,7 +418,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-exp:	FUNC	; signature func exp(float x) -> float
+exp:	FUNC	; signature func exp(float x) -> float @ 377:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -442,7 +442,7 @@ exp:	FUNC	; signature func exp(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 408:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -451,7 +451,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 412:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -474,38 +474,38 @@ cos:	FUNC	; signature func cos(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sin:	FUNC	; signature func sin(float x) -> float
+sin:	FUNC	; signature func sin(float x) -> float @ 424:14
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		SUBf %1 $x #HALF_PI	; y = (float) cos(x - HALF_PI)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 427:30
 		MOVf $y %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-tan:	FUNC	; signature func tan(float x) -> float
+tan:	FUNC	; signature func tan(float x) -> float @ 430:14
 	$x:	INPf
 	$c:	LOCf
 ;-----------------------------------------------------------------------------
 		MOVf $y #0.0 	; y = 0.0
 		MOVf %1 $x 	; c = (float) cos(x)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 435:20
 		MOVf $c %0 
 		NEQf $c #0.0 @.f0	; if (c == 0.0) error("Domain error")
 		MOVp %1 &.s_Domain4d9 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 436:37
 		GOTO @.e1  
 	.f0:	MOVf %1 $x 	; y = (float) sin(x) / c
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 437:26
 		DIVf $y %0 $c
 	.e1:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-lerp:	FUNC	; signature func lerp(float a, float b, float x) -> float
+lerp:	FUNC	; signature func lerp(float a, float b, float x) -> float @ 440:15
 	$a:	INPf
 	$b:	INPf
 	$x:	INPf
@@ -515,23 +515,23 @@ lerp:	FUNC	; signature func lerp(float a, float b, float x) -> float
 		ADDf $y $a %0
 		RETU   	; }
 
-BATCH_SIZE:	! DEFi #256	; signature const BATCH_SIZE : int
-K_TABLE_SIZE:	! DEFi #64	; signature const K_TABLE_SIZE : int
-LOG1000:	! DEFf #6.9077552789821	; signature const LOG1000 : float
-STANDARD_SAMPLE_RATE:	! DEFf #44100.0	; signature const STANDARD_SAMPLE_RATE : float
+BATCH_SIZE:	! DEFi #256	; signature const BATCH_SIZE : int @ 448:27
+K_TABLE_SIZE:	! DEFi #64	; signature const K_TABLE_SIZE : int @ 449:28
+LOG1000:	! DEFf #6.9077552789821	; signature const LOG1000 : float @ 450:38
+STANDARD_SAMPLE_RATE:	! DEFf #44100.0	; signature const STANDARD_SAMPLE_RATE : float @ 451:43
 	GLOB *1
-doReset:	DATi #FALSE	; signature global doReset : int
-kTable:	GLOB *K_TABLE_SIZE	; signature array kTable[K_TABLE_SIZE] : unknown
+doReset:	DATi #FALSE	; signature global doReset : int @ 456:1
+kTable:	GLOB *K_TABLE_SIZE	; signature array kTable[K_TABLE_SIZE] : unknown @ 456:34
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 465:15
 	$f:	LOCf
 	$k:	LOCf
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4da 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 468:15
 		MOVi $i #0 	; for (i = 0 to K_TABLE_SIZE) 
 		GEQi #0 #K_TABLE_SIZE @.e0
 	.l1:	NOOP
@@ -539,11 +539,11 @@ init:	FUNC	; signature func init() -> void
 		! iTOf <B> #K_TABLE_SIZE #1.0
 		! DIVf <B> #LOG1000 <B>
 		iTOf %1 $i <B>
-		CALL &exp %0 *2	; expects exp(float) -> float
+		CALL &exp %0 *2	; expects exp(float) -> float @ 470:97
 		! DIVf <A> <A> #STANDARD_SAMPLE_RATE
 		MULf $f <A> %0
 		MOVf %1 $f 	; global kTable[i] = (float) tan(f)
-		CALL &tan %0 *2	; expects tan(float) -> float
+		CALL &tan %0 *2	; expects tan(float) -> float @ 471:36
 		POKE &kTable $i %0
 		FORi $i #K_TABLE_SIZE @.l1	; }
 	.e0:	RETU   	; }
@@ -551,36 +551,36 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 481:16
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4db 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 483:16
 		POKE &doReset #TRUE 	; global doReset = TRUE
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 495:17
 	$params:	LOCA *PARAM_COUNT
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_update4dc 	; trace("update")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 498:17
 		RETU   	; }
 
-MAX_STAGE_COUNT:	! DEFi #8	; signature const MAX_STAGE_COUNT : int
-AP12_K:	! DEFi #0	; signature const AP12_K : int
-AP12_R:	! DEFi #1	; signature const AP12_R : int
-AP12_M0:	! DEFi #2	; signature const AP12_M0 : int
-AP12_M1:	! DEFi #3	; signature const AP12_M1 : int
-AP12_M2:	! DEFi #4	; signature const AP12_M2 : int
-AP12_PARAM_COUNT:	! DEFi #5	; signature const AP12_PARAM_COUNT : int
+MAX_STAGE_COUNT:	! DEFi #8	; signature const MAX_STAGE_COUNT : int @ 502:30
+AP12_K:	! DEFi #0	; signature const AP12_K : int @ 503:21
+AP12_R:	! DEFi #1	; signature const AP12_R : int @ 504:21
+AP12_M0:	! DEFi #2	; signature const AP12_M0 : int @ 505:22
+AP12_M1:	! DEFi #3	; signature const AP12_M1 : int @ 506:22
+AP12_M2:	! DEFi #4	; signature const AP12_M2 : int @ 507:22
+AP12_PARAM_COUNT:	! DEFi #5	; signature const AP12_PARAM_COUNT : int @ 508:31
 	! MULi <A> #MAX_STAGE_COUNT #4
-AP12_STATE_SIZE:	! DEFi <A>	; signature const AP12_STATE_SIZE : int
+AP12_STATE_SIZE:	! DEFi <A>	; signature const AP12_STATE_SIZE : int @ 509:48
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-setupAP12Params:	FUNC	; signature func setupAP12Params(float pitch, float rq, ptr params) -> void
+setupAP12Params:	FUNC	; signature func setupAP12Params(float pitch, float rq, ptr params) -> void @ 511:26
 	$pitch:	INPf
 	$rq:	INPf
 	$params:	INPp
@@ -603,7 +603,7 @@ setupAP12Params:	FUNC	; signature func setupAP12Params(float pitch, float rq, pt
 		PEEK %2 &kTable %2
 		FLOf %3 $fidx 
 		SUBf %3 $fidx %3
-		CALL &lerp %0 *4	; expects lerp(float, float, float) -> float
+		CALL &lerp %0 *4	; expects lerp(float, float, float) -> float @ 517:98
 		MOVf $k %0 
 		POKE $params #AP12_K $k	; params[AP12_K] = k
 		POKE $params #AP12_R $rq	; params[AP12_R] = rq
@@ -622,7 +622,7 @@ setupAP12Params:	FUNC	; signature func setupAP12Params(float pitch, float rq, pt
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-ap12StereoChain:	FUNC	; signature func ap12StereoChain(ptr state, int stageCount, float inLeft, float inRight, ptr paramsLeft, ptr paramsRight, ptr outLeft, ptr outRight) -> void
+ap12StereoChain:	FUNC	; signature func ap12StereoChain(ptr state, int stageCount, float inLeft, float inRight, ptr paramsLeft, ptr paramsRight, ptr outLeft, ptr outRight) -> void @ 526:26
 	$state:	INPp
 	$stageCount:	INPi
 	$inLeft:	INPf
@@ -727,7 +727,7 @@ ap12StereoChain:	FUNC	; signature func ap12StereoChain(ptr state, int stageCount
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-shaper:	FUNC	; signature func shaper(float x) -> float
+shaper:	FUNC	; signature func shaper(float x) -> float @ 580:17
 	$x:	INPf
 	$cx:	LOCf
 ;-----------------------------------------------------------------------------
@@ -746,7 +746,7 @@ shaper:	FUNC	; signature func shaper(float x) -> float
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 605:18
 	$leftParams:	LOCA *AP12_PARAM_COUNT
 	$rightParams:	LOCA *AP12_PARAM_COUNT
 	$ap12State:	LOCA *AP12_STATE_SIZE
@@ -801,7 +801,7 @@ process:	FUNC	; signature func process() -> void
 		ADDf %1 $frequency %1
 		MOVf %2 #2.0 
 		ADRL %3 $leftParams *0
-		CALL &setupAP12Params %0 *4	; expects setupAP12Params(float, float, ptr) -> void
+		CALL &setupAP12Params %0 *4	; expects setupAP12Params(float, float, ptr) -> void @ 628:78
 		ADDf $ph2 $ph #0.05	; ph2 = ph + 0.05
 		LSSf $ph2 #1.0 @.f5	; if (ph2 >= 1.0) ph2 = ph2 - 2.0
 		SUBf $ph2 $ph2 #2.0	; ph2 = ph2 - 2.0
@@ -812,7 +812,7 @@ process:	FUNC	; signature func process() -> void
 		ADDf %1 $frequency %1
 		MOVf %2 #2.0 
 		ADRL %3 $rightParams *0
-		CALL &setupAP12Params %0 *4	; expects setupAP12Params(float, float, ptr) -> void
+		CALL &setupAP12Params %0 *4	; expects setupAP12Params(float, float, ptr) -> void @ 631:80
 		MOVi $i #0 	; for (i = 0 to BATCH_SIZE) 
 		GEQi #0 #BATCH_SIZE @.l2
 	.l7:	PEEK %0 &signal:0 	; inL = itof((int) global signal[0]) * (1.0 / 2048.0)
@@ -825,7 +825,7 @@ process:	FUNC	; signature func process() -> void
 		SUBi %1 $clock #1	; read(clock - 1, 1, input)
 		MOVi %2 #1 
 		ADRL %3 $input *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 639:28
 		! DIVf <A> #1.0 #2048.0	; fbL = itof((int) input[0]) * (1.0 / 2048.0)
 		iTOf $fbL $input:0 <A>
 		! DIVf <A> #1.0 #2048.0	; fbR = itof((int) input[1]) * (1.0 / 2048.0)
@@ -833,16 +833,16 @@ process:	FUNC	; signature func process() -> void
 		ADRL %1 $ap12State *0	; ap12StereoChain(ap12State, stageCount, inL - (float) shaper(fbL * feedback), inR - (float) shaper(fbR * feedback), leftParams, rightParams, &l, &r)
 		MOVi %2 $stageCount 
 		MULf %4 $fbL $feedback
-		CALL &shaper %3 *2	; expects shaper(float) -> float
+		CALL &shaper %3 *2	; expects shaper(float) -> float @ 642:79
 		SUBf %3 $inL %3
 		MULf %5 $fbR $feedback
-		CALL &shaper %4 *2	; expects shaper(float) -> float
+		CALL &shaper %4 *2	; expects shaper(float) -> float @ 642:117
 		SUBf %4 $inR %4
 		ADRL %5 $leftParams *0
 		ADRL %6 $rightParams *0
 		ADRL %7 $l *0
 		ADRL %8 $r *0
-		CALL &ap12StereoChain %0 *9	; expects ap12StereoChain(ptr, int, float, float, ptr, ptr, ptr, ptr) -> void
+		CALL &ap12StereoChain %0 *9	; expects ap12StereoChain(ptr, int, float, float, ptr, ptr, ptr, ptr) -> void @ 642:151
 		MOVf $fbL $l 	; fbL = l
 		MOVf $fbR $r 	; fbR = r
 		fTOi $input:0 $fbL #2048.0	; input[0] = ftoi(fbL * 2048.0)
@@ -850,12 +850,12 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $clock 	; write(clock, 1, input)
 		MOVi %2 #1 
 		ADRL %3 $input *0
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 647:26
 		MOVi %1 $clock 	; read(clock, 1, global signal)
 		MOVi %2 #1 
 		MOVp %3 &signal 
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 648:33
+		CALL ^yield %0 *1	; expects function() -> unknown @ 653:11
 		FORi $i #BATCH_SIZE @.l7	; }
 		GOTO @.l2  	; }
 		RETU   	; }

--- a/tests/impala/golden/pong_code.gazl
+++ b/tests/impala/golden/pong_code.gazl
@@ -1,27 +1,27 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 10:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 11:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 19:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 19:33
 	DATA &.s_18PPVV4d2 &.s_116AAO4d3 &.s_132NNL4d4
 	DATA &.s_164TAP4d5 &.s_1PPVVT4d6 &.s_2AAOOI4d7
 	DATA &.s_12NNLL4d8 &.s_contTA4d9
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 31:1
+; signature extern native trace() -> unknown @ 32:1
+; signature extern native yield() -> unknown @ 33:1
+; signature extern native write() -> unknown @ 34:1
+; signature extern native read() -> unknown @ 36:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 72:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 73:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 74:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
+instance:	DATi #0	; signature global instance : int @ 75:1
 	CNST *1
-clockFreqLimit:	DATi #88200	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
+clockFreqLimit:	DATi #88200	; signature readonly clockFreqLimit : int @ 78:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 80:1
 	CNST *1
 	! SHLi <A> #1 #OPERATOR_1_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_1_HIGH_PARAM_INDEX
@@ -34,16 +34,16 @@ signal:	GLOB *2	; signature array signal[2] : unknown
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #OPERAND_2_LOW_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
-XOR_SHIFT_RANDOM_TO_FLOAT_FACTOR:	! DEFf #4.6566128730774e-10	; signature const XOR_SHIFT_RANDOM_TO_FLOAT_FACTOR : float
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 87:1
+XOR_SHIFT_RANDOM_TO_FLOAT_FACTOR:	! DEFf #4.6566128730774e-10	; signature const XOR_SHIFT_RANDOM_TO_FLOAT_FACTOR : float @ 89:1
 	GLOB *1
-xorShiftRandomSeedX:	DATi #123456789	; signature global xorShiftRandomSeedX : int
+xorShiftRandomSeedX:	DATi #123456789	; signature global xorShiftRandomSeedX : int @ 90:1
 	GLOB *1
-xorShiftRandomSeedY:	DATi #362436069	; signature global xorShiftRandomSeedY : int
+xorShiftRandomSeedY:	DATi #362436069	; signature global xorShiftRandomSeedY : int @ 91:1
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-xorShiftRandom:	FUNC	; signature func xorShiftRandom() -> int
+xorShiftRandom:	FUNC	; signature func xorShiftRandom() -> int @ 91:25
 	$x:	LOCi
 	$t:	LOCi
 ;-----------------------------------------------------------------------------
@@ -61,48 +61,48 @@ xorShiftRandom:	FUNC	; signature func xorShiftRandom() -> int
 		POKE &xorShiftRandomSeedY $y 	; global xorShiftRandomSeedY = y
 		RETU   	; }
 
-MAX_TAP_COUNT:	! DEFi #16	; signature const MAX_TAP_COUNT : int
-PAN_LEFT_BIT:	! DEFi #7	; signature const PAN_LEFT_BIT : int
-PAN_RIGHT_BIT:	! DEFi #6	; signature const PAN_RIGHT_BIT : int
-VOL_DEC_BIT:	! DEFi #5	; signature const VOL_DEC_BIT : int
-VOL_INC_BIT:	! DEFi #4	; signature const VOL_INC_BIT : int
-ACCELERATE_BIT:	! DEFi #3	; signature const ACCELERATE_BIT : int
-DEACCELERATE_BIT:	! DEFi #2	; signature const DEACCELERATE_BIT : int
-RANDOM_BIT:	! DEFi #1	; signature const RANDOM_BIT : int
-RECTIFIER_BIT:	! DEFi #0	; signature const RECTIFIER_BIT : int
-VOL_DEC_FACTOR:	! DEFf #0.70710678118655	; signature const VOL_DEC_FACTOR : float
-VOL_INC_FACTOR:	! DEFf #1.414213562373	; signature const VOL_INC_FACTOR : float
-TIME_DEC_FACTOR:	! DEFf #0.70710678118655	; signature const TIME_DEC_FACTOR : float
-TIME_INC_FACTOR:	! DEFf #1.414213562373	; signature const TIME_INC_FACTOR : float
-PAN_ATTENUATE:	! DEFf #0.25	; signature const PAN_ATTENUATE : float
-BATCH_SIZE:	! DEFi #64	; signature const BATCH_SIZE : int
-TAP_BITS:	! DEFi #0	; signature const TAP_BITS : int
-TAP_DELAY:	! DEFi #1	; signature const TAP_DELAY : int
-TAP_LEFT_GAIN:	! DEFi #2	; signature const TAP_LEFT_GAIN : int
-TAP_RIGHT_GAIN:	! DEFi #3	; signature const TAP_RIGHT_GAIN : int
-TAP_STRUCT_SIZE:	! DEFi #4	; signature const TAP_STRUCT_SIZE : int
+MAX_TAP_COUNT:	! DEFi #16	; signature const MAX_TAP_COUNT : int @ 109:1
+PAN_LEFT_BIT:	! DEFi #7	; signature const PAN_LEFT_BIT : int @ 110:1
+PAN_RIGHT_BIT:	! DEFi #6	; signature const PAN_RIGHT_BIT : int @ 111:1
+VOL_DEC_BIT:	! DEFi #5	; signature const VOL_DEC_BIT : int @ 112:1
+VOL_INC_BIT:	! DEFi #4	; signature const VOL_INC_BIT : int @ 113:1
+ACCELERATE_BIT:	! DEFi #3	; signature const ACCELERATE_BIT : int @ 114:1
+DEACCELERATE_BIT:	! DEFi #2	; signature const DEACCELERATE_BIT : int @ 115:1
+RANDOM_BIT:	! DEFi #1	; signature const RANDOM_BIT : int @ 116:1
+RECTIFIER_BIT:	! DEFi #0	; signature const RECTIFIER_BIT : int @ 118:1
+VOL_DEC_FACTOR:	! DEFf #0.70710678118655	; signature const VOL_DEC_FACTOR : float @ 119:1
+VOL_INC_FACTOR:	! DEFf #1.414213562373	; signature const VOL_INC_FACTOR : float @ 120:1
+TIME_DEC_FACTOR:	! DEFf #0.70710678118655	; signature const TIME_DEC_FACTOR : float @ 121:1
+TIME_INC_FACTOR:	! DEFf #1.414213562373	; signature const TIME_INC_FACTOR : float @ 122:1
+PAN_ATTENUATE:	! DEFf #0.25	; signature const PAN_ATTENUATE : float @ 124:1
+BATCH_SIZE:	! DEFi #64	; signature const BATCH_SIZE : int @ 124:26
+TAP_BITS:	! DEFi #0	; signature const TAP_BITS : int @ 129:1
+TAP_DELAY:	! DEFi #1	; signature const TAP_DELAY : int @ 130:1
+TAP_LEFT_GAIN:	! DEFi #2	; signature const TAP_LEFT_GAIN : int @ 131:1
+TAP_RIGHT_GAIN:	! DEFi #3	; signature const TAP_RIGHT_GAIN : int @ 132:1
+TAP_STRUCT_SIZE:	! DEFi #4	; signature const TAP_STRUCT_SIZE : int @ 134:1
 	GLOB *1
-tapCount:	DATi #0	; signature global tapCount : int
+tapCount:	DATi #0	; signature global tapCount : int @ 135:1
 	! MULi <A> #TAP_STRUCT_SIZE #MAX_TAP_COUNT
-tapData:	GLOB *<A>	; signature array tapData[<A>] : unknown
+tapData:	GLOB *<A>	; signature array tapData[<A>] : unknown @ 142:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 142:15
 ;-----------------------------------------------------------------------------
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 150:16
 ;-----------------------------------------------------------------------------
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-maxi:	FUNC	; signature func maxi(int a, int b) -> int
+maxi:	FUNC	; signature func maxi(int a, int b) -> int @ 154:15
 	$a:	INPi
 	$b:	INPi
 ;-----------------------------------------------------------------------------
@@ -114,7 +114,7 @@ maxi:	FUNC	; signature func maxi(int a, int b) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-calcGainsAndDelays:	FUNC	; signature func calcGainsAndDelays(int configBits, int stepBits, float initGain, float initDelay, ptr gains, ptr delays, ptr maxGain, ptr maxDelay, ptr endGain, ptr endDelay) -> void
+calcGainsAndDelays:	FUNC	; signature func calcGainsAndDelays(int configBits, int stepBits, float initGain, float initDelay, ptr gains, ptr delays, ptr maxGain, ptr maxDelay, ptr endGain, ptr endDelay) -> void @ 161:29
 	$configBits:	INPi
 	$stepBits:	INPi
 	$initGain:	INPf
@@ -171,7 +171,7 @@ calcGainsAndDelays:	FUNC	; signature func calcGainsAndDelays(int configBits, int
 
 ;-----------------------------------------------------------------------------
 	$o:	OUTf
-addTaps:	FUNC	; signature func addTaps(int op, int configBits, int stepBits, float offset, ptr gains, ptr delays, float gainScale, float delayScale, int firstStep) -> float
+addTaps:	FUNC	; signature func addTaps(int op, int configBits, int stepBits, float offset, ptr gains, ptr delays, float gainScale, float delayScale, int firstStep) -> float @ 183:18
 	$op:	INPi
 	$configBits:	INPi
 	$stepBits:	INPi
@@ -217,7 +217,7 @@ addTaps:	FUNC	; signature func addTaps(int op, int configBits, int stepBits, flo
 		! SHLi <A> #1 #RANDOM_BIT	; if ((configBits & (1 << RANDOM_BIT)) != 0) r = itof((int) xorShiftRandom()) * (XOR_SHIFT_RANDOM_TO_FLOAT_FACTOR * (1.0/12.0)) * d
 		ANDi %0 $configBits <A>
 		EQUi %0 #0 @.f5
-		CALL &xorShiftRandom %0 *1	; expects xorShiftRandom() -> int
+		CALL &xorShiftRandom %0 *1	; expects xorShiftRandom() -> int @ 200:78
 		! DIVf <A> #1.0 #12.0
 		! MULf <A> #XOR_SHIFT_RANDOM_TO_FLOAT_FACTOR <A>
 		iTOf %0 %0 <A>
@@ -230,7 +230,7 @@ addTaps:	FUNC	; signature func addTaps(int op, int configBits, int stepBits, flo
 		fTOi %1 %1 #1.0
 		SUBi %1 %1 #BATCH_SIZE
 		MOVi %2 #0 
-		CALL &maxi %0 *3	; expects maxi(int, int) -> int
+		CALL &maxi %0 *3	; expects maxi(int, int) -> int @ 202:52
 		POKE $p #TAP_DELAY %0
 		fTOi %0 $lg #1.0	; p[TAP_LEFT_GAIN] = ftoi(lg)
 		POKE $p #TAP_LEFT_GAIN %0
@@ -247,7 +247,7 @@ addTaps:	FUNC	; signature func addTaps(int op, int configBits, int stepBits, flo
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 216:17
 	$localParams:	LOCA *PARAM_COUNT
 	$i:	LOCi
 	$v:	LOCi
@@ -287,7 +287,7 @@ update:	FUNC	; signature func update() -> void
 		ADRL %8 $maxDelay1 *0
 		ADRL %9 $endGain *0
 		ADRL %10 $endDelay *0
-		CALL &calcGainsAndDelays %0 *11	; expects calcGainsAndDelays(int, int, float, float, ptr, ptr, ptr, ptr, ptr, ptr) -> void
+		CALL &calcGainsAndDelays %0 *11	; expects calcGainsAndDelays(int, int, float, float, ptr, ptr, ptr, ptr, ptr, ptr) -> void @ 231:183
 	.f0:	MOVf $stepLength2 $stepLength1 	; stepLength2 = stepLength1
 		MOVf $offset #0.0 	; offset = 0.0
 		SWCH $localParams:OPERATOR_2_PARAM_INDEX *5 @.s1	; switch ((int) localParams[OPERATOR_2_PARAM_INDEX] == 0 to 5) 
@@ -308,7 +308,7 @@ update:	FUNC	; signature func update() -> void
 		ADRL %8 $maxDelay1 *0
 		ADRL %9 $endGain *0
 		ADRL %10 $endDelay *0
-		CALL &calcGainsAndDelays %0 *11	; expects calcGainsAndDelays(int, int, float, float, ptr, ptr, ptr, ptr, ptr, ptr) -> void
+		CALL &calcGainsAndDelays %0 *11	; expects calcGainsAndDelays(int, int, float, float, ptr, ptr, ptr, ptr, ptr, ptr) -> void @ 241:201
 		MOVi %1 $localParams:OPERATOR_1_PARAM_INDEX 	; offset = (float) addTaps((int) localParams[OPERATOR_1_PARAM_INDEX], (int) localParams[OPERAND_1_LOW_PARAM_INDEX], (int) localParams[OPERAND_1_HIGH_PARAM_INDEX], 0.0, gains, delays, 256.0 / maxGain1, stepLength1 / maxDelay1, 0)
 		MOVi %2 $localParams:OPERAND_1_LOW_PARAM_INDEX 
 		MOVi %3 $localParams:OPERAND_1_HIGH_PARAM_INDEX 
@@ -318,7 +318,7 @@ update:	FUNC	; signature func update() -> void
 		DIVf %7 #256.0 $maxGain1
 		DIVf %8 $stepLength1 $maxDelay1
 		MOVi %9 #0 
-		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float
+		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float @ 242:230
 		MOVf $offset %0 
 		MOVi %1 $localParams:OPERATOR_2_PARAM_INDEX 	; addTaps((int) localParams[OPERATOR_2_PARAM_INDEX], (int) localParams[OPERAND_2_LOW_PARAM_INDEX], (int) localParams[OPERAND_2_HIGH_PARAM_INDEX], offset, &gains[8], &delays[8], 256.0 / maxGain1, stepLength2 / maxDelay1, 8)
 		MOVi %2 $localParams:OPERAND_2_LOW_PARAM_INDEX 
@@ -329,7 +329,7 @@ update:	FUNC	; signature func update() -> void
 		DIVf %7 #256.0 $maxGain1
 		DIVf %8 $stepLength2 $maxDelay1
 		MOVi %9 #8 
-		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float
+		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float @ 243:224
 		GOTO @done  	; goto done
 	.s1:	NOOP
 	.e2:	MOVf $maxGain2 #0.00001 	; maxGain2 = 0.00001
@@ -344,7 +344,7 @@ update:	FUNC	; signature func update() -> void
 		ADRL %8 $maxDelay2 *0
 		ADRL %9 $endGain *0
 		ADRL %10 $endDelay *0
-		CALL &calcGainsAndDelays %0 *11	; expects calcGainsAndDelays(int, int, float, float, ptr, ptr, ptr, ptr, ptr, ptr) -> void
+		CALL &calcGainsAndDelays %0 *11	; expects calcGainsAndDelays(int, int, float, float, ptr, ptr, ptr, ptr, ptr, ptr) -> void @ 249:190
 		MOVi %1 $localParams:OPERATOR_2_PARAM_INDEX 	; addTaps((int) localParams[OPERATOR_2_PARAM_INDEX], (int) localParams[OPERAND_2_LOW_PARAM_INDEX], (int) localParams[OPERAND_2_HIGH_PARAM_INDEX], offset, &gains[8], &delays[8], 256.0 / maxGain2, stepLength2 / maxDelay2, 8)
 		MOVi %2 $localParams:OPERAND_2_LOW_PARAM_INDEX 
 		MOVi %3 $localParams:OPERAND_2_HIGH_PARAM_INDEX 
@@ -354,7 +354,7 @@ update:	FUNC	; signature func update() -> void
 		DIVf %7 #256.0 $maxGain2
 		DIVf %8 $stepLength2 $maxDelay2
 		MOVi %9 #8 
-		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float
+		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float @ 250:222
 	noSecond:	LEQi $localParams:OPERATOR_1_PARAM_INDEX #0 @.f3	; if ((int) localParams[OPERATOR_1_PARAM_INDEX] > 0) 
 		MOVi %1 $localParams:OPERATOR_1_PARAM_INDEX 	; addTaps((int) localParams[OPERATOR_1_PARAM_INDEX], (int) localParams[OPERAND_1_LOW_PARAM_INDEX], (int) localParams[OPERAND_1_HIGH_PARAM_INDEX], 0.0, gains, delays, 256.0 / maxGain1, stepLength1 / maxDelay1, 0)
 		MOVi %2 $localParams:OPERAND_1_LOW_PARAM_INDEX 
@@ -365,17 +365,17 @@ update:	FUNC	; signature func update() -> void
 		DIVf %7 #256.0 $maxGain1
 		DIVf %8 $stepLength1 $maxDelay1
 		MOVi %9 #0 
-		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float
+		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float @ 253:212
 	.f3:	NOOP
 	done:	RETU   	; }
 
-temp:	GLOB *2	; signature array temp[2] : unknown
+temp:	GLOB *2	; signature array temp[2] : unknown @ 258:21
 	! MULi <A> #BATCH_SIZE #2
-buffer:	GLOB *<A>	; signature array buffer[<A>] : unknown
+buffer:	GLOB *<A>	; signature array buffer[<A>] : unknown @ 259:36
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 276:18
 	! MULi <A> #BATCH_SIZE #2
 	$tapData:	LOCA *TAP_STRUCT_SIZE
 	$i:	LOCi
@@ -406,14 +406,14 @@ process:	FUNC	; signature func process() -> void
 		COPY &signal $bp *2	; copy (2 from bp to global signal)
 		COPY $bp &temp *2	; copy (2 from global temp to bp)
 		ADDp $bp $bp $dir	; bp = bp + dir
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 295:11
 		FORi $bi #BATCH_SIZE @.l3	; }
 	.e2:	PEEK %0 &clock 	; clock = global clock - BATCH_SIZE
 		SUBi $clock %0 #BATCH_SIZE
 		MOVi %1 $clock 	; write(clock, BATCH_SIZE, global buffer)
 		MOVi %2 #BATCH_SIZE 
 		MOVp %3 &buffer 
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 299:42
 		MOVp $bp &buffer 	; for (bp = global buffer to global buffer + BATCH_SIZE * 2) *bp = 0
 		! MULi <A> #BATCH_SIZE #2
 		ADDp %0 &buffer <A>
@@ -430,7 +430,7 @@ process:	FUNC	; signature func process() -> void
 		SUBi %2 $clock $tapData:TAP_DELAY	; read(clock - (int) tapData[TAP_DELAY], BATCH_SIZE, tapped)
 		MOVi %3 #BATCH_SIZE 
 		ADRL %4 $tapped *0
-		CALL ^read %1 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %1 *4	; expects function(int, int, ptr) -> unknown @ 306:62
 		! SHLi <A> #1 #RECTIFIER_BIT	; if (((int) tapData[TAP_BITS] & (1 << RECTIFIER_BIT)) != 0) 
 		ANDi %1 $tapData:TAP_BITS <A>
 		EQUi %1 #0 @.f8

--- a/tests/impala/golden/pongdev_code.gazl
+++ b/tests/impala/golden/pongdev_code.gazl
@@ -1,26 +1,26 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_18PPVV4d2 &.s_116AAO4d3 &.s_132NNL4d4
 	DATA &.s_164vDT4d5 &.s_1PPVVT4d6 &.s_2AAOOI4d7
 	DATA &.s_12NNLL4d8 &.s_contvD4d9
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 81:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 82:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
-signal:	GLOB *2	; signature array signal[2] : unknown
-EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown
+instance:	DATi #0	; signature global instance : int @ 86:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 91:1
+EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown @ 91:41
 	DATA #0x0 #0x1 #0x2 #0x3 #0x4 #0x5 #0x6 #0x7 #0x8 #0x9
 	DATA #0xa #0xb #0xc #0xd #0xe #0xf #0x10 #0x11 #0x12 #0x13
 	DATA #0x14 #0x15 #0x16 #0x17 #0x18 #0x19 #0x1a #0x1b #0x1c
@@ -55,24 +55,24 @@ EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unkn
 	DATA #0x7c00 #0x8000 #0x8800 #0x9000 #0x9800 #0xa000
 	DATA #0xa800 #0xb000 #0xb800 #0xc000 #0xc800 #0xd000
 	DATA #0xd800 #0xe000 #0xe800 #0xf000 #0xffff
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 126:1
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 127:1
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 128:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 129:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 130:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 131:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
-EPSILON_FLOAT:	! DEFf #1.0e-45	; signature const EPSILON_FLOAT : float
-SMALL_FLOAT:	! DEFf #1.0e-5	; signature const SMALL_FLOAT : float
-LARGE_FLOAT:	! DEFf #1.0e+10	; signature const LARGE_FLOAT : float
-HUGE_FLOAT:	! DEFf #1.0e+38	; signature const HUGE_FLOAT : float
-XOR_SHIFT_RANDOM_TO_FLOAT_FACTOR:	! DEFf #4.6566128730774e-10	; signature const XOR_SHIFT_RANDOM_TO_FLOAT_FACTOR : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 132:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 133:1
+EPSILON_FLOAT:	! DEFf #1.0e-45	; signature const EPSILON_FLOAT : float @ 134:1
+SMALL_FLOAT:	! DEFf #1.0e-5	; signature const SMALL_FLOAT : float @ 135:1
+LARGE_FLOAT:	! DEFf #1.0e+10	; signature const LARGE_FLOAT : float @ 136:1
+HUGE_FLOAT:	! DEFf #1.0e+38	; signature const HUGE_FLOAT : float @ 138:1
+XOR_SHIFT_RANDOM_TO_FLOAT_FACTOR:	! DEFf #4.6566128730774e-10	; signature const XOR_SHIFT_RANDOM_TO_FLOAT_FACTOR : float @ 140:1
 
 ;-----------------------------------------------------------------------------
 	$a:	OUTp
-stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
+stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr @ 140:17
 	$d:	INPp
 	$s:	INPp
 	$b:	LOCp
@@ -90,7 +90,7 @@ stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr
+intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr @ 159:22
 	$i:	INPi
 	$radix:	INPi
 	$minLength:	INPi
@@ -137,7 +137,7 @@ intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, 
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr buffer) -> ptr
+floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr buffer) -> ptr @ 179:24
 	$f:	INPf
 	$precision:	INPi
 	$buffer:	INPp
@@ -272,7 +272,7 @@ floatToString:	FUNC	; signature func floatToString(float f, int precision, ptr b
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
+traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void @ 284:20
 	$text:	INPp
 	$n:	INPi
 	$ints:	INPp
@@ -286,7 +286,7 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		EQUp $text &NULL @.f0	; if (text != null) p = (pointer) stpcpy(p, text)
 		MOVp %1 $p 	; p = (pointer) stpcpy(p, text)
 		MOVp %2 $text 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 291:49
 		MOVp $p %0 
 	.f0:	POKE $p #0 	; *p = 0
 		MOVi $i #0 	; for (i = 0 to n) 
@@ -299,18 +299,18 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		MOVi %4 #10 
 		MOVi %5 #1 
 		ADRL %6 $buffer *0
-		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr @ 295:62
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 295:63
 		MOVp $p %0 
 		FORi $i $n @.l2	; }
 	.e1:	ADRL %1 $line *0	; trace(line)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 297:13
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceFloats:	FUNC	; signature func traceFloats(ptr text, int n, ptr floats, int precision) -> void
+traceFloats:	FUNC	; signature func traceFloats(ptr text, int n, ptr floats, int precision) -> void @ 300:22
 	$text:	INPp
 	$n:	INPi
 	$floats:	INPp
@@ -325,7 +325,7 @@ traceFloats:	FUNC	; signature func traceFloats(ptr text, int n, ptr floats, int 
 		EQUp $text &NULL @.f0	; if (text != null) p = (pointer) stpcpy(p, text)
 		MOVp %1 $p 	; p = (pointer) stpcpy(p, text)
 		MOVp %2 $text 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 307:49
 		MOVp $p %0 
 	.f0:	POKE $p #0 	; *p = 0
 		MOVi $i #0 	; for (i = 0 to n) 
@@ -337,18 +337,18 @@ traceFloats:	FUNC	; signature func traceFloats(ptr text, int n, ptr floats, int 
 		PEEK %3 $floats $i
 		MOVi %4 $precision 
 		ADRL %5 $buffer *0
-		CALL &floatToString %2 *4	; expects floatToString(float, int, ptr) -> ptr
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &floatToString %2 *4	; expects floatToString(float, int, ptr) -> ptr @ 311:70
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 311:71
 		MOVp $p %0 
 		FORi $i $n @.l2	; }
 	.e1:	ADRL %1 $line *0	; trace(line)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 313:13
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
+traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void @ 316:19
 	$text:	INPp
 	$i:	INPi
 	$ints:	LOCA *1
@@ -357,13 +357,13 @@ traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
 		MOVp %1 $text 	; traceInts(text, 1, ints)
 		MOVi %2 #1 
 		ADRL %3 $ints *0
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 320:26
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceFloat:	FUNC	; signature func traceFloat(ptr text, float f, int precision) -> void
+traceFloat:	FUNC	; signature func traceFloat(ptr text, float f, int precision) -> void @ 323:21
 	$text:	INPp
 	$f:	INPf
 	$precision:	INPi
@@ -374,24 +374,24 @@ traceFloat:	FUNC	; signature func traceFloat(ptr text, float f, int precision) -
 		MOVi %2 #1 
 		ADRL %3 $floats *0
 		MOVi %4 $precision 
-		CALL &traceFloats %0 *5	; expects traceFloats(ptr, int, ptr, int) -> void
+		CALL &traceFloats %0 *5	; expects traceFloats(ptr, int, ptr, int) -> void @ 327:41
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 330:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 332:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 333:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 336:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -405,16 +405,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 343:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4dd 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 346:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float)trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 347:35
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -422,7 +422,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 361:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -431,7 +431,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 365:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -454,18 +454,18 @@ cos:	FUNC	; signature func cos(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sin:	FUNC	; signature func sin(float x) -> float
+sin:	FUNC	; signature func sin(float x) -> float @ 377:14
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		SUBf %1 $x #HALF_PI	; y = (float) cos(x - HALF_PI)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 380:30
 		MOVf $y %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-square:	FUNC	; signature func square(float x) -> float
+square:	FUNC	; signature func square(float x) -> float @ 383:17
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		MULf $y $x $x	; y = x * x
@@ -474,7 +474,7 @@ square:	FUNC	; signature func square(float x) -> float
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-complexFFT:	FUNC	; signature func complexFFT(int n, ptr data) -> void
+complexFFT:	FUNC	; signature func complexFFT(int n, ptr data) -> void @ 389:21
 	$n:	INPi
 	$data:	INPp
 	$i:	LOCi
@@ -530,11 +530,11 @@ complexFFT:	FUNC	; signature func complexFFT(int n, ptr data) -> void
 		iTOf %1 $mmax #1.0
 		DIVf $theta <A> %1
 		MULf %2 $theta #0.5	; rx = 2.0 * (float) square((float) sin(theta * 0.5))
-		CALL &sin %1 *2	; expects sin(float) -> float
-		CALL &square %0 *2	; expects square(float) -> float
+		CALL &sin %1 *2	; expects sin(float) -> float @ 422:53
+		CALL &square %0 *2	; expects square(float) -> float @ 422:54
 		MULf $rx #2.0 %0
 		MOVf %1 $theta 	; ry = (float) sin(theta)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 423:26
 		MOVf $ry %0 
 		MOVf $px #1.0 	; px = 1.0
 		MOVf $py #0.0 	; py = 0.0
@@ -599,7 +599,7 @@ complexFFT:	FUNC	; signature func complexFFT(int n, ptr data) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-realFFT:	FUNC	; signature func realFFT(int n, ptr input, ptr output) -> void
+realFFT:	FUNC	; signature func realFFT(int n, ptr input, ptr output) -> void @ 450:18
 	$n:	INPi
 	$input:	INPp
 	$output:	INPp
@@ -631,7 +631,7 @@ realFFT:	FUNC	; signature func realFFT(int n, ptr input, ptr output) -> void
 		CALL ^assertFail %0 *1
 	.a2:	MOVi %1 $n 	; complexFFT(n, input)
 		MOVp %2 $input 
-		CALL &complexFFT %0 *3	; expects complexFFT(int, ptr) -> void
+		CALL &complexFFT %0 *3	; expects complexFFT(int, ptr) -> void @ 457:22
 		PEEK $r0 $input #0	; r0 = (float) input[0]
 		PEEK $i0 $input #1	; i0 = (float) input[1]
 		ADDf %0 $r0 $i0	; output[0] = (r0 + i0)
@@ -642,11 +642,11 @@ realFFT:	FUNC	; signature func realFFT(int n, ptr input, ptr output) -> void
 		iTOf %0 $n #1.0
 		DIVf $theta <A> %0
 		MULf %2 $theta #0.5	; rx = 2.0 * (float) square((float) sin(theta * 0.5))
-		CALL &sin %1 *2	; expects sin(float) -> float
-		CALL &square %0 *2	; expects square(float) -> float
+		CALL &sin %1 *2	; expects sin(float) -> float @ 467:53
+		CALL &square %0 *2	; expects square(float) -> float @ 467:54
 		MULf $rx #2.0 %0
 		MOVf %1 $theta 	; ry = (float) sin(theta)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 468:26
 		MOVf $ry %0 
 		MOVf $px #1.0 	; px = 1.0
 		MOVf $py #0.0 	; py = 0.0
@@ -703,7 +703,7 @@ realFFT:	FUNC	; signature func realFFT(int n, ptr input, ptr output) -> void
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-exp:	FUNC	; signature func exp(float x) -> float
+exp:	FUNC	; signature func exp(float x) -> float @ 515:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -727,7 +727,7 @@ exp:	FUNC	; signature func exp(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-log:	FUNC	; signature func log(float x) -> float
+log:	FUNC	; signature func log(float x) -> float @ 548:14
 	$x:	INPf
 	$a:	LOCf
 	$b:	LOCf
@@ -738,7 +738,7 @@ log:	FUNC	; signature func log(float x) -> float
 		LEQf $x #0.0 @.t0	; if (x <= 0.0 || x >= 1.0e38) error("Domain error")
 		LSSf $x #1.0e38 @.f1
 	.t0:	MOVp %1 &.s_Domain4de 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 556:52
 		GOTO @.e2  
 	.f1:	MOVf $b #0.0 	; b = 0.0
 		MOVf $m $x 	; m = x
@@ -767,7 +767,7 @@ log:	FUNC	; signature func log(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-pow:	FUNC	; signature func pow(float x, float y) -> float
+pow:	FUNC	; signature func pow(float x, float y) -> float @ 576:14
 	$x:	INPf
 	$y:	INPf
 	$a:	LOCf
@@ -780,15 +780,15 @@ pow:	FUNC	; signature func pow(float x, float y) -> float
 		SUBf $a #0.0 $a	; a = -a
 	.f1:	LEQf $a #0.0 @.f2	; if (a > 0.0) z = (float) exp((float) log(a) * y)
 		MOVf %2 $a 	; z = (float) exp((float) log(a) * y)
-		CALL &log %1 *2	; expects log(float) -> float
+		CALL &log %1 *2	; expects log(float) -> float @ 583:46
 		MULf %1 %1 $y
-		CALL &exp %0 *2	; expects exp(float) -> float
+		CALL &exp %0 *2	; expects exp(float) -> float @ 583:50
 		MOVf $z %0 
 		GOTO @.e3  
 	.f2:	LSSf $a #0.0 @.t4	; if (a < 0.0 || y <= 0.0) error("Domain error")
 		GRTf $y #0.0 @.f5
 	.t4:	MOVp %1 &.s_Domain4de 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 584:53
 	.f5:	NOOP
 	.e3:	EQUf $a $x @.f7	; if (a != x && (y * 0.5) != floor(y * 0.5)) z = -z
 		MULf %0 $y #0.5
@@ -801,23 +801,23 @@ pow:	FUNC	; signature func pow(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sqrt:	FUNC	; signature func sqrt(float x) -> float
+sqrt:	FUNC	; signature func sqrt(float x) -> float @ 588:15
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; y = (float) pow(x, 0.5)
 		MOVf %2 #0.5 
-		CALL &pow %0 *3	; expects pow(float, float) -> float
+		CALL &pow %0 *3	; expects pow(float, float) -> float @ 591:25
 		MOVf $y %0 
 		RETU   	; }
 
 	GLOB *1
-xorShiftRandomSeedX:	DATi #123456789	; signature global xorShiftRandomSeedX : int
+xorShiftRandomSeedX:	DATi #123456789	; signature global xorShiftRandomSeedX : int @ 595:1
 	GLOB *1
-xorShiftRandomSeedY:	DATi #362436069	; signature global xorShiftRandomSeedY : int
+xorShiftRandomSeedY:	DATi #362436069	; signature global xorShiftRandomSeedY : int @ 596:1
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-xorShiftRandom:	FUNC	; signature func xorShiftRandom() -> int
+xorShiftRandom:	FUNC	; signature func xorShiftRandom() -> int @ 596:25
 	$x:	LOCi
 	$t:	LOCi
 ;-----------------------------------------------------------------------------
@@ -835,70 +835,70 @@ xorShiftRandom:	FUNC	; signature func xorShiftRandom() -> int
 		POKE &xorShiftRandomSeedY $y 	; global xorShiftRandomSeedY = y
 		RETU   	; }
 
-MAX_TAP_COUNT:	! DEFi #16	; signature const MAX_TAP_COUNT : int
-PAN_LEFT_BIT:	! DEFi #7	; signature const PAN_LEFT_BIT : int
-PAN_RIGHT_BIT:	! DEFi #6	; signature const PAN_RIGHT_BIT : int
-VOL_DEC_BIT:	! DEFi #5	; signature const VOL_DEC_BIT : int
-VOL_INC_BIT:	! DEFi #4	; signature const VOL_INC_BIT : int
-ACCELERATE_BIT:	! DEFi #3	; signature const ACCELERATE_BIT : int
-DEACCELERATE_BIT:	! DEFi #2	; signature const DEACCELERATE_BIT : int
-RANDOM_BIT:	! DEFi #1	; signature const RANDOM_BIT : int
-RECTIFIER_BIT:	! DEFi #0	; signature const RECTIFIER_BIT : int
-SIXTEENTHS_MODE:	! DEFi #1	; signature const SIXTEENTHS_MODE : int
-EIGHTS_MODE:	! DEFi #2	; signature const EIGHTS_MODE : int
-ODD_SIXTEENTHS_MODE:	! DEFi #3	; signature const ODD_SIXTEENTHS_MODE : int
-MORE_SIXTEENTHS_MODE:	! DEFi #4	; signature const MORE_SIXTEENTHS_MODE : int
-VOL_DEC_FACTOR:	! DEFf #0.70710678118655	; signature const VOL_DEC_FACTOR : float
-VOL_INC_FACTOR:	! DEFf #1.414213562373	; signature const VOL_INC_FACTOR : float
-VOL_DEC_FACTOR_EXTENDED:	! DEFf #0.70710678118655	; signature const VOL_DEC_FACTOR_EXTENDED : float
-VOL_INC_FACTOR_EXTENDED:	! DEFf #1.414213562373	; signature const VOL_INC_FACTOR_EXTENDED : float
-TIME_DEC_FACTOR:	! DEFf #0.70710678118655	; signature const TIME_DEC_FACTOR : float
-TIME_INC_FACTOR:	! DEFf #1.414213562373	; signature const TIME_INC_FACTOR : float
-PAN_ATTENUATE:	! DEFf #0.25	; signature const PAN_ATTENUATE : float
-BATCH_SIZE:	! DEFi #64	; signature const BATCH_SIZE : int
-TAP_BITS:	! DEFi #0	; signature const TAP_BITS : int
-TAP_DELAY:	! DEFi #1	; signature const TAP_DELAY : int
-TAP_LEFT_GAIN:	! DEFi #2	; signature const TAP_LEFT_GAIN : int
-TAP_RIGHT_GAIN:	! DEFi #3	; signature const TAP_RIGHT_GAIN : int
-TAP_STRUCT_SIZE:	! DEFi #4	; signature const TAP_STRUCT_SIZE : int
+MAX_TAP_COUNT:	! DEFi #16	; signature const MAX_TAP_COUNT : int @ 614:1
+PAN_LEFT_BIT:	! DEFi #7	; signature const PAN_LEFT_BIT : int @ 615:1
+PAN_RIGHT_BIT:	! DEFi #6	; signature const PAN_RIGHT_BIT : int @ 616:1
+VOL_DEC_BIT:	! DEFi #5	; signature const VOL_DEC_BIT : int @ 617:1
+VOL_INC_BIT:	! DEFi #4	; signature const VOL_INC_BIT : int @ 618:1
+ACCELERATE_BIT:	! DEFi #3	; signature const ACCELERATE_BIT : int @ 619:1
+DEACCELERATE_BIT:	! DEFi #2	; signature const DEACCELERATE_BIT : int @ 620:1
+RANDOM_BIT:	! DEFi #1	; signature const RANDOM_BIT : int @ 621:1
+RECTIFIER_BIT:	! DEFi #0	; signature const RECTIFIER_BIT : int @ 623:1
+SIXTEENTHS_MODE:	! DEFi #1	; signature const SIXTEENTHS_MODE : int @ 624:1
+EIGHTS_MODE:	! DEFi #2	; signature const EIGHTS_MODE : int @ 625:1
+ODD_SIXTEENTHS_MODE:	! DEFi #3	; signature const ODD_SIXTEENTHS_MODE : int @ 626:1
+MORE_SIXTEENTHS_MODE:	! DEFi #4	; signature const MORE_SIXTEENTHS_MODE : int @ 628:1
+VOL_DEC_FACTOR:	! DEFf #0.70710678118655	; signature const VOL_DEC_FACTOR : float @ 629:1
+VOL_INC_FACTOR:	! DEFf #1.414213562373	; signature const VOL_INC_FACTOR : float @ 630:1
+VOL_DEC_FACTOR_EXTENDED:	! DEFf #0.70710678118655	; signature const VOL_DEC_FACTOR_EXTENDED : float @ 631:1
+VOL_INC_FACTOR_EXTENDED:	! DEFf #1.414213562373	; signature const VOL_INC_FACTOR_EXTENDED : float @ 632:1
+TIME_DEC_FACTOR:	! DEFf #0.70710678118655	; signature const TIME_DEC_FACTOR : float @ 633:1
+TIME_INC_FACTOR:	! DEFf #1.414213562373	; signature const TIME_INC_FACTOR : float @ 634:1
+PAN_ATTENUATE:	! DEFf #0.25	; signature const PAN_ATTENUATE : float @ 636:1
+BATCH_SIZE:	! DEFi #64	; signature const BATCH_SIZE : int @ 636:26
+TAP_BITS:	! DEFi #0	; signature const TAP_BITS : int @ 641:1
+TAP_DELAY:	! DEFi #1	; signature const TAP_DELAY : int @ 642:1
+TAP_LEFT_GAIN:	! DEFi #2	; signature const TAP_LEFT_GAIN : int @ 643:1
+TAP_RIGHT_GAIN:	! DEFi #3	; signature const TAP_RIGHT_GAIN : int @ 644:1
+TAP_STRUCT_SIZE:	! DEFi #4	; signature const TAP_STRUCT_SIZE : int @ 646:1
 	GLOB *1
-tapCount:	DATi #0	; signature global tapCount : int
+tapCount:	DATi #0	; signature global tapCount : int @ 647:1
 	! MULi <A> #TAP_STRUCT_SIZE #MAX_TAP_COUNT
-tapData:	GLOB *<A>	; signature array tapData[<A>] : unknown
+tapData:	GLOB *<A>	; signature array tapData[<A>] : unknown @ 654:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 654:15
 	$i:	LOCi
 	$buf:	LOCA *256
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4df 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 657:15
 		PEEK %2 &instance 	; trace(intToString(global instance, 10, 1, buf))
 		MOVi %3 #10 
 		MOVi %4 #1 
 		ADRL %5 $buf *0
-		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr @ 658:48
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 658:49
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 665:16
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4e0 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 667:16
 		MOVp %1 &.s_params4e1 	; traceInts(" params: ", PARAM_COUNT, global params)
 		MOVi %2 #PARAM_COUNT 
 		MOVp %3 &params 
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 668:52
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-maxi:	FUNC	; signature func maxi(int a, int b) -> int
+maxi:	FUNC	; signature func maxi(int a, int b) -> int @ 672:15
 	$a:	INPi
 	$b:	INPi
 ;-----------------------------------------------------------------------------
@@ -910,7 +910,7 @@ maxi:	FUNC	; signature func maxi(int a, int b) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-calcGainsAndDelays:	FUNC	; signature func calcGainsAndDelays(int highBits, int lowBits, float initGain, float initDelay, ptr gains, ptr delays, ptr maxGain, ptr maxDelay, ptr endGain, ptr endDelay) -> void
+calcGainsAndDelays:	FUNC	; signature func calcGainsAndDelays(int highBits, int lowBits, float initGain, float initDelay, ptr gains, ptr delays, ptr maxGain, ptr maxDelay, ptr endGain, ptr endDelay) -> void @ 679:29
 	$highBits:	INPi
 	$lowBits:	INPi
 	$initGain:	INPf
@@ -964,20 +964,20 @@ calcGainsAndDelays:	FUNC	; signature func calcGainsAndDelays(int highBits, int l
 		MOVi %2 #8 
 		MOVp %3 $gains 
 		MOVi %4 #8 
-		CALL &traceFloats %0 *5	; expects traceFloats(ptr, int, ptr, int) -> void
+		CALL &traceFloats %0 *5	; expects traceFloats(ptr, int, ptr, int) -> void @ 697:37
 		MOVp %1 &.s_max4e3 	; traceFloat("max: ", (float) *maxGain, 8)
 		PEEK %2 $maxGain 
 		MOVi %3 #8 
-		CALL &traceFloat %0 *4	; expects traceFloat(ptr, float, int) -> void
+		CALL &traceFloat %0 *4	; expects traceFloat(ptr, float, int) -> void @ 698:42
 		MOVp %1 &.s_delays4e4 	; traceFloats("delays: ", 8, delays, 8)
 		MOVi %2 #8 
 		MOVp %3 $delays 
 		MOVi %4 #8 
-		CALL &traceFloats %0 *5	; expects traceFloats(ptr, int, ptr, int) -> void
+		CALL &traceFloats %0 *5	; expects traceFloats(ptr, int, ptr, int) -> void @ 699:39
 		MOVp %1 &.s_max4e3 	; traceFloat("max: ", (float) *maxDelay, 8)
 		PEEK %2 $maxDelay 
 		MOVi %3 #8 
-		CALL &traceFloat %0 *4	; expects traceFloat(ptr, float, int) -> void
+		CALL &traceFloat %0 *4	; expects traceFloat(ptr, float, int) -> void @ 700:43
 		POKE $endGain $g 	; *endGain = g
 		POKE $endDelay $d 	; *endDelay = d
 		RETU   	; }
@@ -985,7 +985,7 @@ calcGainsAndDelays:	FUNC	; signature func calcGainsAndDelays(int highBits, int l
 
 ;-----------------------------------------------------------------------------
 	$o:	OUTf
-addTaps:	FUNC	; signature func addTaps(int op, int highBits, int lowBits, float offset, ptr gains, ptr delays, float gainScale, float delayScale, int firstStep) -> float
+addTaps:	FUNC	; signature func addTaps(int op, int highBits, int lowBits, float offset, ptr gains, ptr delays, float gainScale, float delayScale, int firstStep) -> float @ 705:18
 	$op:	INPi
 	$highBits:	INPi
 	$lowBits:	INPi
@@ -1031,7 +1031,7 @@ addTaps:	FUNC	; signature func addTaps(int op, int highBits, int lowBits, float 
 		! SHLi <A> #1 #RANDOM_BIT	; if ((highBits & (1 << RANDOM_BIT)) != 0) r = itof((int) xorShiftRandom()) * (XOR_SHIFT_RANDOM_TO_FLOAT_FACTOR * (1.0/12.0)) * d
 		ANDi %0 $highBits <A>
 		EQUi %0 #0 @.f5
-		CALL &xorShiftRandom %0 *1	; expects xorShiftRandom() -> int
+		CALL &xorShiftRandom %0 *1	; expects xorShiftRandom() -> int @ 723:76
 		! DIVf <A> #1.0 #12.0
 		! MULf <A> #XOR_SHIFT_RANDOM_TO_FLOAT_FACTOR <A>
 		iTOf %0 %0 <A>
@@ -1044,7 +1044,7 @@ addTaps:	FUNC	; signature func addTaps(int op, int highBits, int lowBits, float 
 		fTOi %1 %1 #1.0
 		SUBi %1 %1 #BATCH_SIZE
 		MOVi %2 #0 
-		CALL &maxi %0 *3	; expects maxi(int, int) -> int
+		CALL &maxi %0 *3	; expects maxi(int, int) -> int @ 725:52
 		POKE $p #TAP_DELAY %0
 		fTOi %0 $lg #1.0	; p[TAP_LEFT_GAIN] = ftoi(lg)
 		POKE $p #TAP_LEFT_GAIN %0
@@ -1058,9 +1058,9 @@ addTaps:	FUNC	; signature func addTaps(int op, int highBits, int lowBits, float 
 		FORi $i #8 @.l1	; }
 	.e0:	RETU   	; }
 
-CHECK_PARAMS_COUNT:	! DEFi #6	; signature const CHECK_PARAMS_COUNT : int
-lastParams:	GLOB *CHECK_PARAMS_COUNT	; signature array lastParams[CHECK_PARAMS_COUNT] : unknown
-CHECK_PARAMS:	CNST *CHECK_PARAMS_COUNT	; signature array CHECK_PARAMS[CHECK_PARAMS_COUNT] : unknown
+CHECK_PARAMS_COUNT:	! DEFi #6	; signature const CHECK_PARAMS_COUNT : int @ 735:33
+lastParams:	GLOB *CHECK_PARAMS_COUNT	; signature array lastParams[CHECK_PARAMS_COUNT] : unknown @ 736:44
+CHECK_PARAMS:	CNST *CHECK_PARAMS_COUNT	; signature array CHECK_PARAMS[CHECK_PARAMS_COUNT] : unknown @ 737:49
 	DATA #OPERATOR_1_PARAM_INDEX #OPERAND_1_HIGH_PARAM_INDEX
 	DATA #OPERAND_1_LOW_PARAM_INDEX #OPERATOR_2_PARAM_INDEX
 	DATA #OPERAND_2_HIGH_PARAM_INDEX
@@ -1068,7 +1068,7 @@ CHECK_PARAMS:	CNST *CHECK_PARAMS_COUNT	; signature array CHECK_PARAMS[CHECK_PARA
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 745:17
 	$localParams:	LOCA *PARAM_COUNT
 	$i:	LOCi
 	$v:	LOCi
@@ -1098,7 +1098,7 @@ update:	FUNC	; signature func update() -> void
 	.f2:	FORi $i #CHECK_PARAMS_COUNT @.l1	; }
 	.e0:	EQUi $rebuild #FALSE @.f3	; if (rebuild != FALSE) 
 		MOVp %1 &.s_rebuil4e5 	; trace("rebuilding")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 760:22
 		POKE &tapCount #0 	; global tapCount = 0
 		POKE &xorShiftRandomSeedX #123456789 	; global xorShiftRandomSeedX = 123456789
 		POKE &xorShiftRandomSeedY #362436069 	; global xorShiftRandomSeedY = 362436069
@@ -1120,7 +1120,7 @@ update:	FUNC	; signature func update() -> void
 		ADRL %8 $maxDelay1 *0
 		ADRL %9 $endGain *0
 		ADRL %10 $endDelay *0
-		CALL &calcGainsAndDelays %0 *11	; expects calcGainsAndDelays(int, int, float, float, ptr, ptr, ptr, ptr, ptr, ptr) -> void
+		CALL &calcGainsAndDelays %0 *11	; expects calcGainsAndDelays(int, int, float, float, ptr, ptr, ptr, ptr, ptr, ptr) -> void @ 769:184
 	.f4:	MOVf $offset #0.0 	; offset = 0.0
 		SWCH $localParams:OPERATOR_2_PARAM_INDEX *5 @.s5	; switch ((int) localParams[OPERATOR_2_PARAM_INDEX] == 0 to 5) 
 	.s5#0:	GOTO @noSecond  	; goto noSecond
@@ -1140,7 +1140,7 @@ update:	FUNC	; signature func update() -> void
 		ADRL %8 $maxDelay1 *0
 		ADRL %9 $endGain *0
 		ADRL %10 $endDelay *0
-		CALL &calcGainsAndDelays %0 *11	; expects calcGainsAndDelays(int, int, float, float, ptr, ptr, ptr, ptr, ptr, ptr) -> void
+		CALL &calcGainsAndDelays %0 *11	; expects calcGainsAndDelays(int, int, float, float, ptr, ptr, ptr, ptr, ptr, ptr) -> void @ 778:202
 		MOVi %1 $localParams:OPERATOR_1_PARAM_INDEX 	; offset = (float) addTaps((int) localParams[OPERATOR_1_PARAM_INDEX], (int) localParams[OPERAND_1_HIGH_PARAM_INDEX], (int) localParams[OPERAND_1_LOW_PARAM_INDEX], 0.0, gains, delays, 256.0 / maxGain1, stepLength / maxDelay1, 0)
 		MOVi %2 $localParams:OPERAND_1_HIGH_PARAM_INDEX 
 		MOVi %3 $localParams:OPERAND_1_LOW_PARAM_INDEX 
@@ -1150,7 +1150,7 @@ update:	FUNC	; signature func update() -> void
 		DIVf %7 #256.0 $maxGain1
 		DIVf %8 $stepLength $maxDelay1
 		MOVi %9 #0 
-		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float
+		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float @ 779:230
 		MOVf $offset %0 
 		MOVi %1 $localParams:OPERATOR_2_PARAM_INDEX 	; addTaps((int) localParams[OPERATOR_2_PARAM_INDEX], (int) localParams[OPERAND_2_HIGH_PARAM_INDEX], (int) localParams[OPERAND_2_LOW_PARAM_INDEX], offset, &gains[8], &delays[8], 256.0 / maxGain1, stepLength / maxDelay1, 8)
 		MOVi %2 $localParams:OPERAND_2_HIGH_PARAM_INDEX 
@@ -1161,7 +1161,7 @@ update:	FUNC	; signature func update() -> void
 		DIVf %7 #256.0 $maxGain1
 		DIVf %8 $stepLength $maxDelay1
 		MOVi %9 #8 
-		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float
+		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float @ 780:224
 		GOTO @done  	; goto done
 	.s5:	NOOP
 	.e6:	MOVf $maxGain2 #0.00001 	; maxGain2 = 0.00001
@@ -1176,7 +1176,7 @@ update:	FUNC	; signature func update() -> void
 		ADRL %8 $maxDelay2 *0
 		ADRL %9 $endGain *0
 		ADRL %10 $endDelay *0
-		CALL &calcGainsAndDelays %0 *11	; expects calcGainsAndDelays(int, int, float, float, ptr, ptr, ptr, ptr, ptr, ptr) -> void
+		CALL &calcGainsAndDelays %0 *11	; expects calcGainsAndDelays(int, int, float, float, ptr, ptr, ptr, ptr, ptr, ptr) -> void @ 786:191
 		MOVi %1 $localParams:OPERATOR_2_PARAM_INDEX 	; addTaps((int) localParams[OPERATOR_2_PARAM_INDEX], (int) localParams[OPERAND_2_HIGH_PARAM_INDEX], (int) localParams[OPERAND_2_LOW_PARAM_INDEX], offset, &gains[8], &delays[8], 256.0 / maxGain2, stepLength / maxDelay2, 8)
 		MOVi %2 $localParams:OPERAND_2_HIGH_PARAM_INDEX 
 		MOVi %3 $localParams:OPERAND_2_LOW_PARAM_INDEX 
@@ -1186,7 +1186,7 @@ update:	FUNC	; signature func update() -> void
 		DIVf %7 #256.0 $maxGain2
 		DIVf %8 $stepLength $maxDelay2
 		MOVi %9 #8 
-		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float
+		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float @ 787:222
 	noSecond:	LEQi $localParams:OPERATOR_1_PARAM_INDEX #0 @.f3	; if ((int) localParams[OPERATOR_1_PARAM_INDEX] > 0) 
 		MOVi %1 $localParams:OPERATOR_1_PARAM_INDEX 	; addTaps((int) localParams[OPERATOR_1_PARAM_INDEX], (int) localParams[OPERAND_1_HIGH_PARAM_INDEX], (int) localParams[OPERAND_1_LOW_PARAM_INDEX], 0.0, gains, delays, 256.0 / maxGain1, stepLength / maxDelay1, 0)
 		MOVi %2 $localParams:OPERAND_1_HIGH_PARAM_INDEX 
@@ -1197,17 +1197,17 @@ update:	FUNC	; signature func update() -> void
 		DIVf %7 #256.0 $maxGain1
 		DIVf %8 $stepLength $maxDelay1
 		MOVi %9 #0 
-		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float
+		CALL &addTaps %0 *10	; expects addTaps(int, int, int, float, ptr, ptr, float, float, int) -> float @ 790:212
 	done:	NOOP
 	.f3:	RETU   	; }
 
-temp:	GLOB *2	; signature array temp[2] : unknown
+temp:	GLOB *2	; signature array temp[2] : unknown @ 910:21
 	! MULi <A> #BATCH_SIZE #2
-buffer:	GLOB *<A>	; signature array buffer[<A>] : unknown
+buffer:	GLOB *<A>	; signature array buffer[<A>] : unknown @ 911:36
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 928:18
 	! MULi <A> #BATCH_SIZE #2
 	$tapData:	LOCA *TAP_STRUCT_SIZE
 	$tapped:	LOCA *2
@@ -1231,7 +1231,7 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $clock 	; write(clock, 1, global signal)
 		MOVi %2 #1 
 		MOVp %3 &signal 
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 942:33
 		MOVp $p &tapData 	; p = global tapData
 		MOVi $i #0 	; for (i = 0 to global tapCount) 
 		PEEK %0 &tapCount 
@@ -1241,7 +1241,7 @@ process:	FUNC	; signature func process() -> void
 		SUBi %2 $clock $tapData:TAP_DELAY	; read(clock - (int) tapData[TAP_DELAY], 1, tapped)
 		MOVi %3 #1 
 		ADRL %4 $tapped *0
-		CALL ^read %1 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %1 *4	; expects function(int, int, ptr) -> unknown @ 946:53
 		! SHLi <A> #1 #RECTIFIER_BIT	; if (((int) tapData[TAP_BITS] & (1 << RECTIFIER_BIT)) != 0) 
 		ANDi %1 $tapData:TAP_BITS <A>
 		EQUi %1 #0 @.f4
@@ -1261,7 +1261,7 @@ process:	FUNC	; signature func process() -> void
 		POKE &signal:0 %0 
 		SHRi %0 $mixR #8	; global signal[1] = mixR >> 8
 		POKE &signal:1 %0 
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 959:10
 		GOTO @.l1  	; }
 		GOTO @.e5  	; } else 
 	.f0:	NOOP
@@ -1273,14 +1273,14 @@ process:	FUNC	; signature func process() -> void
 		COPY &signal $bp *2	; copy (2 from bp to global signal)
 		COPY $bp &temp *2	; copy (2 from global temp to bp)
 		ADDp $bp $bp #2	; bp = bp + 2
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 971:11
 		FORi $bi #BATCH_SIZE @.l8	; }
 	.e7:	PEEK %0 &clock 	; clock = global clock - BATCH_SIZE
 		SUBi $clock %0 #BATCH_SIZE
 		MOVi %1 $clock 	; write(clock, BATCH_SIZE, global buffer)
 		MOVi %2 #BATCH_SIZE 
 		MOVp %3 &buffer 
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 975:42
 		MOVp $bp &buffer 	; for (bp = global buffer to global buffer + BATCH_SIZE * 2) *bp = 0
 		! MULi <A> #BATCH_SIZE #2
 		ADDp %0 &buffer <A>
@@ -1297,7 +1297,7 @@ process:	FUNC	; signature func process() -> void
 		SUBi %2 $clock $tapData:TAP_DELAY	; read(clock - (int) tapData[TAP_DELAY], BATCH_SIZE, _tapped)
 		MOVi %3 #BATCH_SIZE 
 		ADRL %4 $_tapped *0
-		CALL ^read %1 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %1 *4	; expects function(int, int, ptr) -> unknown @ 982:63
 		! SHLi <A> #1 #RECTIFIER_BIT	; if (((int) tapData[TAP_BITS] & (1 << RECTIFIER_BIT)) != 0) 
 		ANDi %1 $tapData:TAP_BITS <A>
 		EQUi %1 #0 @.f13

--- a/tests/impala/golden/prawnOS.gazl
+++ b/tests/impala/golden/prawnOS.gazl
@@ -1,17 +1,17 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-; signature extern native print() -> unknown
-; signature extern native printInt() -> unknown
-; signature extern native printLF() -> unknown
-; signature extern native abort() -> unknown
-; signature extern native input() -> unknown
-; signature extern native inputEOF() -> unknown
-; signature extern native launch() -> unknown
+; signature extern native print() -> unknown @ 1:20
+; signature extern native printInt() -> unknown @ 2:23
+; signature extern native printLF() -> unknown @ 3:22
+; signature extern native abort() -> unknown @ 4:20
+; signature extern native input() -> unknown @ 5:20
+; signature extern native inputEOF() -> unknown @ 6:23
+; signature extern native launch() -> unknown @ 7:21
 
 ;-----------------------------------------------------------------------------
 	$d:	OUTi
-strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int
+strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int @ 9:17
 	$s0:	INPp
 	$s1:	INPp
 	$a:	LOCp
@@ -35,29 +35,29 @@ strcmp:	FUNC	; signature func strcmp(ptr s0, ptr s1) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 22:15
 	$inp:	LOCA *256
 ;-----------------------------------------------------------------------------
 	mainLoop:	MOVp %1 &.s_4d2 	; mainLoop:
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 27:14
 		MOVi %1 #255 	; input(255, inp)
 		ADRL %2 $inp *0
-		CALL ^input %0 *3	; expects function(int, ptr) -> unknown
+		CALL ^input %0 *3	; expects function(int, ptr) -> unknown @ 28:18
 		ADRL %1 $inp *0	; if ((int)strcmp(inp, "logon") == 0) 
 		MOVp %2 &.s_logon4d3 
-		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int @ 30:33
 		NEQi %0 #0 @mainLoop
 	.l1:	MOVp %1 &.s_Enteru4d4 	; print("Enter username: ")
-		CALL ^print %0 *2	; expects function(ptr) -> unknown
+		CALL ^print %0 *2	; expects function(ptr) -> unknown @ 32:30
 		MOVi %1 #255 	; input(255, inp)
 		ADRL %2 $inp *0
-		CALL ^input %0 *3	; expects function(int, ptr) -> unknown
+		CALL ^input %0 *3	; expects function(int, ptr) -> unknown @ 33:20
 		ADRL %1 $inp *0	; } while ((int)strcmp(inp, "username") != 0)
 		MOVp %2 &.s_userna4d5 
-		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int
+		CALL &strcmp %0 *3	; expects strcmp(ptr, ptr) -> int @ 34:42
 		NEQi %0 #0 @.l1
 		MOVp %1 &.s_advent4d6 	; launch("advent")
-		CALL ^launch %0 *2	; expects function(ptr) -> unknown
+		CALL ^launch %0 *2	; expects function(ptr) -> unknown @ 35:20
 		GOTO @mainLoop  	; goto mainLoop
 		RETU   	; }
 

--- a/tests/impala/golden/rhubarb_code.gazl
+++ b/tests/impala/golden/rhubarb_code.gazl
@@ -1,27 +1,27 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_Sillyr4d2 &.s_4d3 &.s_4d3 &.s_LEFTDE4d4 &.s_4d3
 	DATA &.s_4d3 &.s_4d3 &.s_RINGMO4d5
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 81:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 82:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
+instance:	DATi #0	; signature global instance : int @ 83:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
-EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 86:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 91:1
+EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown @ 91:41
 	DATA #0x0 #0x1 #0x2 #0x3 #0x4 #0x5 #0x6 #0x7 #0x8 #0x9
 	DATA #0xa #0xb #0xc #0xd #0xe #0xf #0x10 #0x11 #0x12 #0x13
 	DATA #0x14 #0x15 #0x16 #0x17 #0x18 #0x19 #0x1a #0x1b #0x1c
@@ -56,19 +56,19 @@ EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unkn
 	DATA #0x7c00 #0x8000 #0x8800 #0x9000 #0x9800 #0xa000
 	DATA #0xa800 #0xb000 #0xb800 #0xc000 #0xc800 #0xd000
 	DATA #0xd800 #0xe000 #0xe800 #0xf000 #0xffff
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 126:1
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 127:1
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 128:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 129:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 130:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 131:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 132:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 134:1
 
 ;-----------------------------------------------------------------------------
 	$a:	OUTp
-stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
+stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr @ 134:17
 	$d:	INPp
 	$s:	INPp
 	$b:	LOCp
@@ -86,7 +86,7 @@ stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr
+intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr @ 153:22
 	$i:	INPi
 	$radix:	INPi
 	$minLength:	INPi
@@ -133,7 +133,7 @@ intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
+traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void @ 171:20
 	$text:	INPp
 	$n:	INPi
 	$ints:	INPp
@@ -147,7 +147,7 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		EQUp $text &NULL @.f0	; if (text != null) p = (pointer) stpcpy(p, text)
 		MOVp %1 $p 	; p = (pointer) stpcpy(p, text)
 		MOVp %2 $text 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 178:49
 		MOVp $p %0 
 	.f0:	POKE $p #0 	; *p = 0
 		MOVi $i #0 	; for (i = 0 to n) 
@@ -160,18 +160,18 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		MOVi %4 #10 
 		MOVi %5 #1 
 		ADRL %6 $buffer *0
-		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr @ 182:62
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 182:63
 		MOVp $p %0 
 		FORi $i $n @.l2	; }
 	.e1:	ADRL %1 $line *0	; trace(line)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 184:13
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
+traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void @ 187:19
 	$text:	INPp
 	$i:	INPi
 	$ints:	LOCA *1
@@ -180,24 +180,24 @@ traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
 		MOVp %1 $text 	; traceInts(text, 1, ints)
 		MOVi %2 #1 
 		ADRL %3 $ints *0
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 191:26
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 194:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 196:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 197:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 200:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -211,16 +211,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 207:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4d7 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 210:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float)trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 211:35
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -228,7 +228,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 225:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -237,7 +237,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 229:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -257,46 +257,46 @@ cos:	FUNC	; signature func cos(float x) -> float
 		MOVf $y #0.0 	; y = 0.0
 	.f1:	RETU   	; }
 
-COS_TABLE_BITS:	! DEFi #12	; signature const COS_TABLE_BITS : int
+COS_TABLE_BITS:	! DEFi #12	; signature const COS_TABLE_BITS : int @ 244:1
 	! SHLi <A> #1 #COS_TABLE_BITS
-COS_TABLE_SIZE:	! DEFi <A>	; signature const COS_TABLE_SIZE : int
-BATCH_SIZE:	! DEFi #77	; signature const BATCH_SIZE : int
+COS_TABLE_SIZE:	! DEFi <A>	; signature const COS_TABLE_SIZE : int @ 245:1
+BATCH_SIZE:	! DEFi #77	; signature const BATCH_SIZE : int @ 245:26
 	! ADDi <A> #COS_TABLE_SIZE #1
-cosTable:	GLOB *<A>	; signature array cosTable[<A>] : unknown
+cosTable:	GLOB *<A>	; signature array cosTable[<A>] : unknown @ 251:1
 	GLOB *1
-doReset:	DATi #FALSE	; signature global doReset : int
+doReset:	DATi #FALSE	; signature global doReset : int @ 252:1
 	GLOB *1
-rate:	DATi #0	; signature global rate : int
+rate:	DATi #0	; signature global rate : int @ 253:1
 	GLOB *1
-diff:	DATi #0	; signature global diff : int
+diff:	DATi #0	; signature global diff : int @ 254:1
 	GLOB *1
-delayL:	DATi #0	; signature global delayL : int
+delayL:	DATi #0	; signature global delayL : int @ 255:1
 	GLOB *1
-delayR:	DATi #0	; signature global delayR : int
+delayR:	DATi #0	; signature global delayR : int @ 256:1
 	GLOB *1
-syncBit:	DATi #0	; signature global syncBit : int
+syncBit:	DATi #0	; signature global syncBit : int @ 263:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 263:15
 	$i:	LOCi
 	$buf:	LOCA *256
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4d8 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 266:15
 		PEEK %2 &instance 	; trace(intToString(global instance, 10, 1, buf))
 		MOVi %3 #10 
 		MOVi %4 #1 
 		ADRL %5 $buf *0
-		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr @ 267:48
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 267:49
 		MOVi $i #0 	; for (i = 0 to COS_TABLE_SIZE) global cosTable[i] = ftoi((float) cos((TWICE_PI / itof(COS_TABLE_SIZE)) * itof(i)) * 2048.0)
 		GEQi #0 #COS_TABLE_SIZE @.e0
 	.l1:	NOOP
 		! iTOf <A> #COS_TABLE_SIZE #1.0	; global cosTable[i] = ftoi((float) cos((TWICE_PI / itof(COS_TABLE_SIZE)) * itof(i)) * 2048.0)
 		! DIVf <A> #TWICE_PI <A>
 		iTOf %1 $i <A>
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 268:115
 		fTOi %0 %0 #2048.0
 		POKE &cosTable $i %0
 		FORi $i #COS_TABLE_SIZE @.l1
@@ -307,32 +307,32 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 276:16
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4d9 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 278:16
 		MOVp %1 &.s_params4da 	; traceInts(" params: ", PARAM_COUNT, global params)
 		MOVi %2 #PARAM_COUNT 
 		MOVp %3 &params 
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 279:52
 		POKE &doReset #TRUE 	; global doReset = TRUE
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 287:17
 	$buf:	LOCA *256
 	$params:	LOCA *PARAM_COUNT
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_update4db 	; trace("update")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 290:17
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 308:18
 	$l:	LOCi
 	$r:	LOCi
 	$holdL:	LOCi
@@ -362,7 +362,7 @@ process:	FUNC	; signature func process() -> void
 		GOTO @.l2  	; }
 	.e3:	POKE &signal:0 $holdL 	; global signal[0] = holdL
 		POKE &signal:1 $holdL 	; global signal[1] = holdL
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 345:10
 		GOTO @.l0  	; }
 		RETU   	; }
 

--- a/tests/impala/golden/ringmod_code.gazl
+++ b/tests/impala/golden/ringmod_code.gazl
@@ -1,26 +1,26 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_4d2 &.s_4d2 &.s_4d2 &.s_LEFTDE4d3 &.s_4d2 &.s_4d2
 	DATA &.s_4d2 &.s_RINGMO4d4
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 81:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 82:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
+instance:	DATi #0	; signature global instance : int @ 83:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 86:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 88:1
 	CNST *1
 	! SHLi <A> #1 #OPERAND_1_HIGH_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_1_LOW_PARAM_INDEX
@@ -31,8 +31,8 @@ signal:	GLOB *2	; signature array signal[2] : unknown
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #SWITCHES_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
-EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 95:1
+EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown @ 95:41
 	DATA #0x0 #0x1 #0x2 #0x3 #0x4 #0x5 #0x6 #0x7 #0x8 #0x9
 	DATA #0xa #0xb #0xc #0xd #0xe #0xf #0x10 #0x11 #0x12 #0x13
 	DATA #0x14 #0x15 #0x16 #0x17 #0x18 #0x19 #0x1a #0x1b #0x1c
@@ -67,19 +67,19 @@ EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unkn
 	DATA #0x7c00 #0x8000 #0x8800 #0x9000 #0x9800 #0xa000
 	DATA #0xa800 #0xb000 #0xb800 #0xc000 #0xc800 #0xd000
 	DATA #0xd800 #0xe000 #0xe800 #0xf000 #0xffff
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 130:1
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 131:1
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 132:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 133:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 134:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 135:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 136:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 138:1
 
 ;-----------------------------------------------------------------------------
 	$a:	OUTp
-stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
+stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr @ 138:17
 	$d:	INPp
 	$s:	INPp
 	$b:	LOCp
@@ -97,7 +97,7 @@ stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr
+intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr @ 157:22
 	$i:	INPi
 	$radix:	INPi
 	$minLength:	INPi
@@ -144,7 +144,7 @@ intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
+traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void @ 175:20
 	$text:	INPp
 	$n:	INPi
 	$ints:	INPp
@@ -158,7 +158,7 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		EQUp $text &NULL @.f0	; if (text != null) p = (pointer) stpcpy(p, text)
 		MOVp %1 $p 	; p = (pointer) stpcpy(p, text)
 		MOVp %2 $text 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 182:49
 		MOVp $p %0 
 	.f0:	POKE $p #0 	; *p = 0
 		MOVi $i #0 	; for (i = 0 to n) 
@@ -171,18 +171,18 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		MOVi %4 #10 
 		MOVi %5 #1 
 		ADRL %6 $buffer *0
-		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr @ 186:62
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 186:63
 		MOVp $p %0 
 		FORi $i $n @.l2	; }
 	.e1:	ADRL %1 $line *0	; trace(line)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 188:13
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
+traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void @ 191:19
 	$text:	INPp
 	$i:	INPi
 	$ints:	LOCA *1
@@ -191,24 +191,24 @@ traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
 		MOVp %1 $text 	; traceInts(text, 1, ints)
 		MOVi %2 #1 
 		ADRL %3 $ints *0
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 195:26
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 198:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 200:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 201:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 204:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -222,16 +222,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 211:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4d6 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 214:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float)trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 215:35
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -239,7 +239,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 229:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -248,7 +248,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 233:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -268,46 +268,46 @@ cos:	FUNC	; signature func cos(float x) -> float
 		MOVf $y #0.0 	; y = 0.0
 	.f1:	RETU   	; }
 
-COS_TABLE_BITS:	! DEFi #12	; signature const COS_TABLE_BITS : int
+COS_TABLE_BITS:	! DEFi #12	; signature const COS_TABLE_BITS : int @ 248:1
 	! SHLi <A> #1 #COS_TABLE_BITS
-COS_TABLE_SIZE:	! DEFi <A>	; signature const COS_TABLE_SIZE : int
-BATCH_SIZE:	! DEFi #77	; signature const BATCH_SIZE : int
+COS_TABLE_SIZE:	! DEFi <A>	; signature const COS_TABLE_SIZE : int @ 249:1
+BATCH_SIZE:	! DEFi #77	; signature const BATCH_SIZE : int @ 249:26
 	! ADDi <A> #COS_TABLE_SIZE #1
-cosTable:	GLOB *<A>	; signature array cosTable[<A>] : unknown
+cosTable:	GLOB *<A>	; signature array cosTable[<A>] : unknown @ 255:1
 	GLOB *1
-doReset:	DATi #FALSE	; signature global doReset : int
+doReset:	DATi #FALSE	; signature global doReset : int @ 256:1
 	GLOB *1
-rate:	DATi #0	; signature global rate : int
+rate:	DATi #0	; signature global rate : int @ 257:1
 	GLOB *1
-diff:	DATi #0	; signature global diff : int
+diff:	DATi #0	; signature global diff : int @ 258:1
 	GLOB *1
-delayL:	DATi #0	; signature global delayL : int
+delayL:	DATi #0	; signature global delayL : int @ 259:1
 	GLOB *1
-delayR:	DATi #0	; signature global delayR : int
+delayR:	DATi #0	; signature global delayR : int @ 260:1
 	GLOB *1
-syncBit:	DATi #0	; signature global syncBit : int
+syncBit:	DATi #0	; signature global syncBit : int @ 269:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 269:15
 	$i:	LOCi
 	$buf:	LOCA *256
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4d7 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 272:15
 		PEEK %2 &instance 	; trace(intToString(global instance, 10, 1, buf))
 		MOVi %3 #10 
 		MOVi %4 #1 
 		ADRL %5 $buf *0
-		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr @ 273:48
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 273:49
 		MOVi $i #0 	; for (i = 0 to COS_TABLE_SIZE) global cosTable[i] = ftoi((float) cos((TWICE_PI / itof(COS_TABLE_SIZE)) * itof(i)) * 2048.0)
 		GEQi #0 #COS_TABLE_SIZE @.e0
 	.l1:	NOOP
 		! iTOf <A> #COS_TABLE_SIZE #1.0	; global cosTable[i] = ftoi((float) cos((TWICE_PI / itof(COS_TABLE_SIZE)) * itof(i)) * 2048.0)
 		! DIVf <A> #TWICE_PI <A>
 		iTOf %1 $i <A>
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 274:115
 		fTOi %0 %0 #2048.0
 		POKE &cosTable $i %0
 		FORi $i #COS_TABLE_SIZE @.l1
@@ -318,21 +318,21 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 284:16
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4d8 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 286:16
 		MOVp %1 &.s_params4d9 	; traceInts(" params: ", PARAM_COUNT, global params)
 		MOVi %2 #PARAM_COUNT 
 		MOVp %3 &params 
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 287:52
 		POKE &doReset #TRUE 	; global doReset = TRUE
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int
+displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int @ 291:28
 	$x:	INPi
 ;-----------------------------------------------------------------------------
 		! SUBi <A> #8 #3	; y = 0x1 << (x >> (8 - 3))
@@ -343,34 +343,34 @@ displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 304:17
 	$buf:	LOCA *256
 	$params:	LOCA *PARAM_COUNT
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_update4da 	; trace("update")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 307:17
 		MOVp %1 &.s_params4d9 	; traceInts(" params: ", PARAM_COUNT, global params)
 		MOVi %2 #PARAM_COUNT 
 		MOVp %3 &params 
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 308:52
 		ADRL %0 $params *0	; copy (PARAM_COUNT from global params to params)
 		COPY %0 &params *PARAM_COUNT
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_1_HIGH_PARAM_INDEX	; global delayL = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_1_HIGH_PARAM_INDEX]]
 		POKE &delayL %0 
 		MOVi %1 $params:OPERAND_1_HIGH_PARAM_INDEX 	; global displayLEDs[0] = displayDelayValue((int) params[OPERAND_1_HIGH_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 311:85
 		POKE &displayLEDs:0 %0 
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_1_LOW_PARAM_INDEX	; global delayR = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_1_LOW_PARAM_INDEX]]
 		POKE &delayR %0 
 		MOVi %1 $params:OPERAND_1_LOW_PARAM_INDEX 	; global displayLEDs[1] = displayDelayValue((int) params[OPERAND_1_LOW_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 313:84
 		POKE &displayLEDs:1 %0 
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_2_HIGH_PARAM_INDEX	; global rate = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_2_HIGH_PARAM_INDEX]]
 		POKE &rate %0 
 		SHLi %0 $params:OPERAND_2_LOW_PARAM_INDEX #8	; global diff = (int) params[OPERAND_2_LOW_PARAM_INDEX] << 8
 		POKE &diff %0 
 		MOVi %1 $params:OPERAND_2_LOW_PARAM_INDEX 	; global displayLEDs[3] = displayDelayValue((int) params[OPERAND_2_LOW_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 316:84
 		POKE &displayLEDs:3 %0 
 		PEEK %0 &params:SWITCHES_PARAM_INDEX 	; global syncBit = (int) global params[SWITCHES_PARAM_INDEX] & SWITCHES_SYNC_MASK
 		ANDi %0 %0 #SWITCHES_SYNC_MASK
@@ -380,7 +380,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 335:18
 	$i:	LOCi
 	$c0:	LOCi
 	$c1:	LOCi
@@ -422,7 +422,7 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $clock 	; write(clock, 1, global signal)
 		MOVi %2 #1 
 		MOVp %3 &signal 
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 353:34
 		ANDi $idx $idx #0xFFFF	; idx = idx & 0xFFFF
 		! SUBi <A> #16 #COS_TABLE_BITS	; p = &global cosTable[idx >> (16 - COS_TABLE_BITS)]
 		SHRi %0 $idx <A>
@@ -457,11 +457,11 @@ process:	FUNC	; signature func process() -> void
 		SUBi %1 $clock $delayL	; read(clock - delayL, 1, leftPair)
 		MOVi %2 #1 
 		ADRL %3 $leftPair *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 366:37
 		SUBi %1 $clock $delayR	; read(clock - delayR, 1, rightPair)
 		MOVi %2 #1 
 		ADRL %3 $rightPair *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 367:38
 		MULi %0 $leftPair:0 $cosL	; global signal[0] = ((int) leftPair[0] * cosL) >> 15
 		SHRi %0 %0 #15
 		POKE &signal:0 %0 
@@ -469,7 +469,7 @@ process:	FUNC	; signature func process() -> void
 		SHRi %0 %0 #15
 		POKE &signal:1 %0 
 		ADDi $idx $idx $rate	; idx = idx + rate
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 371:11
 		FORi $i #BATCH_SIZE @.l4	; }
 		GOTO @.l0  	; }
 		RETU   	; }

--- a/tests/impala/golden/rpm16_code.gazl
+++ b/tests/impala/golden/rpm16_code.gazl
@@ -1,26 +1,26 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_4d2 &.s_4d2 &.s_4d2 &.s_LEFTDE4d3 &.s_4d2 &.s_4d2
 	DATA &.s_4d2 &.s_RINGMO4d4
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 81:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 82:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
+instance:	DATi #0	; signature global instance : int @ 83:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 86:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 88:1
 	CNST *1
 	! SHLi <A> #1 #OPERAND_1_HIGH_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_1_LOW_PARAM_INDEX
@@ -31,32 +31,32 @@ signal:	GLOB *2	; signature array signal[2] : unknown
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #SWITCHES_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 111:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 111:15
 ;-----------------------------------------------------------------------------
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 121:16
 ;-----------------------------------------------------------------------------
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 132:17
 ;-----------------------------------------------------------------------------
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 151:18
 	$tmp:	LOCi
 	$clock:	LOCi
 	$samps:	LOCA *4
@@ -76,7 +76,7 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $clock 	; read(clock, 1, samps)
 		MOVi %2 #1 
 		ADRL %3 $samps *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 160:24
 		SUBi $diff $diff #0x8000	; diff = diff - 0x8000
 		GEQi $diff #0 @.f2	; if (diff < 0) 
 		MOVi $diff #0 	; diff = 0
@@ -95,25 +95,25 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $clock 	; write(clock, 1, samps)
 		MOVi %2 #1 
 		ADRL %3 $samps *0
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 167:25
 		ANDi %0 $clock #1	; if ((clock & 1) == 0) 
 		NEQi %0 #0 @.f3
 		DIVi %1 $clock #2	; read(clock / 2, 1, global signal)
 		MOVi %2 #1 
 		MOVp %3 &signal 
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 169:37
 		GOTO @.e4  	; } else 
 	.f3:	DIVi %1 $clock #2	; read(clock / 2, 2, samps)
 		MOVi %2 #2 
 		ADRL %3 $samps *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 171:29
 		ADDi %0 $samps:0 $samps:2	; global signal[0] = ((int) samps[0] + (int) samps[2]) >> 1
 		SHRi %0 %0 #1
 		POKE &signal:0 %0 
 		ADDi %0 $samps:1 $samps:3	; global signal[1] = ((int) samps[1] + (int) samps[3]) >> 1
 		SHRi %0 %0 #1
 		POKE &signal:1 %0 
-	.e4:	CALL ^yield %0 *1	; expects function() -> unknown
+	.e4:	CALL ^yield %0 *1	; expects function() -> unknown @ 175:10
 		ADDi $clock $clock #1	; clock = clock + 1
 		GOTO @.l0  	; }
 		RETU   	; }

--- a/tests/impala/golden/sam.gazl
+++ b/tests/impala/golden/sam.gazl
@@ -1,25 +1,25 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-panelTextRows:	GLOB *8	; signature array panelTextRows[8] : unknown
+FALSE:	! DEFi #0	; signature const FALSE : int @ 9:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 10:1
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 12:1
+panelTextRows:	GLOB *8	; signature array panelTextRows[8] : unknown @ 40:31
 	DATA &.s_5Khz4d2 &.s_114d3 &.s_224d4 &.s_44SPEE4d5
 	DATA &.s_ONCE4d6 &.s_LOOPcl4d7 &.s_LOOPcl4d7:52
 	DATA &.s_MOUTHT4d8
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-CONFIG_STRING_MAX_SIZE:	! DEFi #100	; signature const CONFIG_STRING_MAX_SIZE : int
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 53:1
+CONFIG_STRING_MAX_SIZE:	! DEFi #100	; signature const CONFIG_STRING_MAX_SIZE : int @ 53:39
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-signal:	GLOB *2	; signature array signal[2] : unknown
-config:	GLOB *CONFIG_STRING_MAX_SIZE	; signature array config[CONFIG_STRING_MAX_SIZE] : unknown
+clock:	DATi #0	; signature global clock : int @ 55:17
+signal:	GLOB *2	; signature array signal[2] : unknown @ 56:23
+config:	GLOB *CONFIG_STRING_MAX_SIZE	; signature array config[CONFIG_STRING_MAX_SIZE] : unknown @ 57:44
 	GLOB *1
-configText:	DATp &.s_Enters4d9	; signature global configText : ptr
+configText:	DATp &.s_Enters4d9	; signature global configText : ptr @ 58:88
 	! ADDi <A> #CONFIG_STRING_MAX_SIZE #20
-dynamicPanelTextRow:	GLOB *<A>	; signature array dynamicPanelTextRow[<A>] : unknown
+dynamicPanelTextRow:	GLOB *<A>	; signature array dynamicPanelTextRow[<A>] : unknown @ 59:62
 	CNST *1
-clockFreqLimit:	DATi #88200	; signature readonly clockFreqLimit : int
+clockFreqLimit:	DATi #88200	; signature readonly clockFreqLimit : int @ 61:1
 	CNST *1
 	! SHLi <A> #1 #OPERAND_1_HIGH_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_1_LOW_PARAM_INDEX
@@ -30,33 +30,33 @@ clockFreqLimit:	DATi #88200	; signature readonly clockFreqLimit : int
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #OPERATOR_1_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native abort() -> unknown
-; signature extern native exit() -> unknown
-scales:	CNST *5	; signature array scales[5] : unknown
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 65:1
+; signature extern native trace() -> unknown @ 65:20
+; signature extern native yield() -> unknown @ 66:20
+; signature extern native abort() -> unknown @ 67:20
+; signature extern native exit() -> unknown @ 68:19
+scales:	CNST *5	; signature array scales[5] : unknown @ 70:26
 	DATA #200 #200 #100 #50 #25
 	GLOB *1
-lastClock:	DATi #65535	; signature global lastClock : int
+lastClock:	DATi #65535	; signature global lastClock : int @ 72:29
 	GLOB *1
-pleaseBreak:	DATi #FALSE	; signature global pleaseBreak : int
+pleaseBreak:	DATi #FALSE	; signature global pleaseBreak : int @ 73:31
 	GLOB *1
-abortWhenDone:	DATi #FALSE	; signature global abortWhenDone : int
+abortWhenDone:	DATi #FALSE	; signature global abortWhenDone : int @ 74:33
 	GLOB *1
-writepos:	DATi #0	; signature global writepos : int
+writepos:	DATi #0	; signature global writepos : int @ 75:24
 	GLOB *1
-lastSample:	DATi #0	; signature global lastSample : int
+lastSample:	DATi #0	; signature global lastSample : int @ 76:26
 	GLOB *1
-bufferpos:	DATi #0	; signature global bufferpos : int
+bufferpos:	DATi #0	; signature global bufferpos : int @ 77:25
 	GLOB *1
-useScale:	DATi #25	; signature global useScale : int
+useScale:	DATi #25	; signature global useScale : int @ 78:25
 	GLOB *1
-scale:	DATi #25	; signature global scale : int
+scale:	DATi #25	; signature global scale : int @ 79:22
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTp
-strcpy:	FUNC	; signature func strcpy(ptr d, ptr s) -> ptr
+strcpy:	FUNC	; signature func strcpy(ptr d, ptr s) -> ptr @ 81:17
 	$d:	INPp
 	$s:	INPp
 	$a:	LOCp
@@ -76,7 +76,7 @@ strcpy:	FUNC	; signature func strcpy(ptr d, ptr s) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$a:	OUTp
-stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
+stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr @ 93:17
 	$d:	INPp
 	$s:	INPp
 	$b:	LOCp
@@ -94,7 +94,7 @@ stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTp
-strcat:	FUNC	; signature func strcat(ptr d, ptr s) -> ptr
+strcat:	FUNC	; signature func strcat(ptr d, ptr s) -> ptr @ 105:17
 	$d:	INPp
 	$s:	INPp
 	$a:	LOCp
@@ -115,7 +115,7 @@ strcat:	FUNC	; signature func strcat(ptr d, ptr s) -> ptr
 		GOTO @.l2  	; }
 	.e3:	RETU   	; }
 
-someFlags:	CNST *108	; signature array someFlags[108] : unknown
+someFlags:	CNST *108	; signature array someFlags[108] : unknown @ 119:31
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #2 #2 #2
 	DATA #2 #2 #2 #130 #0 #0 #2 #2 #2 #2 #2 #2 #3 #3 #3 #3 #3
@@ -124,8 +124,8 @@ someFlags:	CNST *108	; signature array someFlags[108] : unknown
 	DATA #172 #192 #160 #160 #172 #180 #164 #192 #168 #168
 	DATA #176 #192 #188 #0 #0 #0 #2 #0 #32 #32 #155 #32 #192
 	DATA #185 #32 #205 #163 #76 #138 #142
-RULES_SIZE:	! DEFi #6000	; signature const RULES_SIZE : int
-rules:	CNST *RULES_SIZE	; signature array rules[RULES_SIZE] : unknown
+RULES_SIZE:	! DEFi #6000	; signature const RULES_SIZE : int @ 136:28
+rules:	CNST *RULES_SIZE	; signature array rules[RULES_SIZE] : unknown @ 137:34
 	DATA #93 #193 #32 #40 #65 #46 #41 #61 #69 #72 #52 #89 #46
 	DATA #160 #40 #65 #41 #32 #61 #65 #200 #32 #40 #65 #82 #69
 	DATA #41 #32 #61 #65 #65 #210 #32 #40 #65 #82 #41 #79 #61
@@ -596,14 +596,14 @@ rules:	CNST *RULES_SIZE	; signature array rules[RULES_SIZE] : unknown
 	DATA #32 #65 #69 #54 #212 #40 #94 #41 #61 #32 #75 #65 #69
 	DATA #52 #82 #73 #88 #212 #93 #193 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0
-rulesOffsets:	CNST *26	; signature array rulesOffsets[26] : unknown
+rulesOffsets:	CNST *26	; signature array rulesOffsets[26] : unknown @ 329:33
 	DATA #0 #405 #503 #674 #825 #1221 #1286 #1406 #1479 #1830
 	DATA #1847 #1870 #1937 #2033 #2133 #2721 #2814 #2852 #2885
 	DATA #3117 #3495 #3638 #3667 #3886 #3911 #4058
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-TextToPhonemes:	FUNC	; signature func TextToPhonemes(ptr input) -> int
+TextToPhonemes:	FUNC	; signature func TextToPhonemes(ptr input) -> int @ 333:25
 	$input:	INPp
 	$inputCopy:	LOCA *256
 	$p:	LOCp
@@ -951,9 +951,9 @@ TextToPhonemes:	FUNC	; signature func TextToPhonemes(ptr input) -> int
 		GOTO @.l46  	; }
 	_return:	RETU   	; }
 
-stressInputTable:	CNST *9	; signature array stressInputTable[9] : unknown
+stressInputTable:	CNST *9	; signature array stressInputTable[9] : unknown @ 623:36
 	DATA #'*' #'1' #'2' #'3' #'4' #'5' #'6' #'7' #'8'
-signInputTable1:	CNST *81	; signature array signInputTable1[81] : unknown
+signInputTable1:	CNST *81	; signature array signInputTable1[81] : unknown @ 627:36
 	DATA #' ' #'.' #'?' #',' #'-' #'I' #'I' #'E' #'A' #'A'
 	DATA #'A' #'A' #'U' #'A' #'I' #'E' #'U' #'O' #'R' #'L'
 	DATA #'W' #'Y' #'W' #'R' #'L' #'W' #'Y' #'M' #'N' #'N'
@@ -963,7 +963,7 @@ signInputTable1:	CNST *81	; signature array signInputTable1[81] : unknown
 	DATA #'G' #'*' #'*' #'G' #'*' #'*' #'P' #'*' #'*' #'T'
 	DATA #'*' #'*' #'K' #'*' #'*' #'K' #'*' #'*' #'U' #'U'
 	DATA #'U'
-signInputTable2:	CNST *81	; signature array signInputTable2[81] : unknown
+signInputTable2:	CNST *81	; signature array signInputTable2[81] : unknown @ 641:36
 	DATA #'*' #'*' #'*' #'*' #'*' #'Y' #'H' #'H' #'E' #'A'
 	DATA #'H' #'O' #'H' #'X' #'X' #'R' #'X' #'H' #'X' #'X'
 	DATA #'X' #'X' #'H' #'*' #'*' #'*' #'*' #'*' #'*' #'X'
@@ -973,7 +973,7 @@ signInputTable2:	CNST *81	; signature array signInputTable2[81] : unknown
 	DATA #'*' #'*' #'*' #'X' #'*' #'*' #'*' #'*' #'*' #'*'
 	DATA #'*' #'*' #'*' #'*' #'*' #'X' #'*' #'*' #'L' #'M'
 	DATA #'N'
-flags:	CNST *81	; signature array flags[81] : unknown
+flags:	CNST *81	; signature array flags[81] : unknown @ 655:26
 	DATA #0 #0 #0 #0 #0 #0xA4 #0xA4 #0xA4 #0xA4 #0xA4 #0xA4
 	DATA #0x84 #0x84 #0xA4 #0xA4 #0x84 #0x84 #0x84 #0x84 #0x84
 	DATA #0x84 #0x84 #0x44 #0x44 #0x44 #0x44 #0x44 #0x4C #0x4C
@@ -983,14 +983,14 @@ flags:	CNST *81	; signature array flags[81] : unknown
 	DATA #0x4E #0x4E #0x4E #0x4E #0x4E #0x4E #0x4E #0x4E #0x4E
 	DATA #0x4B #0x4B #0x4B #0x4B #0x4B #0x4B #0x4B #0x4B #0x4B
 	DATA #0x4B #0x4B #0x4B #0x80 #0xC1 #0xC1
-flags2:	CNST *78	; signature array flags2[78] : unknown
+flags2:	CNST *78	; signature array flags2[78] : unknown @ 669:26
 	DATA #0x80 #0xC1 #0xC1 #0xC1 #0xC1 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0x10 #0x10 #0x10 #0x10
 	DATA #8 #0xC #8 #4 #0x40 #0x24 #0x20 #0x20 #0x24 #0 #0
 	DATA #0x24 #0x20 #0x20 #0x24 #0x20 #0x20 #0 #0x20 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #4 #4 #4 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #4 #4 #4 #0 #0 #0 #0 #0 #0
-sinus:	CNST *256	; signature array sinus[256] : unknown
+sinus:	CNST *256	; signature array sinus[256] : unknown @ 682:26
 	DATA #0 #0 #0 #0x10 #0x10 #0x10 #0x10 #0x10 #0x10 #0x20
 	DATA #0x20 #0x20 #0x20 #0x20 #0x20 #0x30 #0x30 #0x30 #0x30
 	DATA #0x30 #0x30 #0x30 #0x40 #0x40 #0x40 #0x40 #0x40 #0x40
@@ -1019,7 +1019,7 @@ sinus:	CNST *256	; signature array sinus[256] : unknown
 	DATA #0xC0 #0xC0 #0xC0 #0xC0 #0xC0 #0xC0 #0xC0 #0xD0 #0xD0
 	DATA #0xD0 #0xD0 #0xD0 #0xD0 #0xD0 #0xE0 #0xE0 #0xE0 #0xE0
 	DATA #0xE0 #0xE0 #0xF0 #0xF0 #0xF0 #0xF0 #0xF0 #0xF0 #0 #0
-rectangle:	GLOB *256	; signature array rectangle[256] : unknown
+rectangle:	GLOB *256	; signature array rectangle[256] : unknown @ 717:28
 	DATA #0x90 #0x90 #0x90 #0x90 #0x90 #0x90 #0x90 #0x90 #0x90
 	DATA #0x90 #0x90 #0x90 #0x90 #0x90 #0x90 #0x90 #0x90 #0x90
 	DATA #0x90 #0x90 #0x90 #0x90 #0x90 #0x90 #0x90 #0x90 #0x90
@@ -1049,7 +1049,7 @@ rectangle:	GLOB *256	; signature array rectangle[256] : unknown
 	DATA #0x70 #0x70 #0x70 #0x70 #0x70 #0x70 #0x70 #0x70 #0x70
 	DATA #0x70 #0x70 #0x70 #0x70 #0x70 #0x70 #0x70 #0x70 #0x70
 	DATA #0x70 #0x70 #0x70 #0x70
-multtable:	CNST *256	; signature array multtable[256] : unknown
+multtable:	CNST *256	; signature array multtable[256] : unknown @ 752:31
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #1 #1 #2 #2 #3 #3 #4 #4 #5 #5 #6 #6 #7 #7 #0 #1 #2 #3
 	DATA #4 #5 #6 #7 #8 #9 #0xA #0xB #0xC #0xD #0xE #0xF #0 #1
@@ -1075,7 +1075,7 @@ multtable:	CNST *256	; signature array multtable[256] : unknown
 	DATA #0xF8 #0xF7 #0xF6 #0xF5 #0xF4 #0xF3 #0xF2 #0xF1 #0
 	DATA #0xFF #0xFF #0xFE #0xFE #0xFD #0xFD #0xFC #0xFC #0xFB
 	DATA #0xFB #0xFA #0xFA #0xF9 #0xF9 #0xF8
-freq1data:	GLOB *80	; signature array freq1data[80] : unknown
+freq1data:	GLOB *80	; signature array freq1data[80] : unknown @ 787:28
 	DATA #0 #0x13 #0x13 #0x13 #0x13 #0xA #0xE #0x12 #0x18
 	DATA #0x1A #0x16 #0x14 #0x10 #0x14 #0xE #0x12 #0xE #0x12
 	DATA #0x12 #0x10 #0xC #0xE #0xA #0x12 #0xE #0xA #8 #6 #6
@@ -1083,7 +1083,7 @@ freq1data:	GLOB *80	; signature array freq1data[80] : unknown
 	DATA #6 #6 #5 #6 #0 #0x12 #0x1A #0x14 #0x1A #0x12 #0xC #6
 	DATA #6 #6 #6 #6 #6 #6 #6 #6 #6 #6 #6 #6 #6 #6 #6 #6 #6 #6
 	DATA #0xA #0xA #6 #6 #6 #0x2C #0x13
-freq2data:	GLOB *80	; signature array freq2data[80] : unknown
+freq2data:	GLOB *80	; signature array freq2data[80] : unknown @ 800:27
 	DATA #0 #0x43 #0x43 #0x43 #0x43 #0x54 #0x48 #0x42 #0x3E
 	DATA #0x28 #0x2C #0x1E #0x24 #0x2C #0x48 #0x30 #0x24 #0x1E
 	DATA #0x32 #0x24 #0x1C #0x44 #0x18 #0x32 #0x1E #0x18 #0x52
@@ -1093,7 +1093,7 @@ freq2data:	GLOB *80	; signature array freq2data[80] : unknown
 	DATA #0x1A #0x1A #0x1A #0x42 #0x42 #0x42 #0x6E #0x6E #0x6E
 	DATA #0x54 #0x54 #0x54 #0x1A #0x1A #0x1A #0x42 #0x42 #0x42
 	DATA #0x6D #0x56 #0x6D #0x54 #0x54 #0x54 #0x7F #0x7F
-freq3data:	CNST *80	; signature array freq3data[80] : unknown
+freq3data:	CNST *80	; signature array freq3data[80] : unknown @ 813:29
 	DATA #0 #0x5B #0x5B #0x5B #0x5B #0x6E #0x5D #0x5B #0x58
 	DATA #0x59 #0x57 #0x58 #0x52 #0x59 #0x5D #0x3E #0x52 #0x58
 	DATA #0x3E #0x6E #0x50 #0x5D #0x5A #0x3C #0x6E #0x5A #0x6E
@@ -1103,7 +1103,7 @@ freq3data:	CNST *80	; signature array freq3data[80] : unknown
 	DATA #0x51 #0x51 #0x51 #0x79 #0x79 #0x79 #0x70 #0x6E #0x6E
 	DATA #0x5E #0x5E #0x5E #0x51 #0x51 #0x51 #0x79 #0x79 #0x79
 	DATA #0x65 #0x65 #0x70 #0x5E #0x5E #0x5E #8 #1
-ampl1data:	CNST *80	; signature array ampl1data[80] : unknown
+ampl1data:	CNST *80	; signature array ampl1data[80] : unknown @ 826:29
 	DATA #0 #0 #0 #0 #0 #0xD #0xD #0xE #0xF #0xF #0xF #0xF
 	DATA #0xF #0xC #0xD #0xC #0xF #0xF #0xD #0xD #0xD #0xE
 	DATA #0xD #0xC #0xD #0xD #0xD #0xC #9 #9 #0 #0 #0 #0 #0 #0
@@ -1111,46 +1111,46 @@ ampl1data:	CNST *80	; signature array ampl1data[80] : unknown
 	DATA #0xF #0xF #0xF #0xF #0xD #2 #4 #0 #2 #4 #0 #1 #4 #0
 	DATA #1 #4 #0 #0 #0 #0 #0 #0 #0 #0 #0xC #0 #0 #0 #0 #0xF
 	DATA #0xF
-ampl2data:	CNST *80	; signature array ampl2data[80] : unknown
+ampl2data:	CNST *80	; signature array ampl2data[80] : unknown @ 839:29
 	DATA #0 #0 #0 #0 #0 #0xA #0xB #0xD #0xE #0xD #0xC #0xC
 	DATA #0xB #9 #0xB #0xB #0xC #0xC #0xC #8 #8 #0xC #8 #0xA
 	DATA #8 #8 #0xA #3 #9 #6 #0 #0 #0 #0 #0 #0 #0 #0 #3 #5 #3
 	DATA #4 #0 #0 #0 #5 #0xA #2 #0xE #0xD #0xC #0xD #0xC #8 #0
 	DATA #1 #0 #0 #1 #0 #0 #1 #0 #0 #1 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0xA #0 #0 #0xA #0 #0 #0
-ampl3data:	CNST *80	; signature array ampl3data[80] : unknown
+ampl3data:	CNST *80	; signature array ampl3data[80] : unknown @ 852:29
 	DATA #0 #0 #0 #0 #0 #8 #7 #8 #8 #1 #1 #0 #1 #0 #7 #5 #1 #0
 	DATA #6 #1 #0 #7 #0 #5 #1 #0 #8 #0 #0 #3 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #1 #0 #0 #0 #0 #0 #1 #0xE #1 #9 #1 #0 #1 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #7 #0 #0 #5 #0 #0x13 #0x10
-phonemeLengthTable2:	CNST *80	; signature array phonemeLengthTable2[80] : unknown
+phonemeLengthTable2:	CNST *80	; signature array phonemeLengthTable2[80] : unknown @ 865:39
 	DATA #0 #0x12 #0x12 #0x12 #8 #0xB #9 #0xB #0xE #0xF #0xB
 	DATA #0x10 #0xC #6 #6 #0xE #0xC #0xE #0xC #0xB #8 #8 #0xB
 	DATA #0xA #9 #8 #8 #8 #8 #8 #3 #5 #2 #2 #2 #2 #2 #2 #6 #6
 	DATA #8 #6 #6 #2 #9 #4 #2 #1 #0xE #0xF #0xF #0xF #0xE #0xE
 	DATA #8 #2 #2 #7 #2 #1 #7 #2 #2 #7 #2 #2 #8 #2 #2 #6 #2 #2
 	DATA #7 #2 #4 #7 #1 #4 #5 #5
-phonemeLengthTable1:	CNST *80	; signature array phonemeLengthTable1[80] : unknown
+phonemeLengthTable1:	CNST *80	; signature array phonemeLengthTable1[80] : unknown @ 878:39
 	DATA #0 #0x12 #0x12 #0x12 #8 #8 #8 #8 #8 #0xB #6 #0xC #0xA
 	DATA #5 #5 #0xB #0xA #0xA #0xA #9 #8 #7 #9 #7 #6 #8 #6 #7
 	DATA #7 #7 #2 #5 #2 #2 #2 #2 #2 #2 #6 #6 #7 #6 #6 #2 #8 #3
 	DATA #1 #0x1E #0xD #0xC #0xC #0xC #0xE #9 #6 #1 #2 #5 #1
 	DATA #1 #6 #1 #2 #6 #1 #2 #8 #2 #2 #4 #2 #2 #6 #1 #4 #6 #1
 	DATA #4 #0xC7 #0xFF
-tab45696:	CNST *80	; signature array tab45696[80] : unknown
+tab45696:	CNST *80	; signature array tab45696[80] : unknown @ 891:28
 	DATA #0 #2 #2 #2 #2 #4 #4 #4 #4 #4 #4 #4 #4 #4 #4 #4 #4 #4
 	DATA #3 #2 #4 #4 #2 #2 #2 #2 #2 #1 #1 #1 #1 #1 #1 #1 #1 #1
 	DATA #1 #1 #2 #2 #2 #1 #0 #1 #0 #1 #0 #5 #5 #5 #5 #5 #4 #4
 	DATA #2 #0 #1 #2 #0 #1 #2 #0 #1 #2 #0 #1 #2 #0 #2 #2 #0 #1
 	DATA #3 #0 #2 #3 #0 #2 #0xA0 #0xA0
-tab45776:	CNST *80	; signature array tab45776[80] : unknown
+tab45776:	CNST *80	; signature array tab45776[80] : unknown @ 904:28
 	DATA #0 #2 #2 #2 #2 #4 #4 #4 #4 #4 #4 #4 #4 #4 #4 #4 #4 #4
 	DATA #3 #3 #4 #4 #3 #3 #3 #3 #3 #1 #2 #3 #2 #1 #3 #3 #3 #3
 	DATA #1 #1 #3 #3 #3 #2 #2 #3 #2 #3 #0 #0 #5 #5 #5 #5 #4 #4
 	DATA #2 #0 #2 #2 #0 #3 #2 #0 #4 #2 #0 #3 #2 #0 #2 #2 #0 #2
 	DATA #3 #0 #3 #3 #0 #3 #0xB0 #0xA0
-tab45856:	CNST *80	; signature array tab45856[80] : unknown
+tab45856:	CNST *80	; signature array tab45856[80] : unknown @ 917:28
 	DATA #0 #0x1F #0x1F #0x1F #0x1F #2 #2 #2 #2 #2 #2 #2 #2 #2
 	DATA #5 #5 #2 #0xA #2 #8 #5 #5 #0xB #0xA #9 #8 #8 #0xA0 #8
 	DATA #8 #0x17 #0x1F #0x12 #0x12 #0x12 #0x12 #0x1E #0x1E
@@ -1159,20 +1159,20 @@ tab45856:	CNST *80	; signature array tab45856[80] : unknown
 	DATA #0x1B #0x1A #0x1D #0x1B #0x1A #0x1D #0x1B #0x17 #0x1D
 	DATA #0x17 #0x17 #0x1D #0x17 #0x17 #0x1D #0x17 #0x17 #0x1D
 	DATA #0x17 #0x17 #0x17
-tab45936:	CNST *80	; signature array tab45936[80] : unknown
+tab45936:	CNST *80	; signature array tab45936[80] : unknown @ 930:29
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0xF1 #0xE2
 	DATA #0xD3 #0xBB #0x7C #0x95 #1 #2 #3 #3 #0 #0x72 #0 #2 #0
 	DATA #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0 #0
 	DATA #0 #0 #0x1B #0 #0 #0x19 #0 #0 #0 #0 #0 #0 #0 #0 #0
-amplitudeRescale:	CNST *17	; signature array amplitudeRescale[17] : unknown
+amplitudeRescale:	CNST *17	; signature array amplitudeRescale[17] : unknown @ 943:36
 	DATA #0 #1 #2 #2 #2 #3 #3 #4 #4 #5 #6 #8 #9 #0xB #0xD #0xF
 	DATA #0
-tab47492:	CNST *12	; signature array tab47492[12] : unknown
+tab47492:	CNST *12	; signature array tab47492[12] : unknown @ 948:28
 	DATA #0 #0 #-32 #-26 #-20 #-13 #-7 #0 #6 #0xC #6
-tab48426:	CNST *5	; signature array tab48426[5] : unknown
+tab48426:	CNST *5	; signature array tab48426[5] : unknown @ 951:28
 	DATA #0x18 #0x1A #0x17 #0x17 #0x17
-randomtable:	CNST *0x500	; signature array randomtable[0x500] : unknown
+randomtable:	CNST *0x500	; signature array randomtable[0x500] : unknown @ 954:35
 	DATA #0x38 #0x84 #0x6B #0x19 #0xC6 #0x63 #0x18 #0x86 #0x73
 	DATA #0x98 #0xC6 #0xB1 #0x1C #0xCA #0x31 #0x8C #0xC7 #0x31
 	DATA #0x88 #0xC2 #0x30 #0x98 #0x46 #0x31 #0x18 #0xC6 #0x35
@@ -1311,38 +1311,38 @@ randomtable:	CNST *0x500	; signature array randomtable[0x500] : unknown
 	DATA #0xF #0xF8 #6 #0xC1 #0xFE #1 #0xFC #3 #0xE0 #0xF #0
 	DATA #0xFC
 	GLOB *1
-speed:	DATi #72	; signature global speed : int
+speed:	DATi #72	; signature global speed : int @ 1269:22
 	GLOB *1
-pitch:	DATi #64	; signature global pitch : int
+pitch:	DATi #64	; signature global pitch : int @ 1270:22
 	GLOB *1
-mouth:	DATi #128	; signature global mouth : int
+mouth:	DATi #128	; signature global mouth : int @ 1271:23
 	GLOB *1
-throat:	DATi #128	; signature global throat : int
-input:	GLOB *256	; signature array input[256] : unknown
-stress:	GLOB *256	; signature array stress[256] : unknown
-phonemeLength:	GLOB *256	; signature array phonemeLength[256] : unknown
-phonemeIndex:	GLOB *256	; signature array phonemeIndex[256] : unknown
-phonemeIndexOutput:	GLOB *60	; signature array phonemeIndexOutput[60] : unknown
-stressOutput:	GLOB *60	; signature array stressOutput[60] : unknown
-phonemeLengthOutput:	GLOB *60	; signature array phonemeLengthOutput[60] : unknown
-tab44800:	GLOB *256	; signature array tab44800[256] : unknown
-pitches:	GLOB *256	; signature array pitches[256] : unknown
-frequency1:	GLOB *256	; signature array frequency1[256] : unknown
-frequency2:	GLOB *256	; signature array frequency2[256] : unknown
-frequency3:	GLOB *256	; signature array frequency3[256] : unknown
-amplitude1:	GLOB *256	; signature array amplitude1[256] : unknown
-amplitude2:	GLOB *256	; signature array amplitude2[256] : unknown
-amplitude3:	GLOB *256	; signature array amplitude3[256] : unknown
+throat:	DATi #128	; signature global throat : int @ 1272:24
+input:	GLOB *256	; signature array input[256] : unknown @ 1274:24
+stress:	GLOB *256	; signature array stress[256] : unknown @ 1276:25
+phonemeLength:	GLOB *256	; signature array phonemeLength[256] : unknown @ 1277:32
+phonemeIndex:	GLOB *256	; signature array phonemeIndex[256] : unknown @ 1278:31
+phonemeIndexOutput:	GLOB *60	; signature array phonemeIndexOutput[60] : unknown @ 1281:36
+stressOutput:	GLOB *60	; signature array stressOutput[60] : unknown @ 1282:30
+phonemeLengthOutput:	GLOB *60	; signature array phonemeLengthOutput[60] : unknown @ 1283:37
+tab44800:	GLOB *256	; signature array tab44800[256] : unknown @ 1285:27
+pitches:	GLOB *256	; signature array pitches[256] : unknown @ 1287:26
+frequency1:	GLOB *256	; signature array frequency1[256] : unknown @ 1289:29
+frequency2:	GLOB *256	; signature array frequency2[256] : unknown @ 1290:29
+frequency3:	GLOB *256	; signature array frequency3[256] : unknown @ 1291:29
+amplitude1:	GLOB *256	; signature array amplitude1[256] : unknown @ 1293:29
+amplitude2:	GLOB *256	; signature array amplitude2[256] : unknown @ 1294:29
+amplitude3:	GLOB *256	; signature array amplitude3[256] : unknown @ 1295:29
 	GLOB *1
-oldtimetableindex:	DATi #0	; signature global oldtimetableindex : int
+oldtimetableindex:	DATi #0	; signature global oldtimetableindex : int @ 1298:33
 	! MULi <A> #5 #5
-timetable:	CNST *<A>	; signature array timetable[<A>] : unknown
+timetable:	CNST *<A>	; signature array timetable[<A>] : unknown @ 1300:33
 	DATA #162 #167 #167 #127 #128 #226 #60 #60 #0 #0 #225 #60
 	DATA #59 #0 #0 #200 #0 #0 #54 #55 #199 #0 #0 #54 #54
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-outputSample:	FUNC	; signature func outputSample(int delayIndex, int sample) -> void
+outputSample:	FUNC	; signature func outputSample(int delayIndex, int sample) -> void @ 1308:23
 	$delayIndex:	INPi
 	$sample:	INPi
 	$delay:	LOCi
@@ -1372,7 +1372,7 @@ outputSample:	FUNC	; signature func outputSample(int delayIndex, int sample) -> 
 		GEQi #0 %0 @.e2
 	.l3:	POKE &signal:1 $s 	; global signal[0] = global signal[1] = s
 		POKE &signal:0 $s 
-		CALL ^yield %1 *1	; expects function() -> unknown
+		CALL ^yield %1 *1	; expects function() -> unknown @ 1318:10
 		FORi $i %0 @.l3	; }
 	.e2:	POKE &writepos $bufferposScaled 	; global writepos = bufferposScaled
 		SHLi %0 $sample #7	; global lastSample = (sample << 7) - 1024
@@ -1383,7 +1383,7 @@ outputSample:	FUNC	; signature func outputSample(int delayIndex, int sample) -> 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-SAMInit:	FUNC	; signature func SAMInit() -> void
+SAMInit:	FUNC	; signature func SAMInit() -> void @ 1324:18
 	$i:	LOCi
 ;-----------------------------------------------------------------------------
 		MOVi $i #0 	; for (i = 0 to 256) 
@@ -1407,13 +1407,13 @@ SAMInit:	FUNC	; signature func SAMInit() -> void
 		FORi $i #60 @.l3	; }
 	.e2:	RETU   	; }
 
-tables:	CNST *7	; signature array tables[7] : unknown
+tables:	CNST *7	; signature array tables[7] : unknown @ 1347:26
 	DATA &pitches &frequency1 &frequency2 &frequency3
 	DATA &amplitude1 &amplitude2 &amplitude3
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-Parser1:	FUNC	; signature func Parser1() -> int
+Parser1:	FUNC	; signature func Parser1() -> int @ 1352:18
 	$i:	LOCi
 	$sign1:	LOCi
 	$sign2:	LOCi
@@ -1478,7 +1478,7 @@ Parser1:	FUNC	; signature func Parser1() -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-Insert:	FUNC	; signature func Insert(int position, int mem60, int mem59, int mem58) -> void
+Insert:	FUNC	; signature func Insert(int position, int mem60, int mem59, int mem58) -> void @ 1411:17
 	$position:	INPi
 	$mem60:	INPi
 	$mem59:	INPi
@@ -1505,7 +1505,7 @@ Insert:	FUNC	; signature func Insert(int position, int mem60, int mem59, int mem
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-Parser2:	FUNC	; signature func Parser2() -> void
+Parser2:	FUNC	; signature func Parser2() -> void @ 1427:18
 	$pos:	LOCi
 	$mem58:	LOCi
 	$X:	LOCi
@@ -1536,7 +1536,7 @@ Parser2:	FUNC	; signature func Parser2() -> void
 		MOVi %2 $A 
 		MOVi %3 #0 
 		MOVi %4 $mem58 
-		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void
+		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void @ 1448:30
 		MOVi $X $pos 	; X = pos
 		GOTO @pos41749  	; goto pos41749
 	.f3:	PEEK $A &phonemeIndex $X	; A = (int)global phonemeIndex[X]
@@ -1556,7 +1556,7 @@ Parser2:	FUNC	; signature func Parser2() -> void
 		MOVi %2 $A 
 		MOVi %3 #0 
 		MOVi %4 $mem58 
-		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void
+		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void @ 1464:28
 		GOTO @continue0  	; goto continue0
 	.f7:	MOVi $Y $A 	; Y = A
 		PEEK %0 &flags $A	; A = (int)global flags[A] & 128
@@ -1579,7 +1579,7 @@ Parser2:	FUNC	; signature func Parser2() -> void
 		MOVi %2 #31 
 		MOVi %3 #0 
 		MOVi %4 #0 
-		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void
+		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void @ 1484:27
 		GOTO @continue0  	; goto continue0
 	.f12:	MOVi $X $pos 	; X = pos
 		PEEK $A &phonemeIndex $pos	; A = (int)global phonemeIndex[pos]
@@ -1664,7 +1664,7 @@ Parser2:	FUNC	; signature func Parser2() -> void
 		ADDi %2 $A #1
 		MOVi %3 #0 
 		PEEK %4 &stress $X
-		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void
+		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void @ 1556:41
 		GOTO @continue0  	; goto continue0
 	.f37:	NOOP
 	pos41788:	NEQi $A #44 @.f38	; pos41788:
@@ -1672,7 +1672,7 @@ Parser2:	FUNC	; signature func Parser2() -> void
 		ADDi %2 $A #1
 		MOVi %3 #0 
 		PEEK %4 &stress $X
-		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void
+		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void @ 1562:41
 		GOTO @continue0  	; goto continue0
 	.f38:	NOOP
 	pos41812:	EQUi $A #69 @.f39	; pos41812:
@@ -1710,7 +1710,7 @@ Parser2:	FUNC	; signature func Parser2() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-Code41883:	FUNC	; signature func Code41883() -> void
+Code41883:	FUNC	; signature func Code41883() -> void @ 1589:20
 	$pos:	LOCi
 	$Y:	LOCi
 ;-----------------------------------------------------------------------------
@@ -1740,7 +1740,7 @@ Code41883:	FUNC	; signature func Code41883() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-Code48619:	FUNC	; signature func Code48619() -> void
+Code48619:	FUNC	; signature func Code48619() -> void @ 1606:20
 	$X:	LOCi
 	$A:	LOCi
 	$index:	LOCi
@@ -1900,7 +1900,7 @@ Code48619:	FUNC	; signature func Code48619() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-SetPhonemeLength:	FUNC	; signature func SetPhonemeLength() -> void
+SetPhonemeLength:	FUNC	; signature func SetPhonemeLength() -> void @ 1709:27
 	$A:	LOCi
 	$position:	LOCi
 	$table:	LOCp
@@ -1924,7 +1924,7 @@ SetPhonemeLength:	FUNC	; signature func SetPhonemeLength() -> void
 
 ;-----------------------------------------------------------------------------
 	$X:	OUTi
-Code41240:	FUNC	; signature func Code41240() -> int
+Code41240:	FUNC	; signature func Code41240() -> int @ 1723:20
 	$pos:	LOCi
 	$A:	LOCi
 	$index:	LOCi
@@ -1949,13 +1949,13 @@ Code41240:	FUNC	; signature func Code41240() -> int
 		ADDi %3 $index #1
 		PEEK %3 &phonemeLengthTable1 %3
 		PEEK %4 &stress $pos
-		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void
+		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void @ 1737:93
 		ADDi %1 $pos #2	; Insert(pos+2, index+2, (int)global phonemeLengthTable1[index+2], (int)global stress[pos])
 		ADDi %2 $index #2
 		ADDi %3 $index #2
 		PEEK %3 &phonemeLengthTable1 %3
 		PEEK %4 &stress $pos
-		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void
+		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void @ 1738:93
 		GOTO @inc3AndContinue0  	; goto inc3AndContinue0
 	.e3:	NOOP
 	.l5:	ADDi $X $X #1	; X = X + 1
@@ -1974,13 +1974,13 @@ Code41240:	FUNC	; signature func Code41240() -> int
 		ADDi %3 $index #1
 		PEEK %3 &phonemeLengthTable1 %3
 		PEEK %4 &stress $pos
-		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void
+		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void @ 1752:92
 		ADDi %1 $pos #2	; Insert(pos+2, index+2, (int)global phonemeLengthTable1[index+2], (int)global stress[pos])
 		ADDi %2 $index #2
 		ADDi %3 $index #2
 		PEEK %3 &phonemeLengthTable1 %3
 		PEEK %4 &stress $pos
-		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void
+		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void @ 1753:92
 	inc3AndContinue0:	ADDi $pos $pos #3	; pos = pos + 3
 	continue0:	GOTO @.l0  	; }
 	.e1:	RETU   	; }
@@ -1988,7 +1988,7 @@ Code41240:	FUNC	; signature func Code41240() -> int
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-InitPlayback:	FUNC	; signature func InitPlayback() -> int
+InitPlayback:	FUNC	; signature func InitPlayback() -> int @ 1760:23
 	$A:	LOCi
 	$X:	LOCi
 	$mem54:	LOCi
@@ -1996,17 +1996,17 @@ InitPlayback:	FUNC	; signature func InitPlayback() -> int
 	$index:	LOCi
 	$mem66:	LOCi
 ;-----------------------------------------------------------------------------
-		CALL &SAMInit %0 *1	; expects SAMInit() -> void
+		CALL &SAMInit %0 *1	; expects SAMInit() -> void @ 1764:11
 		POKE &phonemeIndex:255 #255 	; (int)global phonemeIndex[255] = 255
-		CALL &Parser1 %0 *1	; expects Parser1() -> int
+		CALL &Parser1 %0 *1	; expects Parser1() -> int @ 1768:21
 		NEQi %0 #0 @.f0
 		MOVi $r #0 	; r = 0
 		GOTO @_return  	; goto _return
-	.f0:	CALL &Parser2 %0 *1	; expects Parser2() -> void
-		CALL &Code41883 %0 *1	; expects Code41883() -> void
-		CALL &SetPhonemeLength %0 *1	; expects SetPhonemeLength() -> void
-		CALL &Code48619 %0 *1	; expects Code48619() -> void
-		CALL &Code41240 %0 *1	; expects Code41240() -> int
+	.f0:	CALL &Parser2 %0 *1	; expects Parser2() -> void @ 1772:11
+		CALL &Code41883 %0 *1	; expects Code41883() -> void @ 1773:13
+		CALL &SetPhonemeLength %0 *1	; expects SetPhonemeLength() -> void @ 1774:20
+		CALL &Code48619 %0 *1	; expects Code48619() -> void @ 1775:13
+		CALL &Code41240 %0 *1	; expects Code41240() -> int @ 1776:28
 		MOVi $X %0 
 		GEQi %0 #256 @.e1
 	.l2:	PEEK %0 &phonemeIndex $X	; if ((int)global phonemeIndex[X] > 80) 
@@ -2037,7 +2037,7 @@ InitPlayback:	FUNC	; signature func InitPlayback() -> int
 		MOVi %2 #254 
 		MOVi %3 #0 
 		MOVi %4 #0 
-		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void
+		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void @ 1802:26
 		ADDi $mem66 $mem66 #2	; mem66 = mem66 + 2
 		GOTO @continue1  	; goto continue1
 	.f7:	NEQi $index #0 @.f9	; if (index == 0) mem54 = X
@@ -2054,29 +2054,29 @@ InitPlayback:	FUNC	; signature func InitPlayback() -> int
 		MOVi %2 #254 
 		MOVi %3 #0 
 		MOVi %4 #0 
-		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void
+		CALL &Insert %0 *5	; expects Insert(int, int, int, int) -> void @ 1816:24
 		ADDi $X $X #1	; X = X + 1
 		MOVi $mem66 $X 	; mem66 = X
 	.e10:	GOTO @.l4  	; }
 	break1:	MOVi $r #1 	; break1:
 	_return:	RETU   	; }
 
-tab39140:	CNST *30	; signature array tab39140[30] : unknown
+tab39140:	CNST *30	; signature array tab39140[30] : unknown @ 1828:29
 	DATA #0 #0 #0 #0 #0 #10 #14 #19 #24 #27 #23 #21 #16 #20
 	DATA #14 #18 #14 #18 #18 #16 #13 #15 #11 #18 #14 #11 #9 #6
 	DATA #6 #6
-tab39170:	CNST *30	; signature array tab39170[30] : unknown
+tab39170:	CNST *30	; signature array tab39170[30] : unknown @ 1829:29
 	DATA #255 #255 #255 #255 #255 #84 #73 #67 #63 #40 #44 #31
 	DATA #37 #45 #73 #49 #36 #30 #51 #37 #29 #69 #24 #50 #30
 	DATA #24 #83 #46 #54 #86
-tab39200:	CNST *6	; signature array tab39200[6] : unknown
+tab39200:	CNST *6	; signature array tab39200[6] : unknown @ 1832:28
 	DATA #19 #27 #21 #27 #18 #13
-tab39206:	CNST *6	; signature array tab39206[6] : unknown
+tab39206:	CNST *6	; signature array tab39206[6] : unknown @ 1833:28
 	DATA #72 #39 #31 #43 #30 #34
 
 ;-----------------------------------------------------------------------------
 	$r:	OUTi
-trans:	FUNC	; signature func trans(int a, int b) -> int
+trans:	FUNC	; signature func trans(int a, int b) -> int @ 1836:16
 	$a:	INPi
 	$b:	INPi
 	$carry:	LOCi
@@ -2129,7 +2129,7 @@ trans:	FUNC	; signature func trans(int a, int b) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-SetMouthThroat:	FUNC	; signature func SetMouthThroat(int mouth, int throat) -> void
+SetMouthThroat:	FUNC	; signature func SetMouthThroat(int mouth, int throat) -> void @ 1866:25
 	$mouth:	INPi
 	$throat:	INPi
 	$b:	LOCi
@@ -2144,14 +2144,14 @@ SetMouthThroat:	FUNC	; signature func SetMouthThroat(int mouth, int throat) -> v
 		EQUi $b #0 @.f2	; if (b != 0) c = (int)trans(mouth, b)
 		MOVi %1 $mouth 	; c = (int)trans(mouth, b)
 		MOVi %2 $b 
-		CALL &trans %0 *3	; expects trans(int, int) -> int
+		CALL &trans %0 *3	; expects trans(int, int) -> int @ 1873:39
 		MOVi $c %0 
 	.f2:	POKE &freq1data $pos $c	; global freq1data[pos] = c
 		PEEK $b &tab39170 $pos	; b = (int)global tab39170[pos]
 		EQUi $b #0 @.f3	; if (b != 0) c = (int)trans(throat, b)
 		MOVi %1 $throat 	; c = (int)trans(throat, b)
 		MOVi %2 $b 
-		CALL &trans %0 *3	; expects trans(int, int) -> int
+		CALL &trans %0 *3	; expects trans(int, int) -> int @ 1876:40
 		MOVi $c %0 
 	.f3:	POKE &freq2data $pos $c	; global freq2data[pos] = c
 		FORi $pos #30 @.l1	; }
@@ -2161,13 +2161,13 @@ SetMouthThroat:	FUNC	; signature func SetMouthThroat(int mouth, int throat) -> v
 		PEEK $b &tab39200 $Y	; b = (int)global tab39200[Y]
 		MOVi %1 $mouth 	; c = (int)trans(mouth, b)
 		MOVi %2 $b 
-		CALL &trans %0 *3	; expects trans(int, int) -> int
+		CALL &trans %0 *3	; expects trans(int, int) -> int @ 1883:27
 		MOVi $c %0 
 		POKE &freq1data $pos $c	; global freq1data[pos] = c
 		PEEK $b &tab39206 $Y	; b = (int)global tab39206[Y]
 		MOVi %1 $throat 	; c = (int)trans(throat, b)
 		MOVi %2 $b 
-		CALL &trans %0 *3	; expects trans(int, int) -> int
+		CALL &trans %0 *3	; expects trans(int, int) -> int @ 1886:28
 		MOVi $c %0 
 		POKE &freq2data $pos $c	; global freq2data[pos] = c
 		FORi $pos #54 @.l5	; }
@@ -2176,7 +2176,7 @@ SetMouthThroat:	FUNC	; signature func SetMouthThroat(int mouth, int throat) -> v
 
 ;-----------------------------------------------------------------------------
 	$i:	OUTi
-Special1:	FUNC	; signature func Special1(int mem48, int X) -> int
+Special1:	FUNC	; signature func Special1(int mem48, int X) -> int @ 1891:19
 	$mem48:	INPi
 	$X:	INPi
 	$A:	LOCi
@@ -2205,7 +2205,7 @@ Special1:	FUNC	; signature func Special1(int mem48, int X) -> int
 
 ;-----------------------------------------------------------------------------
 	$Y:	OUTi
-GenerateNoise:	FUNC	; signature func GenerateNoise(int Y0, int mem39, ptr mem44, ptr mem66) -> int
+GenerateNoise:	FUNC	; signature func GenerateNoise(int Y0, int mem39, ptr mem44, ptr mem66) -> int @ 1912:24
 	$Y0:	INPi
 	$mem39:	INPi
 	$mem44:	INPp
@@ -2242,11 +2242,11 @@ GenerateNoise:	FUNC	; signature func GenerateNoise(int Y0, int mem39, ptr mem44,
 		EQUi %0 #0 @.f5
 		MOVi %1 #3 	; outputSample(3, 26 & 15)
 		ANDi %2 #26 #15
-		CALL &outputSample %0 *3	; expects outputSample(int, int) -> void
+		CALL &outputSample %0 *3	; expects outputSample(int, int) -> void @ 1932:30
 		GOTO @.e6  	; } else 
 	.f5:	MOVi %1 #4 	; outputSample(4, 6)
 		MOVi %2 #6 
-		CALL &outputSample %0 *3	; expects outputSample(int, int) -> void
+		CALL &outputSample %0 *3	; expects outputSample(int, int) -> void @ 1934:24
 	.e6:	FORi $j #8 @.l4	; }
 	.e3:	ADDi $Y $Y #1	; Y = Y + 1
 		FORi $i #256 @.l2	; }
@@ -2266,12 +2266,12 @@ GenerateNoise:	FUNC	; signature func GenerateNoise(int Y0, int mem39, ptr mem44,
 		NEQi %0 #0 @.f12
 		MOVi %1 #1 	; outputSample(1, mem53 & 15)
 		ANDi %2 $mem53 #15
-		CALL &outputSample %0 *3	; expects outputSample(int, int) -> void
+		CALL &outputSample %0 *3	; expects outputSample(int, int) -> void @ 1950:33
 		EQUi $mem53 #0 @.f12	; if(mem53 != 0) goto pos48296
 		GOTO @pos48296  	; goto pos48296
 	.f12:	MOVi %1 #2 	; outputSample(2, 5)
 		MOVi %2 #5 
-		CALL &outputSample %0 *3	; expects outputSample(int, int) -> void
+		CALL &outputSample %0 *3	; expects outputSample(int, int) -> void @ 1953:23
 	pos48296:	FORi $j #8 @.l11	; }
 	.e10:	FORi $Y #256 @.l9	; }
 	.e8:	POKE $mem44 #1 	; (int)*mem44 = 1
@@ -2281,7 +2281,7 @@ GenerateNoise:	FUNC	; signature func GenerateNoise(int Y0, int mem39, ptr mem44,
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-ProduceOutput:	FUNC	; signature func ProduceOutput() -> void
+ProduceOutput:	FUNC	; signature func ProduceOutput() -> void @ 1964:24
 	$phase1:	LOCi
 	$phase2:	LOCi
 	$phase3:	LOCi
@@ -2329,13 +2329,13 @@ ProduceOutput:	FUNC	; signature func ProduceOutput() -> void
 	.f3:	NEQi $mem56 #1 @.f5	; if (mem56 == 1) X = (int)Special1(1, X)
 		MOVi %1 #1 	; X = (int)Special1(1, X)
 		MOVi %2 $X 
-		CALL &Special1 %0 *3	; expects Special1(int, int) -> int
+		CALL &Special1 %0 *3	; expects Special1(int, int) -> int @ 1987:47
 		MOVi $X %0 
 		GOTO @.e6  
 	.f5:	NEQi $mem56 #2 @.f7	; if (mem56 == 2) X = (int)Special1(255, X)
 		MOVi %1 #255 	; X = (int)Special1(255, X)
 		MOVi %2 $X 
-		CALL &Special1 %0 *3	; expects Special1(int, int) -> int
+		CALL &Special1 %0 *3	; expects Special1(int, int) -> int @ 1988:49
 		MOVi $X %0 
 	.f7:	NOOP
 	.e6:	NOOP
@@ -2514,7 +2514,7 @@ ProduceOutput:	FUNC	; signature func ProduceOutput() -> void
 		MOVi %2 $mem39 
 		ADRL %3 $mem44 *0
 		ADRL %4 $mem66 *0
-		CALL &GenerateNoise %0 *5	; expects GenerateNoise(int, int, ptr, ptr) -> int
+		CALL &GenerateNoise %0 *5	; expects GenerateNoise(int, int, ptr, ptr) -> int @ 2127:54
 		ADDi $Y %0 #2
 		PEEK $speedcounter &speed 	; speedcounter = global speed
 		SUBi $mem48 $mem48 #2	; mem48 = mem48 - 2
@@ -2547,7 +2547,7 @@ ProduceOutput:	FUNC	; signature func ProduceOutput() -> void
 		SHRi $A %1 #4
 		MOVi %1 #0 	; outputSample(0, A)
 		MOVi %2 $A 
-		CALL &outputSample %0 *3	; expects outputSample(int, int) -> void
+		CALL &outputSample %0 *3	; expects outputSample(int, int) -> void @ 2138:23
 		SUBi $speedcounter $speedcounter #1	; speedcounter = speedcounter - 1
 		NEQi $speedcounter #0 @.f43	; if (speedcounter == 0) 
 		PEEK $speedcounter &speed 	; speedcounter = global speed
@@ -2566,7 +2566,7 @@ ProduceOutput:	FUNC	; signature func ProduceOutput() -> void
 		MOVi %2 $mem39 
 		ADRL %3 $mem44 *0
 		ADRL %4 $mem66 *0
-		CALL &GenerateNoise %0 *5	; expects GenerateNoise(int, int, ptr, ptr) -> int
+		CALL &GenerateNoise %0 *5	; expects GenerateNoise(int, int, ptr, ptr) -> int @ 2151:53
 		MOVi $Y %0 
 		GOTO @.l37  	; goto break4
 	.f47:	PEEK %0 &frequency1 $Y	; phase1 = (phase1 + (int)global frequency1[Y]) & 0xFF
@@ -2586,7 +2586,7 @@ ProduceOutput:	FUNC	; signature func ProduceOutput() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-Play:	FUNC	; signature func Play() -> void
+Play:	FUNC	; signature func Play() -> void @ 2163:15
 	$A:	LOCi
 	$X:	LOCi
 	$Y:	LOCi
@@ -2600,18 +2600,18 @@ Play:	FUNC	; signature func Play() -> void
 		POKE &useScale %0 
 		PEEK %1 &mouth 	; SetMouthThroat(global mouth, global throat)
 		PEEK %2 &throat 
-		CALL &SetMouthThroat %0 *3	; expects SetMouthThroat(int, int) -> void
+		CALL &SetMouthThroat %0 *3	; expects SetMouthThroat(int, int) -> void @ 2173:45
 	.l0:	PEEK %0 &pleaseBreak 	; while (global pleaseBreak == FALSE) 
 		NEQi %0 #FALSE @.e1
 		PEEK $A &phonemeIndex $X	; A = (int)global phonemeIndex[X]
 		NEQi $A #255 @.f2	; if (A == 255) 
 		POKE &phonemeIndexOutput $Y #255	; (int)global phonemeIndexOutput[Y] = 255
-		CALL &ProduceOutput %0 *1	; expects ProduceOutput() -> void
+		CALL &ProduceOutput %0 *1	; expects ProduceOutput() -> void @ 2178:19
 		GOTO @break0  	; goto break0
 		GOTO @.e3  	; } else if (A == 254) 
 	.f2:	NEQi $A #254 @.f4	; if (A == 254) 
 		POKE &phonemeIndexOutput $Y #255	; (int)global phonemeIndexOutput[Y] = 255
-		CALL &ProduceOutput %0 *1	; expects ProduceOutput() -> void
+		CALL &ProduceOutput %0 *1	; expects ProduceOutput() -> void @ 2182:19
 		MOVi $Y #0 	; Y = 0
 		GOTO @.e5  	; } else if (A != 0) 
 	.f4:	EQUi $A #0 @.f6	; if (A != 0) 
@@ -2631,7 +2631,7 @@ Play:	FUNC	; signature func Play() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 2195:15
 	$buffer:	LOCA *256
 	$p:	LOCp
 ;-----------------------------------------------------------------------------
@@ -2639,17 +2639,17 @@ init:	FUNC	; signature func init() -> void
 		PEEK %0 $p 	; if ((int) *p == 0) 
 		NEQi %0 #0 @.f0
 		MOVp %1 &.s_Thisfi4da 	; trace("This firmware requires a configuration string. E.g. \"reciter HI THERE!\"")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 2200:85
+		CALL ^abort %0 *1	; expects function() -> unknown @ 2201:10
 	.f0:	MOVp %1 &dynamicPanelTextRow 	; strcpy(global dynamicPanelTextRow, global panelTextRows[4])
 		PEEK %2 &panelTextRows:4 
-		CALL &strcpy %0 *3	; expects strcpy(ptr, ptr) -> ptr
+		CALL &strcpy %0 *3	; expects strcpy(ptr, ptr) -> ptr @ 2203:61
 		MOVp %1 &dynamicPanelTextRow:6 	; strcpy(&global dynamicPanelTextRow[6], global config)
 		MOVp %2 &config 
-		CALL &strcpy %0 *3	; expects strcpy(ptr, ptr) -> ptr
+		CALL &strcpy %0 *3	; expects strcpy(ptr, ptr) -> ptr @ 2204:55
 		MOVp %1 &dynamicPanelTextRow:6 	; strcat(&global dynamicPanelTextRow[6], "\"")
 		MOVp %2 &.s_Thisfi4da:70 
-		CALL &strcat %0 *3	; expects strcat(ptr, ptr) -> ptr
+		CALL &strcat %0 *3	; expects strcat(ptr, ptr) -> ptr @ 2205:46
 		POKE &panelTextRows:4 &dynamicPanelTextRow 	; global panelTextRows[4] = global dynamicPanelTextRow
 		PEEK %0 $p 	; if ((int) *p == '!') 
 		NEQi %0 #'!' @.f1
@@ -2659,22 +2659,22 @@ init:	FUNC	; signature func init() -> void
 		NEQi %0 #'%' @.f2
 		MOVp %1 &input 	; strcpy(global input, p + 1)
 		ADDp %2 $p #1
-		CALL &strcpy %0 *3	; expects strcpy(ptr, ptr) -> ptr
+		CALL &strcpy %0 *3	; expects strcpy(ptr, ptr) -> ptr @ 2213:50
 		GOTO @.e3  
 	.f2:	MOVp %1 &input 	; strcpy(global input, p)
 		MOVp %2 $p 
-		CALL &strcpy %0 *3	; expects strcpy(ptr, ptr) -> ptr
+		CALL &strcpy %0 *3	; expects strcpy(ptr, ptr) -> ptr @ 2215:26
 		MOVp %1 &input 	; if ((int) TextToPhonemes(global input) == 0) abort()
-		CALL &TextToPhonemes %0 *2	; expects TextToPhonemes(ptr) -> int
+		CALL &TextToPhonemes %0 *2	; expects TextToPhonemes(ptr) -> int @ 2216:42
 		NEQi %0 #0 @.f4
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^abort %0 *1	; expects function() -> unknown @ 2216:55
 	.f4:	ADRL %1 $buffer *0	; p = (pointer) stpcpy(buffer, "Phonetic: %")
 		MOVp %2 &.s_Phonet4db 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 2217:46
 		MOVp $p %0 
 		MOVp %1 $p 	; p = (pointer) stpcpy(p, global input)
 		MOVp %2 &input 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 2218:40
 		MOVp $p %0 
 		ADRL %0 $buffer *0	; if (p != buffer && (int) *(p = p - 1) == 155) 
 		EQUp $p %0 @.f6
@@ -2688,24 +2688,24 @@ init:	FUNC	; signature func init() -> void
 		PEEK %0 $p 
 		EQUi %0 #' ' @.l7
 	.f6:	ADRL %1 $buffer *0	; trace(buffer)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 2224:16
 	.e3:	MOVp %1 &input 	; strcat(global input, "\u009b")
 		MOVp %2 &.s_4dc 
-		CALL &strcat %0 *3	; expects strcat(ptr, ptr) -> ptr
+		CALL &strcat %0 *3	; expects strcat(ptr, ptr) -> ptr @ 2226:32
 		MOVp %1 &input 	; strcat(global input, "?")
 		MOVp %2 &.s_4dd 
-		CALL &strcat %0 *3	; expects strcat(ptr, ptr) -> ptr
-		CALL &InitPlayback %0 *1	; expects InitPlayback() -> int
+		CALL &strcat %0 *3	; expects strcat(ptr, ptr) -> ptr @ 2227:27
+		CALL &InitPlayback %0 *1	; expects InitPlayback() -> int @ 2228:27
 		NEQi %0 #0 @.f9
 		MOVp %1 &.s_Couldn4de 	; trace("Couldn't initialize playback. Invalid input?")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 2229:56
+		CALL ^abort %0 *1	; expects function() -> unknown @ 2230:10
 	.f9:	RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 2234:16
 ;-----------------------------------------------------------------------------
 		POKE &lastClock #0x7FFFFFFF 	; global lastClock = 0x7FFFFFFF
 		POKE &pleaseBreak #TRUE 	; global pleaseBreak = TRUE
@@ -2714,7 +2714,7 @@ reset:	FUNC	; signature func reset() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 2240:17
 	$localParams:	LOCA *PARAM_COUNT
 	$newSpeed:	LOCi
 	$newPitch:	LOCi
@@ -2751,7 +2751,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 2310:18
 	$c:	LOCi
 ;-----------------------------------------------------------------------------
 	.l0:	NOOP
@@ -2762,10 +2762,10 @@ process:	FUNC	; signature func process() -> void
 		POKE &lastClock $c 	; global lastClock = c
 		POKE &signal:1 #0 	; global signal[0] = global signal[1] = 0
 		POKE &signal:0 #0 
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 2320:12
 		GOTO @.l2  	; }
 	.e3:	POKE &pleaseBreak #FALSE 	; global pleaseBreak = FALSE
-		CALL &Play %0 *1	; expects Play() -> void
+		CALL &Play %0 *1	; expects Play() -> void @ 2325:10
 		PEEK %0 &pleaseBreak 	; if (global pleaseBreak == FALSE) global lastClock = global clock
 		NEQi %0 #FALSE @.f4
 		PEEK %0 &clock 	; global lastClock = global clock
@@ -2776,7 +2776,7 @@ process:	FUNC	; signature func process() -> void
 		GEQi %0 #2 @.l1
 		PEEK %0 &abortWhenDone 	; if (global abortWhenDone != FALSE) exit()
 		EQUi %0 #FALSE @.f6
-		CALL ^exit %0 *1	; expects function() -> unknown
+		CALL ^exit %0 *1	; expects function() -> unknown @ 2331:44
 		GOTO @.l0  
 	.f6:	NOOP
 	.l8:	PEEK %0 &pleaseBreak 	; while (global pleaseBreak == FALSE && (int) global params[OPERATOR_2_PARAM_INDEX] < 2) 
@@ -2785,7 +2785,7 @@ process:	FUNC	; signature func process() -> void
 		GEQi %0 #2 @.l0
 		POKE &signal:1 #0 	; global signal[0] = global signal[1] = 0
 		POKE &signal:0 #0 
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 2335:12
 		GOTO @.l8  	; }
 	.e7:	GOTO @.l0  	; }
 		RETU   	; }

--- a/tests/impala/golden/specular_code.gazl
+++ b/tests/impala/golden/specular_code.gazl
@@ -1,50 +1,50 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_4d2 &.s_4d2 &.s_THRESH4d3 &.s_00FFlo4d4 &.s_4d2
 	DATA &.s_4d2 &.s_DECAYP4d5 &.s_00FFx14d6
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 81:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 82:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
+instance:	DATi #0	; signature global instance : int @ 83:1
 	CNST *1
-clockFreqLimit:	DATi #44100	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
+clockFreqLimit:	DATi #44100	; signature readonly clockFreqLimit : int @ 86:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 99:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 99:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 101:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 102:9
 		RETU   	; }
 
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 108:1
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 109:1
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 110:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 111:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 112:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 113:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 114:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 116:1
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 116:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -58,16 +58,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 123:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4d7 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 126:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float) trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 127:36
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -75,7 +75,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 141:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -84,7 +84,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 148:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -107,24 +107,24 @@ cos:	FUNC	; signature func cos(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sin:	FUNC	; signature func sin(float x) -> float
+sin:	FUNC	; signature func sin(float x) -> float @ 162:14
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		SUBf %1 $x #HALF_PI	; y = (float) cos(x - HALF_PI)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 165:30
 		MOVf $y %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sqrt:	FUNC	; signature func sqrt(float x) -> float
+sqrt:	FUNC	; signature func sqrt(float x) -> float @ 168:15
 	$x:	INPf
 	$t:	LOCf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) error("Domain error")
 		MOVp %1 &.s_Domain4d8 	; error("Domain error")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 172:36
 	.f0:	MOVf $y $x 	; y = x
 		MOVf $t #0.0 	; t = 0.0
 	.l1:	EQUf $y $t @.e2	; while (y != t) 
@@ -135,87 +135,87 @@ sqrt:	FUNC	; signature func sqrt(float x) -> float
 		GOTO @.l1  	; }
 	.e2:	RETU   	; }
 
-FFT_POWER:	! DEFi #12	; signature const FFT_POWER : int
+FFT_POWER:	! DEFi #12	; signature const FFT_POWER : int @ 184:25
 	! SHLi <A> #1 #FFT_POWER
-FFT_SIZE:	! DEFi <A>	; signature const FFT_SIZE : int
+FFT_SIZE:	! DEFi <A>	; signature const FFT_SIZE : int @ 185:38
 	! DIVi <A> #FFT_SIZE #2
-FFT_SIZE_2:	! DEFi <A>	; signature const FFT_SIZE_2 : int
-PROCESS_SPREAD_FACTOR:	! DEFi #5	; signature const PROCESS_SPREAD_FACTOR : int
+FFT_SIZE_2:	! DEFi <A>	; signature const FFT_SIZE_2 : int @ 186:36
+PROCESS_SPREAD_FACTOR:	! DEFi #5	; signature const PROCESS_SPREAD_FACTOR : int @ 187:36
 	! iTOf <A> #FFT_SIZE #1.0
 	! DIVf <A> #2.0 <A>
-IFFT_SCALE:	! DEFf <A>	; signature const IFFT_SCALE : float
-ANTI_DENORMAL_CONSTANT:	! DEFf #1.0e-10	; signature const ANTI_DENORMAL_CONSTANT : float
-PERFORM_RESET:	! DEFi #0	; signature const PERFORM_RESET : int
+IFFT_SCALE:	! DEFf <A>	; signature const IFFT_SCALE : float @ 188:48
+ANTI_DENORMAL_CONSTANT:	! DEFf #1.0e-10	; signature const ANTI_DENORMAL_CONSTANT : float @ 189:45
+PERFORM_RESET:	! DEFi #0	; signature const PERFORM_RESET : int @ 190:28
 	! ADDi <A> #PERFORM_RESET #1
-ANALYSIS_WINDOW:	! DEFi <A>	; signature const ANALYSIS_WINDOW : int
+ANALYSIS_WINDOW:	! DEFi <A>	; signature const ANALYSIS_WINDOW : int @ 191:46
 	! ADDi <A> #ANALYSIS_WINDOW #1
-ANALYSIS_REINDEX:	! DEFi <A>	; signature const ANALYSIS_REINDEX : int
+ANALYSIS_REINDEX:	! DEFi <A>	; signature const ANALYSIS_REINDEX : int @ 192:49
 	! ADDi <A> #ANALYSIS_REINDEX #1
-ANALYSIS_FFT_2:	! DEFi <A>	; signature const ANALYSIS_FFT_2 : int
+ANALYSIS_FFT_2:	! DEFi <A>	; signature const ANALYSIS_FFT_2 : int @ 193:48
 	! ADDi <A> #ANALYSIS_FFT_2 #FFT_POWER
 	! SUBi <A> <A> #1
-ANALYSIS_UNTANGLE:	! DEFi <A>	; signature const ANALYSIS_UNTANGLE : int
+ANALYSIS_UNTANGLE:	! DEFi <A>	; signature const ANALYSIS_UNTANGLE : int @ 194:61
 	! ADDi <A> #ANALYSIS_UNTANGLE #1
-PROCESS_FIND_MAX:	! DEFi <A>	; signature const PROCESS_FIND_MAX : int
+PROCESS_FIND_MAX:	! DEFi <A>	; signature const PROCESS_FIND_MAX : int @ 195:51
 	! ADDi <A> #PROCESS_FIND_MAX #1
-PROCESS_FEEDBACK:	! DEFi <A>	; signature const PROCESS_FEEDBACK : int
+PROCESS_FEEDBACK:	! DEFi <A>	; signature const PROCESS_FEEDBACK : int @ 196:50
 	! ADDi <A> #PROCESS_FEEDBACK #1
-PROCESS_PARTIAL_1:	! DEFi <A>	; signature const PROCESS_PARTIAL_1 : int
+PROCESS_PARTIAL_1:	! DEFi <A>	; signature const PROCESS_PARTIAL_1 : int @ 197:51
 	! ADDi <A> #PROCESS_PARTIAL_1 #8
-SYNTHESIS_SMEAR_LEFT:	! DEFi <A>	; signature const SYNTHESIS_SMEAR_LEFT : int
+SYNTHESIS_SMEAR_LEFT:	! DEFi <A>	; signature const SYNTHESIS_SMEAR_LEFT : int @ 198:55
 	! ADDi <A> #SYNTHESIS_SMEAR_LEFT #1
-SYNTHESIS_UNTANGLE_LEFT:	! DEFi <A>	; signature const SYNTHESIS_UNTANGLE_LEFT : int
+SYNTHESIS_UNTANGLE_LEFT:	! DEFi <A>	; signature const SYNTHESIS_UNTANGLE_LEFT : int @ 199:61
 	! ADDi <A> #SYNTHESIS_UNTANGLE_LEFT #1
-SYNTHESIS_REINDEX_LEFT:	! DEFi <A>	; signature const SYNTHESIS_REINDEX_LEFT : int
+SYNTHESIS_REINDEX_LEFT:	! DEFi <A>	; signature const SYNTHESIS_REINDEX_LEFT : int @ 200:63
 	! ADDi <A> #SYNTHESIS_REINDEX_LEFT #1
-SYNTHESIS_FFT_LEFT_2:	! DEFi <A>	; signature const SYNTHESIS_FFT_LEFT_2 : int
+SYNTHESIS_FFT_LEFT_2:	! DEFi <A>	; signature const SYNTHESIS_FFT_LEFT_2 : int @ 201:60
 	! ADDi <A> #SYNTHESIS_FFT_LEFT_2 #FFT_POWER
 	! SUBi <A> <A> #1
-SYNTHESIS_MIX_LEFT:	! DEFi <A>	; signature const SYNTHESIS_MIX_LEFT : int
+SYNTHESIS_MIX_LEFT:	! DEFi <A>	; signature const SYNTHESIS_MIX_LEFT : int @ 202:68
 	! ADDi <A> #SYNTHESIS_MIX_LEFT #1
-SYNTHESIS_SMEAR_RIGHT:	! DEFi <A>	; signature const SYNTHESIS_SMEAR_RIGHT : int
+SYNTHESIS_SMEAR_RIGHT:	! DEFi <A>	; signature const SYNTHESIS_SMEAR_RIGHT : int @ 203:57
 	! ADDi <A> #SYNTHESIS_SMEAR_RIGHT #1
-SYNTHESIS_UNTANGLE_RIGHT:	! DEFi <A>	; signature const SYNTHESIS_UNTANGLE_RIGHT : int
+SYNTHESIS_UNTANGLE_RIGHT:	! DEFi <A>	; signature const SYNTHESIS_UNTANGLE_RIGHT : int @ 204:63
 	! ADDi <A> #SYNTHESIS_UNTANGLE_RIGHT #1
-SYNTHESIS_REINDEX_RIGHT:	! DEFi <A>	; signature const SYNTHESIS_REINDEX_RIGHT : int
+SYNTHESIS_REINDEX_RIGHT:	! DEFi <A>	; signature const SYNTHESIS_REINDEX_RIGHT : int @ 205:65
 	! ADDi <A> #SYNTHESIS_REINDEX_RIGHT #1
-SYNTHESIS_FFT_RIGHT_2:	! DEFi <A>	; signature const SYNTHESIS_FFT_RIGHT_2 : int
+SYNTHESIS_FFT_RIGHT_2:	! DEFi <A>	; signature const SYNTHESIS_FFT_RIGHT_2 : int @ 206:62
 	! ADDi <A> #SYNTHESIS_FFT_RIGHT_2 #FFT_POWER
 	! SUBi <A> <A> #1
-SYNTHESIS_MIX_RIGHT:	! DEFi <A>	; signature const SYNTHESIS_MIX_RIGHT : int
+SYNTHESIS_MIX_RIGHT:	! DEFi <A>	; signature const SYNTHESIS_MIX_RIGHT : int @ 207:70
 	! ADDi <A> #SYNTHESIS_MIX_RIGHT #1
-PROCESS_STEPS:	! DEFi <A>	; signature const PROCESS_STEPS : int
-THRESHOLD_PARAM:	! DEFi #OPERAND_1_HIGH_PARAM_INDEX	; signature const THRESHOLD_PARAM : int
-BAND_PARAM:	! DEFi #OPERAND_1_LOW_PARAM_INDEX	; signature const BAND_PARAM : int
-DECAY_PARAM:	! DEFi #OPERAND_2_HIGH_PARAM_INDEX	; signature const DECAY_PARAM : int
-PARTIALS_PARAM:	! DEFi #OPERAND_2_LOW_PARAM_INDEX	; signature const PARTIALS_PARAM : int
+PROCESS_STEPS:	! DEFi <A>	; signature const PROCESS_STEPS : int @ 208:50
+THRESHOLD_PARAM:	! DEFi #OPERAND_1_HIGH_PARAM_INDEX	; signature const THRESHOLD_PARAM : int @ 210:1
+BAND_PARAM:	! DEFi #OPERAND_1_LOW_PARAM_INDEX	; signature const BAND_PARAM : int @ 210:49
+DECAY_PARAM:	! DEFi #OPERAND_2_HIGH_PARAM_INDEX	; signature const DECAY_PARAM : int @ 212:1
+PARTIALS_PARAM:	! DEFi #OPERAND_2_LOW_PARAM_INDEX	; signature const PARTIALS_PARAM : int @ 212:53
 	CNST *1
 	! SHLi <A> #1 #THRESHOLD_PARAM
 	! SHLi <B> #1 #DECAY_PARAM
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 214:46
 	GLOB *1
-doReset:	DATi #TRUE	; signature global doReset : int
-window:	GLOB *FFT_SIZE_2	; signature array window[FFT_SIZE_2] : unknown
-cRotateRe:	GLOB *256	; signature array cRotateRe[256] : unknown
-cRotateIm:	GLOB *256	; signature array cRotateIm[256] : unknown
-partialGains:	GLOB *8	; signature array partialGains[8] : unknown
+doReset:	DATi #TRUE	; signature global doReset : int @ 219:1
+window:	GLOB *FFT_SIZE_2	; signature array window[FFT_SIZE_2] : unknown @ 219:32
+cRotateRe:	GLOB *256	; signature array cRotateRe[256] : unknown @ 220:28
+cRotateIm:	GLOB *256	; signature array cRotateIm[256] : unknown @ 221:28
+partialGains:	GLOB *8	; signature array partialGains[8] : unknown @ 222:29
 	! SUBi <A> #FFT_POWER #1
-fftWPRe:	GLOB *<A>	; signature array fftWPRe[<A>] : unknown
+fftWPRe:	GLOB *<A>	; signature array fftWPRe[<A>] : unknown @ 223:36
 	! SUBi <A> #FFT_POWER #1
-fftWPIm:	GLOB *<A>	; signature array fftWPIm[<A>] : unknown
+fftWPIm:	GLOB *<A>	; signature array fftWPIm[<A>] : unknown @ 224:36
 	GLOB *1
-threshold:	DATf #0.0	; signature global threshold : float
+threshold:	DATf #0.0	; signature global threshold : float @ 225:23
 	GLOB *1
-decayConstant:	DATf #0.0	; signature global decayConstant : float
+decayConstant:	DATf #0.0	; signature global decayConstant : float @ 226:27
 	GLOB *1
-outputGain:	DATf #0.0	; signature global outputGain : float
-randomArray:	GLOB *FFT_SIZE_2	; signature array randomArray[FFT_SIZE_2] : unknown
-untangleParams:	GLOB *2	; signature array untangleParams[2] : unknown
+outputGain:	DATf #0.0	; signature global outputGain : float @ 227:24
+randomArray:	GLOB *FFT_SIZE_2	; signature array randomArray[FFT_SIZE_2] : unknown @ 228:37
+untangleParams:	GLOB *2	; signature array untangleParams[2] : unknown @ 229:31
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fftReIndex:	FUNC	; signature func fftReIndex(int n, ptr data) -> void
+fftReIndex:	FUNC	; signature func fftReIndex(int n, ptr data) -> void @ 233:21
 	$n:	INPi
 	$data:	INPp
 	$nn:	LOCi
@@ -255,7 +255,7 @@ fftReIndex:	FUNC	; signature func fftReIndex(int n, ptr data) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fftPass4:	FUNC	; signature func fftPass4(int n, ptr data, int fftStep) -> void
+fftPass4:	FUNC	; signature func fftPass4(int n, ptr data, int fftStep) -> void @ 255:19
 	$n:	INPi
 	$data:	INPp
 	$fftStep:	INPi
@@ -399,7 +399,7 @@ fftPass4:	FUNC	; signature func fftPass4(int n, ptr data, int fftStep) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fftPass0:	FUNC	; signature func fftPass0(int n, ptr data) -> void
+fftPass0:	FUNC	; signature func fftPass0(int n, ptr data) -> void @ 312:19
 	$n:	INPi
 	$data:	INPp
 	$i:	LOCi
@@ -437,7 +437,7 @@ fftPass0:	FUNC	; signature func fftPass0(int n, ptr data) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fftPass:	FUNC	; signature func fftPass(int n, ptr data, int fftStep) -> void
+fftPass:	FUNC	; signature func fftPass(int n, ptr data, int fftStep) -> void @ 335:18
 	$n:	INPi
 	$data:	INPp
 	$fftStep:	INPi
@@ -506,25 +506,25 @@ fftPass:	FUNC	; signature func fftPass(int n, ptr data, int fftStep) -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fftUntangleParams:	FUNC	; signature func fftUntangleParams(int n, ptr params) -> void
+fftUntangleParams:	FUNC	; signature func fftUntangleParams(int n, ptr params) -> void @ 372:28
 	$n:	INPi
 	$params:	INPp
 	$wpRe:	LOCf
 	$wpIm:	LOCf
 ;-----------------------------------------------------------------------------
 		MOVf %1 #2.0 	; wpRe = (float) sqrt(2.0) * (float) sin(2.0 * PI * 0.5 / itof(n))
-		CALL &sqrt %0 *2	; expects sqrt(float) -> float
+		CALL &sqrt %0 *2	; expects sqrt(float) -> float @ 375:27
 		! MULf <A> #2.0 #PI
 		! MULf <A> <A> #0.5
 		iTOf %2 $n #1.0
 		DIVf %2 <A> %2
-		CALL &sin %1 *2	; expects sin(float) -> float
+		CALL &sin %1 *2	; expects sin(float) -> float @ 375:66
 		MULf $wpRe %0 %1
 		MULf $wpRe $wpRe $wpRe	; wpRe = wpRe * wpRe
 		! MULf <A> #2.0 #PI	; wpIm = (float) sin(2.0 * PI / itof(n))
 		iTOf %1 $n #1.0
 		DIVf %1 <A> %1
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 377:40
 		MOVf $wpIm %0 
 		POKE $params #0 $wpRe	; params[0] = wpRe
 		POKE $params #1 $wpIm	; params[1] = wpIm
@@ -533,7 +533,7 @@ fftUntangleParams:	FUNC	; signature func fftUntangleParams(int n, ptr params) ->
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-fftUntangle:	FUNC	; signature func fftUntangle(int n, ptr data, ptr params) -> void
+fftUntangle:	FUNC	; signature func fftUntangle(int n, ptr data, ptr params) -> void @ 382:22
 	$n:	INPi
 	$data:	INPp
 	$params:	INPp
@@ -628,7 +628,7 @@ fftUntangle:	FUNC	; signature func fftUntangle(int n, ptr data, ptr params) -> v
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-mixOutput:	FUNC	; signature func mixOutput(ptr fftBuffer, ptr mixBuffer, int mixBufferOffset, int channel) -> void
+mixOutput:	FUNC	; signature func mixOutput(ptr fftBuffer, ptr mixBuffer, int mixBufferOffset, int channel) -> void @ 433:20
 	$fftBuffer:	INPp
 	$mixBuffer:	INPp
 	$mixBufferOffset:	INPi
@@ -667,21 +667,21 @@ mixOutput:	FUNC	; signature func mixOutput(ptr fftBuffer, ptr mixBuffer, int mix
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 453:15
 	$i:	LOCi
 	$theta:	LOCf
 	$wTemp:	LOCf
 	$prng:	LOCi
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4d9 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 456:15
 		MOVi $i #0 	; for (i = 0 to FFT_SIZE_2) 
 		GEQi #0 #FFT_SIZE_2 @.e0
 	.l1:	NOOP
 		! iTOf <A> #FFT_SIZE #1.0	; global window[i] = (float) sin(PI / itof(FFT_SIZE) * itof(i))
 		! DIVf <A> #PI <A>
 		iTOf %1 $i <A>
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 459:64
 		POKE &window $i %0
 		FORi $i #FFT_SIZE_2 @.l1	; }
 	.e0:	MOVi $i #0 	; for (i = 0 to 256) 
@@ -691,17 +691,17 @@ init:	FUNC	; signature func init() -> void
 		! DIVf <A> <A> #256.0
 		iTOf $theta $i <A>
 		MOVf %1 $theta 	; global cRotateRe[i] = (float) cos(theta)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 464:43
 		POKE &cRotateRe $i %0
 		MOVf %1 $theta 	; global cRotateIm[i] = (float) sin(theta)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 465:43
 		POKE &cRotateIm $i %0
 		FORi $i #256 @.l3	; }
 	.e2:	MOVi $i #0 	; for (i = 0 to 8) 
 		GEQi #0 #8 @.e4
 	.l5:	ADDi %1 $i #1	; global partialGains[i] = IFFT_SCALE / (float) sqrt(itof(i + 1))
 		iTOf %1 %1 #1.0
-		CALL &sqrt %0 *2	; expects sqrt(float) -> float
+		CALL &sqrt %0 *2	; expects sqrt(float) -> float @ 469:66
 		DIVf %0 #IFFT_SCALE %0
 		POKE &partialGains $i %0
 		FORi $i #8 @.l5	; }
@@ -714,13 +714,13 @@ init:	FUNC	; signature func init() -> void
 		DIVf %0 <B> %0
 		SUBf $theta #0.0 %0
 		MULf %1 #0.5 $theta	; wTemp = (float) sin(0.5 * theta)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 474:38
 		MOVf $wTemp %0 
 		MULf %0 #-2.0 $wTemp	; global fftWPRe[i] = -2.0 * wTemp * wTemp
 		MULf %0 %0 $wTemp
 		POKE &fftWPRe $i %0
 		MOVf %1 $theta 	; global fftWPIm[i] = (float) sin(theta)
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 476:44
 		POKE &fftWPIm $i %0
 		FORi $i <A> @.l7	; }
 	.e6:	PEEK %0 &instance 	; prng = 2463534242 ^ (global instance << 13)
@@ -739,27 +739,27 @@ init:	FUNC	; signature func init() -> void
 		FORi $i #FFT_SIZE_2 @.l9	; }
 	.e8:	MOVi %1 #FFT_SIZE 	; fftUntangleParams(FFT_SIZE, global untangleParams)
 		MOVp %2 &untangleParams 
-		CALL &fftUntangleParams %0 *3	; expects fftUntangleParams(int, ptr) -> void
+		CALL &fftUntangleParams %0 *3	; expects fftUntangleParams(int, ptr) -> void @ 486:52
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 495:16
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4da 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 497:16
 		POKE &doReset #TRUE 	; global doReset = TRUE
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 508:17
 	$f:	LOCf
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_update4db 	; trace("update")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 511:17
 		PEEK %0 &params:THRESHOLD_PARAM 	; f = itof((int) global params[THRESHOLD_PARAM]) * (1.0 / 255.0)
 		! DIVf <A> #1.0 #255.0
 		iTOf $f %0 <A>
@@ -776,15 +776,15 @@ update:	FUNC	; signature func update() -> void
 		POKE &decayConstant %0 
 		PEEK %2 &decayConstant 	; global outputGain = (float) sqrt((float) sqrt(1.0 - global decayConstant))
 		SUBf %2 #1.0 %2
-		CALL &sqrt %1 *2	; expects sqrt(float) -> float
-		CALL &sqrt %0 *2	; expects sqrt(float) -> float
+		CALL &sqrt %1 *2	; expects sqrt(float) -> float @ 519:75
+		CALL &sqrt %0 *2	; expects sqrt(float) -> float @ 519:76
 		POKE &outputGain %0 
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 538:18
 	! MULi <A> #FFT_SIZE #2
 	$fftBuffer:	LOCA *FFT_SIZE
 	$inputBuffer:	LOCA *FFT_SIZE
@@ -892,11 +892,11 @@ process:	FUNC	; signature func process() -> void
 	.s7#SYNTHESIS_REINDEX_LEFT:	NOOP
 	.s7#SYNTHESIS_REINDEX_RIGHT:	MOVi %1 #FFT_SIZE 	; fftReIndex(FFT_SIZE, fftBuffer)
 		ADRL %2 $fftBuffer *0
-		CALL &fftReIndex %0 *3	; expects fftReIndex(int, ptr) -> void
+		CALL &fftReIndex %0 *3	; expects fftReIndex(int, ptr) -> void @ 591:37
 		GOTO @.e8  	; }
 	.s7#ANALYSIS_FFT_2:	MOVi %1 #FFT_SIZE 	; fftPass0(FFT_SIZE, fftBuffer)
 		ADRL %2 $fftBuffer *0
-		CALL &fftPass0 %0 *3	; expects fftPass0(int, ptr) -> void
+		CALL &fftPass0 %0 *3	; expects fftPass0(int, ptr) -> void @ 595:35
 		GOTO @.e8  	; }
 		! ADDi <A> #ANALYSIS_FFT_2 #1	; case ANALYSIS_FFT_2 + 1, ANALYSIS_FFT_2 + 2, ANALYSIS_FFT_2 + 3
 	.s7#<A>:	NOOP
@@ -920,14 +920,14 @@ process:	FUNC	; signature func process() -> void
 	.s7#<A>:	MOVi %1 #FFT_SIZE 	; fftPass(FFT_SIZE, fftBuffer, processStep - ANALYSIS_FFT_2)
 		ADRL %2 $fftBuffer *0
 		SUBi %3 $processStep #ANALYSIS_FFT_2
-		CALL &fftPass %0 *4	; expects fftPass(int, ptr, int) -> void
+		CALL &fftPass %0 *4	; expects fftPass(int, ptr, int) -> void @ 600:64
 		GOTO @.e8  	; }
 	.s7#ANALYSIS_UNTANGLE:	NOOP
 	.s7#SYNTHESIS_UNTANGLE_LEFT:	NOOP
 	.s7#SYNTHESIS_UNTANGLE_RIGHT:	MOVi %1 #FFT_SIZE 	; fftUntangle(FFT_SIZE, fftBuffer, global untangleParams)
 		ADRL %2 $fftBuffer *0
 		MOVp %3 &untangleParams 
-		CALL &fftUntangle %0 *4	; expects fftUntangle(int, ptr, ptr) -> void
+		CALL &fftUntangle %0 *4	; expects fftUntangle(int, ptr, ptr) -> void @ 604:61
 		GOTO @.e8  	; }
 	.s7#PROCESS_FIND_MAX:	MOVf $useThreshold #0.0 	; useThreshold = 0.0
 		PEEK $bandBits &params:BAND_PARAM 	; bandBits = (int) global params[BAND_PARAM]
@@ -1068,7 +1068,7 @@ process:	FUNC	; signature func process() -> void
 		GOTO @.e8  	; }
 	.s7#SYNTHESIS_FFT_LEFT_2:	MOVi %1 #FFT_SIZE 	; fftPass0(FFT_SIZE, fftBuffer)
 		ADRL %2 $fftBuffer *0
-		CALL &fftPass0 %0 *3	; expects fftPass0(int, ptr) -> void
+		CALL &fftPass0 %0 *3	; expects fftPass0(int, ptr) -> void @ 691:35
 		GOTO @.e8  	; }
 		! ADDi <A> #SYNTHESIS_FFT_LEFT_2 #1	; case SYNTHESIS_FFT_LEFT_2 + 1, SYNTHESIS_FFT_LEFT_2 + 2, SYNTHESIS_FFT_LEFT_2 + 3
 	.s7#<A>:	NOOP
@@ -1092,11 +1092,11 @@ process:	FUNC	; signature func process() -> void
 	.s7#<A>:	MOVi %1 #FFT_SIZE 	; fftPass(FFT_SIZE, fftBuffer, processStep - SYNTHESIS_FFT_LEFT_2)
 		ADRL %2 $fftBuffer *0
 		SUBi %3 $processStep #SYNTHESIS_FFT_LEFT_2
-		CALL &fftPass %0 *4	; expects fftPass(int, ptr, int) -> void
+		CALL &fftPass %0 *4	; expects fftPass(int, ptr, int) -> void @ 697:70
 		GOTO @.e8  	; }
 	.s7#SYNTHESIS_FFT_RIGHT_2:	MOVi %1 #FFT_SIZE 	; fftPass0(FFT_SIZE, fftBuffer)
 		ADRL %2 $fftBuffer *0
-		CALL &fftPass0 %0 *3	; expects fftPass0(int, ptr) -> void
+		CALL &fftPass0 %0 *3	; expects fftPass0(int, ptr) -> void @ 701:35
 		GOTO @.e8  	; }
 		! ADDi <A> #SYNTHESIS_FFT_RIGHT_2 #1	; case SYNTHESIS_FFT_RIGHT_2 + 1, SYNTHESIS_FFT_RIGHT_2 + 2, SYNTHESIS_FFT_RIGHT_2 + 3
 	.s7#<A>:	NOOP
@@ -1120,19 +1120,19 @@ process:	FUNC	; signature func process() -> void
 	.s7#<A>:	MOVi %1 #FFT_SIZE 	; fftPass(FFT_SIZE, fftBuffer, processStep - SYNTHESIS_FFT_RIGHT_2)
 		ADRL %2 $fftBuffer *0
 		SUBi %3 $processStep #SYNTHESIS_FFT_RIGHT_2
-		CALL &fftPass %0 *4	; expects fftPass(int, ptr, int) -> void
+		CALL &fftPass %0 *4	; expects fftPass(int, ptr, int) -> void @ 707:71
 		GOTO @.e8  	; }
 	.s7#SYNTHESIS_MIX_LEFT:	ADRL %1 $fftBuffer *0	; mixOutput(fftBuffer, mixBuffer, mixBufferOffset, 0)
 		ADRL %2 $mixBuffer *0
 		MOVi %3 $mixBufferOffset 
 		MOVi %4 #0 
-		CALL &mixOutput %0 *5	; expects mixOutput(ptr, ptr, int, int) -> void
+		CALL &mixOutput %0 *5	; expects mixOutput(ptr, ptr, int, int) -> void @ 711:57
 		GOTO @.e8  	; }
 	.s7#SYNTHESIS_MIX_RIGHT:	ADRL %1 $fftBuffer *0	; mixOutput(fftBuffer, mixBuffer, mixBufferOffset, 1)
 		ADRL %2 $mixBuffer *0
 		MOVi %3 $mixBufferOffset 
 		MOVi %4 #1 
-		CALL &mixOutput %0 *5	; expects mixOutput(ptr, ptr, int, int) -> void
+		CALL &mixOutput %0 *5	; expects mixOutput(ptr, ptr, int, int) -> void @ 715:57
 		! SUBi <A> #FFT_SIZE_2 #1	; write((clock & ~(FFT_SIZE_2 - 1)) + (PROCESS_STEPS << PROCESS_SPREAD_FACTOR), FFT_SIZE_2, mixBuffer + mixBufferOffset)
 		! XORi <A> <A> #-1
 		ANDi %1 $clock <A>
@@ -1141,7 +1141,7 @@ process:	FUNC	; signature func process() -> void
 		MOVi %2 #FFT_SIZE_2 
 		ADRL %3 $mixBuffer *0
 		ADDp %3 %3 $mixBufferOffset
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 716:124
 		SUBi $mixBufferOffset #FFT_SIZE $mixBufferOffset	; mixBufferOffset = FFT_SIZE - mixBufferOffset
 	.s7:	NOOP
 	.e8:	NOOP
@@ -1158,8 +1158,8 @@ process:	FUNC	; signature func process() -> void
 		MOVi %1 $clock 	; read(clock, 1, global signal)
 		MOVi %2 #1 
 		MOVp %3 &signal 
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 723:32
+		CALL ^yield %0 *1	; expects function() -> unknown @ 725:10
 		GOTO @.l4  	; }
 		RETU   	; }
 

--- a/tests/impala/golden/startupcrash_code.gazl
+++ b/tests/impala/golden/startupcrash_code.gazl
@@ -1,27 +1,27 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #1	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_Sillyr4d2 &.s_4d3 &.s_4d3 &.s_LEFTDE4d4 &.s_4d3
 	DATA &.s_4d3 &.s_4d3 &.s_RINGMO4d5
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 81:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 82:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
+instance:	DATi #0	; signature global instance : int @ 83:1
 	CNST *1
-clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
-EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown
+clockFreqLimit:	DATi #132300	; signature readonly clockFreqLimit : int @ 86:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 91:1
+EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unknown @ 91:41
 	DATA #0x0 #0x1 #0x2 #0x3 #0x4 #0x5 #0x6 #0x7 #0x8 #0x9
 	DATA #0xa #0xb #0xc #0xd #0xe #0xf #0x10 #0x11 #0x12 #0x13
 	DATA #0x14 #0x15 #0x16 #0x17 #0x18 #0x19 #0x1a #0x1b #0x1c
@@ -56,19 +56,19 @@ EIGHT_BIT_EXP_TABLE:	CNST *256	; signature array EIGHT_BIT_EXP_TABLE[256] : unkn
 	DATA #0x7c00 #0x8000 #0x8800 #0x9000 #0x9800 #0xa000
 	DATA #0xa800 #0xb000 #0xb800 #0xc000 #0xc800 #0xd000
 	DATA #0xd800 #0xe000 #0xe800 #0xf000 #0xffff
-LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float
-LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float
-LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+LOG2:	! DEFf #0.69314718055994530942	; signature const LOG2 : float @ 126:1
+LOG2R:	! DEFf #1.44269504088896340736	; signature const LOG2R : float @ 127:1
+LOG10R:	! DEFf #0.43429448190325182765	; signature const LOG10R : float @ 128:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 129:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 130:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 131:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 132:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 134:1
 
 ;-----------------------------------------------------------------------------
 	$a:	OUTp
-stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
+stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr @ 134:17
 	$d:	INPp
 	$s:	INPp
 	$b:	LOCp
@@ -86,7 +86,7 @@ stpcpy:	FUNC	; signature func stpcpy(ptr d, ptr s) -> ptr
 
 ;-----------------------------------------------------------------------------
 	$p:	OUTp
-intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr
+intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, ptr buffer) -> ptr @ 153:22
 	$i:	INPi
 	$radix:	INPi
 	$minLength:	INPi
@@ -133,7 +133,7 @@ intToString:	FUNC	; signature func intToString(int i, int radix, int minLength, 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
+traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void @ 171:20
 	$text:	INPp
 	$n:	INPi
 	$ints:	INPp
@@ -147,7 +147,7 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		EQUp $text &NULL @.f0	; if (text != null) p = (pointer) stpcpy(p, text)
 		MOVp %1 $p 	; p = (pointer) stpcpy(p, text)
 		MOVp %2 $text 
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 178:49
 		MOVp $p %0 
 	.f0:	POKE $p #0 	; *p = 0
 		MOVi $i #0 	; for (i = 0 to n) 
@@ -160,18 +160,18 @@ traceInts:	FUNC	; signature func traceInts(ptr text, int n, ptr ints) -> void
 		MOVi %4 #10 
 		MOVi %5 #1 
 		ADRL %6 $buffer *0
-		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr
+		CALL &intToString %2 *5	; expects intToString(int, int, int, ptr) -> ptr @ 182:62
+		CALL &stpcpy %0 *3	; expects stpcpy(ptr, ptr) -> ptr @ 182:63
 		MOVp $p %0 
 		FORi $i $n @.l2	; }
 	.e1:	ADRL %1 $line *0	; trace(line)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 184:13
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
+traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void @ 187:19
 	$text:	INPp
 	$i:	INPi
 	$ints:	LOCA *1
@@ -180,24 +180,24 @@ traceInt:	FUNC	; signature func traceInt(ptr text, int i) -> void
 		MOVp %1 $text 	; traceInts(text, 1, ints)
 		MOVi %2 #1 
 		ADRL %3 $ints *0
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 191:26
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 194:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 196:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 197:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 200:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -211,16 +211,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 207:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4d7 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 210:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float)trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 211:35
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -228,7 +228,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 225:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -237,7 +237,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 229:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -257,47 +257,47 @@ cos:	FUNC	; signature func cos(float x) -> float
 		MOVf $y #0.0 	; y = 0.0
 	.f1:	RETU   	; }
 
-COS_TABLE_BITS:	! DEFi #12	; signature const COS_TABLE_BITS : int
+COS_TABLE_BITS:	! DEFi #12	; signature const COS_TABLE_BITS : int @ 244:1
 	! SHLi <A> #1 #COS_TABLE_BITS
-COS_TABLE_SIZE:	! DEFi <A>	; signature const COS_TABLE_SIZE : int
-BATCH_SIZE:	! DEFi #77	; signature const BATCH_SIZE : int
+COS_TABLE_SIZE:	! DEFi <A>	; signature const COS_TABLE_SIZE : int @ 245:1
+BATCH_SIZE:	! DEFi #77	; signature const BATCH_SIZE : int @ 245:26
 	! ADDi <A> #COS_TABLE_SIZE #1
-cosTable:	GLOB *<A>	; signature array cosTable[<A>] : unknown
+cosTable:	GLOB *<A>	; signature array cosTable[<A>] : unknown @ 251:1
 	GLOB *1
-doReset:	DATi #FALSE	; signature global doReset : int
+doReset:	DATi #FALSE	; signature global doReset : int @ 252:1
 	GLOB *1
-rate:	DATi #0	; signature global rate : int
+rate:	DATi #0	; signature global rate : int @ 253:1
 	GLOB *1
-diff:	DATi #0	; signature global diff : int
+diff:	DATi #0	; signature global diff : int @ 254:1
 	GLOB *1
-delayL:	DATi #0	; signature global delayL : int
+delayL:	DATi #0	; signature global delayL : int @ 255:1
 	GLOB *1
-delayR:	DATi #0	; signature global delayR : int
+delayR:	DATi #0	; signature global delayR : int @ 256:1
 	GLOB *1
-syncBit:	DATi #0	; signature global syncBit : int
+syncBit:	DATi #0	; signature global syncBit : int @ 263:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 263:15
 	$i:	LOCi
 	$buf:	LOCA *256
 	$p:	LOCp
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4d8 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 266:15
 		PEEK %2 &instance 	; trace(intToString(global instance, 10, 1, buf))
 		MOVi %3 #10 
 		MOVi %4 #1 
 		ADRL %5 $buf *0
-		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL &intToString %1 *5	; expects intToString(int, int, int, ptr) -> ptr @ 267:48
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 267:49
 		MOVi $i #0 	; for (i = 0 to COS_TABLE_SIZE) global cosTable[i] = ftoi((float) cos((TWICE_PI / itof(COS_TABLE_SIZE)) * itof(i)) * 2048.0)
 		GEQi #0 #COS_TABLE_SIZE @.e0
 	.l1:	NOOP
 		! iTOf <A> #COS_TABLE_SIZE #1.0	; global cosTable[i] = ftoi((float) cos((TWICE_PI / itof(COS_TABLE_SIZE)) * itof(i)) * 2048.0)
 		! DIVf <A> #TWICE_PI <A>
 		iTOf %1 $i <A>
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 268:115
 		fTOi %0 %0 #2048.0
 		POKE &cosTable $i %0
 		FORi $i #COS_TABLE_SIZE @.l1
@@ -305,7 +305,7 @@ init:	FUNC	; signature func init() -> void
 		POKE &cosTable:COS_TABLE_SIZE %0 
 		MOVp %1 &.s_DEBUG4d9 	; traceInt("DEBUG: ", DEBUG)
 		MOVi %2 #DEBUG 
-		CALL &traceInt %0 *3	; expects traceInt(ptr, int) -> void
+		CALL &traceInt %0 *3	; expects traceInt(ptr, int) -> void @ 271:28
 		NEQi #DEBUG #0 @.f2	; if (DEBUG == 0) 
 		POKE &doReset #TRUE 	; global doReset = TRUE
 		MOVp $p &NULL 	; p = null
@@ -315,24 +315,24 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 283:16
 	$p:	LOCp
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4da 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 286:16
 		MOVp %1 &.s_params4db 	; traceInts(" params: ", PARAM_COUNT, global params)
 		MOVi %2 #PARAM_COUNT 
 		MOVp %3 &params 
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 287:52
 		MOVp %1 &.s_DEBUG4d9 	; traceInt("DEBUG: ", DEBUG)
 		MOVi %2 #DEBUG 
-		CALL &traceInt %0 *3	; expects traceInt(ptr, int) -> void
+		CALL &traceInt %0 *3	; expects traceInt(ptr, int) -> void @ 288:28
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int
+displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int @ 291:28
 	$x:	INPi
 ;-----------------------------------------------------------------------------
 		! SUBi <A> #8 #3	; y = 0x1 << (x >> (8 - 3))
@@ -343,34 +343,34 @@ displayDelayValue:	FUNC	; signature func displayDelayValue(int x) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 301:17
 	$buf:	LOCA *256
 	$params:	LOCA *PARAM_COUNT
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_update4dc 	; trace("update")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 304:17
 		MOVp %1 &.s_params4db 	; traceInts(" params: ", PARAM_COUNT, global params)
 		MOVi %2 #PARAM_COUNT 
 		MOVp %3 &params 
-		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void
+		CALL &traceInts %0 *4	; expects traceInts(ptr, int, ptr) -> void @ 305:52
 		ADRL %0 $params *0	; copy (PARAM_COUNT from global params to params)
 		COPY %0 &params *PARAM_COUNT
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_1_HIGH_PARAM_INDEX	; global delayL = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_1_HIGH_PARAM_INDEX]]
 		POKE &delayL %0 
 		MOVi %1 $params:OPERAND_1_HIGH_PARAM_INDEX 	; global displayLEDs[0] = displayDelayValue((int) params[OPERAND_1_HIGH_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 308:85
 		POKE &displayLEDs:0 %0 
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_1_LOW_PARAM_INDEX	; global delayR = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_1_LOW_PARAM_INDEX]]
 		POKE &delayR %0 
 		MOVi %1 $params:OPERAND_1_LOW_PARAM_INDEX 	; global displayLEDs[1] = displayDelayValue((int) params[OPERAND_1_LOW_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 310:84
 		POKE &displayLEDs:1 %0 
 		PEEK %0 &EIGHT_BIT_EXP_TABLE $params:OPERAND_2_HIGH_PARAM_INDEX	; global rate = (int) global EIGHT_BIT_EXP_TABLE[(int) params[OPERAND_2_HIGH_PARAM_INDEX]]
 		POKE &rate %0 
 		SHLi %0 $params:OPERAND_2_LOW_PARAM_INDEX #8	; global diff = (int) params[OPERAND_2_LOW_PARAM_INDEX] << 8
 		POKE &diff %0 
 		MOVi %1 $params:OPERAND_2_LOW_PARAM_INDEX 	; global displayLEDs[3] = displayDelayValue((int) params[OPERAND_2_LOW_PARAM_INDEX])
-		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int
+		CALL &displayDelayValue %0 *2	; expects displayDelayValue(int) -> int @ 313:84
 		POKE &displayLEDs:3 %0 
 		PEEK %0 &params:SWITCHES_PARAM_INDEX 	; global syncBit = (int) global params[SWITCHES_PARAM_INDEX] & SWITCHES_SYNC_MASK
 		ANDi %0 %0 #SWITCHES_SYNC_MASK
@@ -380,13 +380,13 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 332:18
 	$i:	LOCi
 	$p:	LOCp
 ;-----------------------------------------------------------------------------
 		MOVi $i #0 	; for (i = 0 to 1000000) yield()
 		GEQi #0 #1000000 @.e0
-	.l1:	CALL ^yield %0 *1	; expects function() -> unknown
+	.l1:	CALL ^yield %0 *1	; expects function() -> unknown @ 335:32
 		FORi $i #1000000 @.l1
 	.e0:	MOVp $p &NULL 	; p = null
 		POKE $p #0 	; *p = 0

--- a/tests/impala/golden/switchtest.gazl
+++ b/tests/impala/golden/switchtest.gazl
@@ -4,7 +4,7 @@
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-x:	FUNC	; signature func x() -> void
+x:	FUNC	; signature func x() -> void @ 1:12
 	$i:	LOCi
 	$j:	LOCi
 	$k:	LOCi
@@ -15,7 +15,7 @@ x:	FUNC	; signature func x() -> void
 	.s0#2:	NOOP
 	.s0#3:	MOVi $j $i 	; j = i
 		GOTO @.e1  
-	.s0#5:	CALL &x %0 *1	; expects x() -> void
+	.s0#5:	CALL &x %0 *1	; expects x() -> void @ 4:13
 		GOTO @.e1  
 	.s0:	MOVi $i $j 	; i = j
 		GOTO @.e1  
@@ -23,11 +23,11 @@ x:	FUNC	; signature func x() -> void
 	.s0#33:	MOVi $k $j 	; k = j
 	.e1:	RETU   	; }
 
-CONSTANT:	! DEFi #2949	; signature const CONSTANT : int
+CONSTANT:	! DEFi #2949	; signature const CONSTANT : int @ 10:26
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-y:	FUNC	; signature func y() -> void
+y:	FUNC	; signature func y() -> void @ 11:12
 	$i:	LOCi
 	$a:	LOCA *5
 ;-----------------------------------------------------------------------------
@@ -62,7 +62,7 @@ y:	FUNC	; signature func y() -> void
 	.s4:	NOOP
 	.e5:	SUBi %0 $i #10	; switch (i == 10 to 100) 
 		SWCH %0 *90 @.s6
-	.s6#90:	CALL &x %0 *1	; expects x() -> void
+	.s6#90:	CALL &x %0 *1	; expects x() -> void @ 15:41
 		GOTO @.e7  
 	.s6:	GOTO @.e7  	; 
 	.s6#190:	ADDi $i $i #1	; i = i + 1
@@ -71,27 +71,27 @@ y:	FUNC	; signature func y() -> void
 	.s6#<A>:	GETL $i $a $i	; i = (int) a[i]
 	.e7:	RETU   	; }
 
-; signature extern native printInt() -> unknown
-; signature extern native printLF() -> unknown
-MINUS_FIVE:	! DEFi #-5	; signature const MINUS_FIVE : int
-gx:	GLOB *10	; signature array gx[10] : unknown
+; signature extern native printInt() -> unknown @ 18:23
+; signature extern native printLF() -> unknown @ 19:22
+MINUS_FIVE:	! DEFi #-5	; signature const MINUS_FIVE : int @ 20:26
+gx:	GLOB *10	; signature array gx[10] : unknown @ 21:20
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-test:	FUNC	; signature func test(int a, int b) -> void
+test:	FUNC	; signature func test(int a, int b) -> void @ 23:15
 	$a:	INPi
 	$b:	INPi
 ;-----------------------------------------------------------------------------
 		MOVi %1 $a 	; printInt(a)
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 24:13
 		MOVi %1 $b 	; printInt(b)
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 25:13
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-main:	FUNC	; signature func main() -> void
+main:	FUNC	; signature func main() -> void @ 28:15
 	$i:	LOCi
 	$a:	LOCi
 	$b:	LOCi
@@ -107,26 +107,26 @@ main:	FUNC	; signature func main() -> void
 		ADDi %1 %1 $a
 		ADDi %1 %1 #1
 		MOVi %2 $b 
-		CALL &test %0 *3	; expects test(int, int) -> void
+		CALL &test %0 *3	; expects test(int, int) -> void @ 35:22
 		ADDi %1 #1 $b	; test(a+1+2/(1+b), b)
 		ADDi %2 $a #1
 		DIVi %1 #2 %1
 		ADDi %1 %2 %1
 		MOVi %2 $b 
-		CALL &test %0 *3	; expects test(int, int) -> void
+		CALL &test %0 *3	; expects test(int, int) -> void @ 36:22
 		ADDi %1 #1 $b	; test(a+1+2/(1+b)+(int)(test(3,1)), a+1+2/(1+b))
 		ADDi %2 $a #1
 		DIVi %1 #2 %1
 		MOVi %4 #3 
 		MOVi %5 #1 
-		CALL &test %3 *3	; expects test(int, int) -> void
+		CALL &test %3 *3	; expects test(int, int) -> void @ 37:34
 		ADDi %2 %2 %1
 		ADDi %1 %2 %3
 		ADDi %2 #1 $b
 		ADDi %3 $a #1
 		DIVi %2 #2 %2
 		ADDi %2 %3 %2
-		CALL &test %0 *3	; expects test(int, int) -> void
+		CALL &test %0 *3	; expects test(int, int) -> void @ 37:49
 		MOVi $i #-5 	; for (i = -5 to 20) 
 		GEQi #-5 #20 @.e0
 	.l1:	NOOP
@@ -137,33 +137,33 @@ main:	FUNC	; signature func main() -> void
 		SWCH %0 *<B> @.s2
 		! SUBi <B> #-2 <A>	; case -2
 	.s2#<B>:	MOVi %1 #-2 	; printInt(-2)
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 41:25
 		GOTO @.e3  
 		! SUBi <B> #11 #1	; case 11-1
 		! SUBi <B> <B> <A>
 	.s2#<B>:	MOVi %1 #10 	; printInt(10)
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 42:27
 		GOTO @.e3  
 		! SUBi <B> #'a' #'a'	; case 'a'-'a'
 		! SUBi <B> <B> <A>
 	.s2#<B>:	MOVi %1 #0 	; printInt(0)
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 43:29
 		GOTO @.e3  
 	.s2:	MULi %0 $i #2	; switch (i * 2 == 0 to 6) 
 		SWCH %0 *6 @.s4
 	.s4:	MOVi %1 #-1000 	; printInt(-1000)
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 46:34
 		GOTO @.e3  
 	.s4#2:	MOVi %1 #11111 	; printInt(11111)
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 47:30
 		GOTO @.e3  
 	.s4#5:	NEQi #1 #1 @.e3	; if (1 == 1) printInt(5555)
 		MOVi %1 #5555 	; printInt(5555)
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 48:41
 	.e5:	GOTO @.e3  	; }
 		! SUBi <B> #5 <A>	; case 5
 	.s2#<B>:	MOVi %1 #5 	; printInt(5)
-		CALL ^printInt %0 *2	; expects function(int) -> unknown
-	.e3:	CALL ^printLF %0 *1	; expects function() -> unknown
+		CALL ^printInt %0 *2	; expects function(int) -> unknown @ 52:23
+	.e3:	CALL ^printLF %0 *1	; expects function() -> unknown @ 54:12
 		FORi $i #20 @.l1	; }
 	.e0:	RETU   	; }

--- a/tests/impala/golden/trancelvania_code.gazl
+++ b/tests/impala/golden/trancelvania_code.gazl
@@ -1,48 +1,48 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 18:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 19:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 27:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 27:33
 	DATA &.s_116ste4d2 &.s_132ste4d3 &.s_Level64d4
 	DATA &.s_Leftst4d5 &.s_Gate4d6 &.s_LPF4d7 &.s_BPF4d8
 	DATA &.s_HPFAtt4d9
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 39:1
+; signature extern native trace() -> unknown @ 40:1
+; signature extern native yield() -> unknown @ 41:1
+; signature extern native write() -> unknown @ 42:1
+; signature extern native read() -> unknown @ 44:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 80:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 81:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 82:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
+instance:	DATi #0	; signature global instance : int @ 83:1
 	CNST *1
-clockFreqLimit:	DATi #176400	; signature readonly clockFreqLimit : int
-signal:	GLOB *2	; signature array signal[2] : unknown
-E:	! DEFf #2.71828182845904523536	; signature const E : float
-HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float
-PI:	! DEFf #3.14159265358979323846	; signature const PI : float
+clockFreqLimit:	DATi #176400	; signature readonly clockFreqLimit : int @ 86:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 97:1
+E:	! DEFf #2.71828182845904523536	; signature const E : float @ 98:1
+HALF_PI:	! DEFf #1.57079632679489661923	; signature const HALF_PI : float @ 99:1
+PI:	! DEFf #3.14159265358979323846	; signature const PI : float @ 100:1
 	! MULf <A> #PI #2.0
-TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float
-COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float
+TWICE_PI:	! DEFf <A>	; signature const TWICE_PI : float @ 101:1
+COS_EPSILON:	! DEFf #1.0e-6	; signature const COS_EPSILON : float @ 103:1
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-error:	FUNC	; signature func error(ptr s) -> void
+error:	FUNC	; signature func error(ptr s) -> void @ 103:16
 	$s:	INPp
 ;-----------------------------------------------------------------------------
 		MOVp %1 $s 	; trace(s)
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
-		CALL ^abort %0 *1	; expects function() -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 105:10
+		CALL ^abort %0 *1	; expects function() -> unknown @ 106:9
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-trunc:	FUNC	; signature func trunc(float x) -> float
+trunc:	FUNC	; signature func trunc(float x) -> float @ 109:16
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		GEQf $x #0.0 @.f0	; if (x < 0.0) y = -floor(-x)
@@ -56,16 +56,16 @@ trunc:	FUNC	; signature func trunc(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$z:	OUTf
-fmod:	FUNC	; signature func fmod(float x, float y) -> float
+fmod:	FUNC	; signature func fmod(float x, float y) -> float @ 116:15
 	$x:	INPf
 	$y:	INPf
 ;-----------------------------------------------------------------------------
 		NEQf $y #0.0 @.f0	; if (y == 0.0) error("Division by zero")
 		MOVp %1 &.s_Divisi4da 	; error("Division by zero")
-		CALL &error %0 *2	; expects error(ptr) -> void
+		CALL &error %0 *2	; expects error(ptr) -> void @ 119:41
 		GOTO @.e1  
 	.f0:	DIVf %1 $x $y	; z = x - (float)trunc(x / y) * y
-		CALL &trunc %0 *2	; expects trunc(float) -> float
+		CALL &trunc %0 *2	; expects trunc(float) -> float @ 120:35
 		MULf %0 %0 $y
 		SUBf $z $x %0
 	.e1:	RETU   	; }
@@ -73,7 +73,7 @@ fmod:	FUNC	; signature func fmod(float x, float y) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-exp:	FUNC	; signature func exp(float x) -> float
+exp:	FUNC	; signature func exp(float x) -> float @ 148:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -97,7 +97,7 @@ exp:	FUNC	; signature func exp(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-cos:	FUNC	; signature func cos(float x) -> float
+cos:	FUNC	; signature func cos(float x) -> float @ 179:14
 	$x:	INPf
 	$a:	LOCf
 	$n:	LOCf
@@ -106,7 +106,7 @@ cos:	FUNC	; signature func cos(float x) -> float
 ;-----------------------------------------------------------------------------
 		MOVf %1 $x 	; m = (float) fmod(x, TWICE_PI)
 		MOVf %2 #TWICE_PI 
-		CALL &fmod %0 *3	; expects fmod(float, float) -> float
+		CALL &fmod %0 *3	; expects fmod(float, float) -> float @ 183:31
 		MOVf $m %0 
 		SUBf %0 #0.0 $m	; m = -m * m
 		MULf $m %0 $m
@@ -129,32 +129,32 @@ cos:	FUNC	; signature func cos(float x) -> float
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTf
-sin:	FUNC	; signature func sin(float x) -> float
+sin:	FUNC	; signature func sin(float x) -> float @ 195:14
 	$x:	INPf
 ;-----------------------------------------------------------------------------
 		SUBf %1 $x #HALF_PI	; y = (float) cos(x - HALF_PI)
-		CALL &cos %0 *2	; expects cos(float) -> float
+		CALL &cos %0 *2	; expects cos(float) -> float @ 198:30
 		MOVf $y %0 
 		RETU   	; }
 
-BATCH_SIZE:	! DEFi #64	; signature const BATCH_SIZE : int
-FILTER_PARAM_TABLE_SIZE:	! DEFi #256	; signature const FILTER_PARAM_TABLE_SIZE : int
+BATCH_SIZE:	! DEFi #64	; signature const BATCH_SIZE : int @ 203:26
+FILTER_PARAM_TABLE_SIZE:	! DEFi #256	; signature const FILTER_PARAM_TABLE_SIZE : int @ 204:40
 	! SUBi <A> #FILTER_PARAM_TABLE_SIZE #1
 	! iTOf <A> <A> #1.0
-FILTER_PARAM_MAX:	! DEFf <A>	; signature const FILTER_PARAM_MAX : float
-LNRQ:	! DEFf #0.346574	; signature const LNRQ : float
-EPSILON:	! DEFf #0.000000001	; signature const EPSILON : float
-LOG1000:	! DEFf #6.9077552789821	; signature const LOG1000 : float
-LOG0_001:	! DEFf #-6.9077552789821	; signature const LOG0_001 : float
+FILTER_PARAM_MAX:	! DEFf <A>	; signature const FILTER_PARAM_MAX : float @ 205:65
+LNRQ:	! DEFf #0.346574	; signature const LNRQ : float @ 206:28
+EPSILON:	! DEFf #0.000000001	; signature const EPSILON : float @ 207:34
+LOG1000:	! DEFf #6.9077552789821	; signature const LOG1000 : float @ 208:38
+LOG0_001:	! DEFf #-6.9077552789821	; signature const LOG0_001 : float @ 209:40
 	GLOB *1
-doReset:	DATi #TRUE	; signature global doReset : int
+doReset:	DATi #TRUE	; signature global doReset : int @ 214:1
 	! MULi <A> #FILTER_PARAM_TABLE_SIZE #2
-filterParamTable:	GLOB *<A>	; signature array filterParamTable[<A>] : unknown
-rateTable:	GLOB *256	; signature array rateTable[256] : unknown
+filterParamTable:	GLOB *<A>	; signature array filterParamTable[<A>] : unknown @ 214:59
+rateTable:	GLOB *256	; signature array rateTable[256] : unknown @ 215:28
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-init:	FUNC	; signature func init() -> void
+init:	FUNC	; signature func init() -> void @ 224:15
 	$f:	LOCf
 	$k:	LOCf
 	$m:	LOCf
@@ -162,26 +162,26 @@ init:	FUNC	; signature func init() -> void
 	$x:	LOCf
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_init4db 	; trace("init")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 227:15
 		MOVi $i #0 	; for (i = 0 to FILTER_PARAM_TABLE_SIZE) 
 		GEQi #0 #FILTER_PARAM_TABLE_SIZE @.e0
 	.l1:	NOOP
 		! DIVf <A> #1.0 #FILTER_PARAM_MAX	; f = (float) exp(LOG1000 * (itof(i) * (1.0 / FILTER_PARAM_MAX))) / 2205.0
 		iTOf %1 $i <A>
 		MULf %1 #LOG1000 %1
-		CALL &exp %0 *2	; expects exp(float) -> float
+		CALL &exp %0 *2	; expects exp(float) -> float @ 229:67
 		DIVf $f %0 #2205.0
 		MULf %1 #4.0 $f	; m = (float) exp((1.0 - 4.0 * f * f) * LNRQ)
 		MULf %1 %1 $f
 		SUBf %1 #1.0 %1
 		MULf %1 %1 #LNRQ
-		CALL &exp %0 *2	; expects exp(float) -> float
+		CALL &exp %0 *2	; expects exp(float) -> float @ 230:46
 		MOVf $m %0 
 		MULf %1 #PI $f	; k = 2.0 * (float) sin(PI * f) - m * 0.5 * (1.0 - (float) cos(2.0 * PI * f))
-		CALL &sin %0 *2	; expects sin(float) -> float
+		CALL &sin %0 *2	; expects sin(float) -> float @ 231:33
 		! MULf <A> #2.0 #PI
 		MULf %2 <A> $f
-		CALL &cos %1 *2	; expects cos(float) -> float
+		CALL &cos %1 *2	; expects cos(float) -> float @ 231:77
 		MULf %2 $m #0.5
 		SUBf %1 #1.0 %1
 		MULf %0 #2.0 %0
@@ -199,7 +199,7 @@ init:	FUNC	; signature func init() -> void
 		! DIVf <A> #1.0 #255.0	; global rateTable[i] = (float) exp(LOG0_001 * (itof(i) * (1.0 / 255.0)))
 		iTOf %1 $i <A>
 		MULf %1 #LOG0_001 %1
-		CALL &exp %0 *2	; expects exp(float) -> float
+		CALL &exp %0 *2	; expects exp(float) -> float @ 236:74
 		POKE &rateTable $i %0
 		FORi $i #256 @.l3	; }
 	.e2:	RETU   	; }
@@ -207,17 +207,17 @@ init:	FUNC	; signature func init() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-reset:	FUNC	; signature func reset() -> void
+reset:	FUNC	; signature func reset() -> void @ 246:16
 ;-----------------------------------------------------------------------------
 		MOVp %1 &.s_reset4dc 	; trace("reset")
-		CALL ^trace %0 *2	; expects function(ptr) -> unknown
+		CALL ^trace %0 *2	; expects function(ptr) -> unknown @ 248:16
 		POKE &doReset #TRUE 	; global doReset = TRUE
 		RETU   	; }
 
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 267:18
 	$i:	LOCi
 	$clock:	LOCi
 	$clockDir:	LOCi
@@ -415,11 +415,11 @@ process:	FUNC	; signature func process() -> void
 	.l18:	MOVi %1 $clock 	; write(clock, 1, global signal)
 		MOVi %2 #1 
 		MOVp %3 &signal 
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 378:34
 		MOVi %1 $clock 	; read(clock, 1, inputSignal)
 		MOVi %2 #1 
 		ADRL %3 $inputSignal *0
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 379:31
 		! DIVf <A> #1.0 #2048.0	; l = itof((int) inputSignal[0]) * (1.0 / 2048.0) + nyquist
 		iTOf %0 $inputSignal:0 <A>
 		ADDf $l %0 $nyquist
@@ -460,7 +460,7 @@ process:	FUNC	; signature func process() -> void
 		POKE &signal:0 %0 
 		fTOi %0 $r #2048.0	; global signal[1] = ftoi(r * 2048.0)
 		POKE &signal:1 %0 
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 401:11
 		ADDi $clock $clock $clockDir	; clock = clock + clockDir
 		SUBf $nyquist #0.0 $nyquist	; nyquist = -nyquist
 		FORi $i #BATCH_SIZE @.l18	; }

--- a/tests/impala/golden/unarytest.gazl
+++ b/tests/impala/golden/unarytest.gazl
@@ -1,11 +1,11 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-ga:	GLOB *100	; signature array ga[100] : unknown
+ga:	GLOB *100	; signature array ga[100] : unknown @ 3:21
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-test:	FUNC	; signature func test() -> void
+test:	FUNC	; signature func test() -> void @ 5:15
 	$i:	LOCi
 	$f:	LOCf
 	$p:	LOCp
@@ -66,5 +66,5 @@ test:	FUNC	; signature func test() -> void
 		! fTOi <A> <A> #1.0
 		! iTOf <A> <A> #1.0
 		MOVf $f <A> 
-		CALL $fp %0 *1	; expects function() -> unknown
+		CALL $fp %0 *1	; expects function() -> unknown @ 39:6
 		RETU   	; }

--- a/tests/impala/golden/verber8_code.gazl
+++ b/tests/impala/golden/verber8_code.gazl
@@ -1,26 +1,26 @@
 ; Compiled with Impala version 1.0
 
 ; signatures version=1
-PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int
-FALSE:	! DEFi #0	; signature const FALSE : int
-TRUE:	! DEFi #1	; signature const TRUE : int
-panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown
+PRAWN_FIRMWARE_PATCH_FORMAT:	! DEFi #2	; signature const PRAWN_FIRMWARE_PATCH_FORMAT : int @ 11:1
+FALSE:	! DEFi #0	; signature const FALSE : int @ 12:1
+TRUE:	! DEFi #1	; signature const TRUE : int @ 20:1
+panelTextRows:	CNST *8	; signature array panelTextRows[8] : unknown @ 20:33
 	DATA &.s_4d2 &.s_4d2 &.s_4d2 &.s_ROOMSI4d3 &.s_4d2 &.s_4d2
 	DATA &.s_4d2 &.s_FEEDBA4d4
-; signature extern native abort() -> unknown
-; signature extern native trace() -> unknown
-; signature extern native yield() -> unknown
-; signature extern native write() -> unknown
-; signature extern native read() -> unknown
+; signature extern native abort() -> unknown @ 32:1
+; signature extern native trace() -> unknown @ 33:1
+; signature extern native yield() -> unknown @ 34:1
+; signature extern native write() -> unknown @ 35:1
+; signature extern native read() -> unknown @ 37:1
 	GLOB *1
-clock:	DATi #0	; signature global clock : int
-signal:	GLOB *2	; signature array signal[2] : unknown
-params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown
-displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown
+clock:	DATi #0	; signature global clock : int @ 68:1
+signal:	GLOB *2	; signature array signal[2] : unknown @ 69:1
+params:	GLOB *PARAM_COUNT	; signature array params[PARAM_COUNT] : unknown @ 70:1
+displayLEDs:	GLOB *4	; signature array displayLEDs[4] : unknown @ 71:1
 	GLOB *1
-instance:	DATi #0	; signature global instance : int
+instance:	DATi #0	; signature global instance : int @ 72:1
 	CNST *1
-clockFreqLimit:	DATi #88200	; signature readonly clockFreqLimit : int
+clockFreqLimit:	DATi #88200	; signature readonly clockFreqLimit : int @ 73:1
 	CNST *1
 	! SHLi <A> #1 #OPERAND_1_HIGH_PARAM_INDEX
 	! SHLi <B> #1 #OPERAND_1_LOW_PARAM_INDEX
@@ -29,30 +29,30 @@ clockFreqLimit:	DATi #88200	; signature readonly clockFreqLimit : int
 	! IORi <A> <A> <B>
 	! SHLi <B> #1 #OPERAND_2_LOW_PARAM_INDEX
 	! IORi <A> <A> <B>
-updateMask:	DATi <A>	; signature readonly updateMask : int
-TAPS_COUNT:	! DEFi #10	; signature const TAPS_COUNT : int
-BATCH_SIZE:	! DEFi #32	; signature const BATCH_SIZE : int
+updateMask:	DATi <A>	; signature readonly updateMask : int @ 82:1
+TAPS_COUNT:	! DEFi #10	; signature const TAPS_COUNT : int @ 83:1
+BATCH_SIZE:	! DEFi #32	; signature const BATCH_SIZE : int @ 84:1
 	! MULi <A> #BATCH_SIZE #2
-BATCH_SIZE_2:	! DEFi <A>	; signature const BATCH_SIZE_2 : int
-T0:	! DEFi #0	; signature const T0 : int
-T3:	! DEFi #1	; signature const T3 : int
-T5:	! DEFi #2	; signature const T5 : int
-T7:	! DEFi #3	; signature const T7 : int
-T11:	! DEFi #4	; signature const T11 : int
-T13:	! DEFi #5	; signature const T13 : int
-TFB:	! DEFi #6	; signature const TFB : int
-TL1:	! DEFi #7	; signature const TL1 : int
-TL2:	! DEFi #8	; signature const TL2 : int
-TR:	! DEFi #9	; signature const TR : int
+BATCH_SIZE_2:	! DEFi <A>	; signature const BATCH_SIZE_2 : int @ 86:1
+T0:	! DEFi #0	; signature const T0 : int @ 87:1
+T3:	! DEFi #1	; signature const T3 : int @ 88:1
+T5:	! DEFi #2	; signature const T5 : int @ 89:1
+T7:	! DEFi #3	; signature const T7 : int @ 90:1
+T11:	! DEFi #4	; signature const T11 : int @ 91:1
+T13:	! DEFi #5	; signature const T13 : int @ 92:1
+TFB:	! DEFi #6	; signature const TFB : int @ 93:1
+TL1:	! DEFi #7	; signature const TL1 : int @ 94:1
+TL2:	! DEFi #8	; signature const TL2 : int @ 95:1
+TR:	! DEFi #9	; signature const TR : int @ 99:1
 	GLOB *1
-feedback:	DATi #0	; signature global feedback : int
+feedback:	DATi #0	; signature global feedback : int @ 100:1
 	GLOB *1
-damping:	DATi #0	; signature global damping : int
-taps:	GLOB *TAPS_COUNT	; signature array taps[TAPS_COUNT] : unknown
+damping:	DATi #0	; signature global damping : int @ 102:1
+taps:	GLOB *TAPS_COUNT	; signature array taps[TAPS_COUNT] : unknown @ 106:1
 
 ;-----------------------------------------------------------------------------
 	$y:	OUTi
-displayBarValue:	FUNC	; signature func displayBarValue(int x) -> int
+displayBarValue:	FUNC	; signature func displayBarValue(int x) -> int @ 106:26
 	$x:	INPi
 ;-----------------------------------------------------------------------------
 		! SUBi <A> #8 #3	; y = ~(0x7F >> (x >> (8 - 3)))
@@ -64,7 +64,7 @@ displayBarValue:	FUNC	; signature func displayBarValue(int x) -> int
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-update:	FUNC	; signature func update() -> void
+update:	FUNC	; signature func update() -> void @ 116:17
 	$params:	LOCA *PARAM_COUNT
 	$taps:	LOCA *TAPS_COUNT
 	$size:	LOCi
@@ -85,16 +85,16 @@ update:	FUNC	; signature func update() -> void
 		SHRi %0 %0 #8
 		POKE &damping %0 
 		MOVi %1 $params:OPERAND_1_HIGH_PARAM_INDEX 	; global displayLEDs[0] = (int) displayBarValue((int) params[OPERAND_1_HIGH_PARAM_INDEX])
-		CALL &displayBarValue %0 *2	; expects displayBarValue(int) -> int
+		CALL &displayBarValue %0 *2	; expects displayBarValue(int) -> int @ 129:89
 		POKE &displayLEDs:0 %0 
 		MOVi %1 $params:OPERAND_1_LOW_PARAM_INDEX 	; global displayLEDs[1] = (int) displayBarValue((int) params[OPERAND_1_LOW_PARAM_INDEX])
-		CALL &displayBarValue %0 *2	; expects displayBarValue(int) -> int
+		CALL &displayBarValue %0 *2	; expects displayBarValue(int) -> int @ 130:88
 		POKE &displayLEDs:1 %0 
 		MOVi %1 $params:OPERAND_2_HIGH_PARAM_INDEX 	; global displayLEDs[2] = (int) displayBarValue((int) params[OPERAND_2_HIGH_PARAM_INDEX])
-		CALL &displayBarValue %0 *2	; expects displayBarValue(int) -> int
+		CALL &displayBarValue %0 *2	; expects displayBarValue(int) -> int @ 131:89
 		POKE &displayLEDs:2 %0 
 		MOVi %1 $params:OPERAND_2_LOW_PARAM_INDEX 	; global displayLEDs[3] = (int) displayBarValue((int) params[OPERAND_2_LOW_PARAM_INDEX])
-		CALL &displayBarValue %0 *2	; expects displayBarValue(int) -> int
+		CALL &displayBarValue %0 *2	; expects displayBarValue(int) -> int @ 132:88
 		POKE &displayLEDs:3 %0 
 		MOVi $taps:T0 #0 	; taps[T0] = 0
 		ADDi %0 $size #1	; taps[T3] = (size + 1) / 3
@@ -121,7 +121,7 @@ update:	FUNC	; signature func update() -> void
 
 ;-----------------------------------------------------------------------------
 		PARA *1
-process:	FUNC	; signature func process() -> void
+process:	FUNC	; signature func process() -> void @ 163:18
 	! MULi <A> #BATCH_SIZE_2 #TAPS_COUNT
 	$offset:	LOCi
 	$i:	LOCi
@@ -173,7 +173,7 @@ process:	FUNC	; signature func process() -> void
 		SUBi %1 $offset %1
 		MOVi %2 #BATCH_SIZE 
 		MOVp %3 $p 
-		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^read %0 *4	; expects function(int, int, ptr) -> unknown @ 192:47
 		ADDp $p $p #BATCH_SIZE_2	; p = p + BATCH_SIZE_2
 		FORi $i <A> @.l4	; }
 	.e3:	MOVi $bi #0 	; for (bi = 0 to BATCH_SIZE) 
@@ -236,7 +236,7 @@ process:	FUNC	; signature func process() -> void
 		SUBi %0 %0 %1
 		POKE &signal:0 %0 
 		POKE &signal:1 $tr 	; global signal[1] = (int) tr
-		CALL ^yield %0 *1	; expects function() -> unknown
+		CALL ^yield %0 *1	; expects function() -> unknown @ 226:11
 		! MULi <A> #T0 #BATCH_SIZE_2	; b[T0 * BATCH_SIZE_2] = t0
 		POKE $b <A> $t0
 		! MULi <A> #T3 #BATCH_SIZE_2	; b[T3 * BATCH_SIZE_2] = t3
@@ -261,7 +261,7 @@ process:	FUNC	; signature func process() -> void
 		SUBi %1 $offset %1
 		MOVi %2 #BATCH_SIZE 
 		MOVp %3 $p 
-		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown
+		CALL ^write %0 *4	; expects function(int, int, ptr) -> unknown @ 240:48
 		ADDp $p $p #BATCH_SIZE_2	; p = p + BATCH_SIZE_2
 		FORi $i <A> @.l8	; }
 		GOTO @.l0  	; }

--- a/tools/gazl-validate.js
+++ b/tools/gazl-validate.js
@@ -116,14 +116,82 @@ function parseParamTypes(paramText) {
     return result;
 }
 
+function splitOrigin(text) {
+    const trimmed = text.trim();
+    if (trimmed.length === 0) {
+        return { body: trimmed, origin: null };
+    }
+
+    const match = trimmed.match(/^(.*\S)\s+@\s+(.+)\s*$/);
+    if (!match) {
+        return { body: trimmed, origin: null };
+    }
+
+    return { body: match[1], origin: match[2].trim() };
+}
+
+function parseOriginMarker(originText) {
+    if (!originText) {
+        return null;
+    }
+
+    const trimmed = originText.trim();
+    if (trimmed.length === 0) {
+        return null;
+    }
+
+    let match = trimmed.match(/^(.*):([0-9]+):([0-9]+)$/);
+    if (match) {
+        return {
+            raw: trimmed,
+            file: match[1],
+            line: parseInt(match[2], 10),
+            column: parseInt(match[3], 10)
+        };
+    }
+
+    match = trimmed.match(/^([0-9]+):([0-9]+)$/);
+    if (match) {
+        return {
+            raw: trimmed,
+            file: null,
+            line: parseInt(match[1], 10),
+            column: parseInt(match[2], 10)
+        };
+    }
+
+    match = trimmed.match(/^(.*):([0-9]+)$/);
+    if (match) {
+        return {
+            raw: trimmed,
+            file: match[1],
+            line: parseInt(match[2], 10),
+            column: null
+        };
+    }
+
+    match = trimmed.match(/^([0-9]+)$/);
+    if (match) {
+        return {
+            raw: trimmed,
+            file: null,
+            line: parseInt(match[1], 10),
+            column: null
+        };
+    }
+
+    return { raw: trimmed };
+}
+
 function parseSignatureComment(comment) {
     if (!comment.startsWith('signature ')) {
         return null;
     }
 
     const payload = comment.substr('signature '.length).trim();
+    const split = splitOrigin(payload);
 
-    const funcMatch = payload.match(/^(.*?)\s+([^\s(]+)\s*\(([^)]*)\)\s*->\s*(\S+)\s*$/);
+    const funcMatch = split.body.match(/^(.*?)\s+([^\s(]+)\s*\(([^)]*)\)\s*->\s*(\S+)\s*$/);
     if (funcMatch) {
         const roleInfo = classifyRole(funcMatch[1]);
         return {
@@ -132,11 +200,12 @@ function parseSignatureComment(comment) {
             params: parseParamTypes(funcMatch[3]),
             returns: funcMatch[4].toLowerCase(),
             extern: roleInfo.extern,
-            native: roleInfo.native
+            native: roleInfo.native,
+            origin: split.origin
         };
     }
 
-    const valueMatch = payload.match(/^(.*?)\s+([^:]+?)\s*:\s*(\S+)\s*$/);
+    const valueMatch = split.body.match(/^(.*?)\s+([^:]+?)\s*:\s*(\S+)\s*$/);
     if (valueMatch) {
         const roleInfo = classifyRole(valueMatch[1]);
         const type = valueMatch[3].toLowerCase();
@@ -150,7 +219,8 @@ function parseSignatureComment(comment) {
                 size: sizeText === '' ? undefined : sizeText,
                 category: type,
                 extern: roleInfo.extern,
-                role: roleInfo.role
+                role: roleInfo.role,
+                origin: split.origin
             };
         }
 
@@ -162,7 +232,8 @@ function parseSignatureComment(comment) {
                 name,
                 category: type,
                 extern: roleInfo.extern,
-                role
+                role,
+                origin: split.origin
             };
         }
         return {
@@ -170,7 +241,8 @@ function parseSignatureComment(comment) {
             name,
             category: type,
             extern: roleInfo.extern,
-            role
+            role,
+            origin: split.origin
         };
     }
 
@@ -183,7 +255,8 @@ function parseExpectsComment(comment) {
     }
 
     const payload = comment.substr('expects '.length).trim();
-    const match = payload.match(/^([^\s(]+)\s*\(([^)]*)\)\s*->\s*(\S+)\s*$/);
+    const split = splitOrigin(payload);
+    const match = split.body.match(/^([^\s(]+)\s*\(([^)]*)\)\s*->\s*(\S+)\s*$/);
     if (!match) {
         return null;
     }
@@ -191,12 +264,13 @@ function parseExpectsComment(comment) {
     return {
         name: match[1],
         params: parseParamTypes(match[2]),
-        returns: match[3].toLowerCase()
+        returns: match[3].toLowerCase(),
+        origin: split.origin
     };
 }
 
-function location(file, line) {
-    return { file, line };
+function location(file, line, originText) {
+    return { file, line, origin: parseOriginMarker(originText) };
 }
 
 function addFunctionExport(ctx, parsed, loc) {
@@ -215,8 +289,8 @@ function addFunctionExport(ctx, parsed, loc) {
             severity: 'error',
             message: `Conflicting definitions for function ${parsed.name}`,
             locations: [
-                { label: 'previous definition', file: existing.locations[0].file, line: existing.locations[0].line },
-                { label: 'redefinition', file: loc.file, line: loc.line }
+                { label: 'previous definition', file: existing.locations[0].file, line: existing.locations[0].line, origin: existing.locations[0].origin },
+                { label: 'redefinition', file: loc.file, line: loc.line, origin: loc.origin }
             ]
         });
         return;
@@ -253,8 +327,8 @@ function addGlobalExport(ctx, parsed, loc) {
             severity: 'error',
             message: `Conflicting definitions for global ${parsed.name}`,
             locations: [
-                { label: 'previous definition', file: existing.locations[0].file, line: existing.locations[0].line },
-                { label: 'redefinition', file: loc.file, line: loc.line }
+                { label: 'previous definition', file: existing.locations[0].file, line: existing.locations[0].line, origin: existing.locations[0].origin },
+                { label: 'redefinition', file: loc.file, line: loc.line, origin: loc.origin }
             ]
         });
         return;
@@ -287,8 +361,8 @@ function addConstExport(ctx, parsed, loc) {
             severity: 'error',
             message: `Conflicting definitions for const ${parsed.name}`,
             locations: [
-                { label: 'previous definition', file: existing.locations[0].file, line: existing.locations[0].line },
-                { label: 'redefinition', file: loc.file, line: loc.line }
+                { label: 'previous definition', file: existing.locations[0].file, line: existing.locations[0].line, origin: existing.locations[0].origin },
+                { label: 'redefinition', file: loc.file, line: loc.line, origin: loc.origin }
             ]
         });
         return;
@@ -321,8 +395,8 @@ function addArrayExport(ctx, parsed, loc) {
             severity: 'error',
             message: `Conflicting definitions for array ${parsed.name}`,
             locations: [
-                { label: 'previous definition', file: existing.locations[0].file, line: existing.locations[0].line },
-                { label: 'redefinition', file: loc.file, line: loc.line }
+                { label: 'previous definition', file: existing.locations[0].file, line: existing.locations[0].line, origin: existing.locations[0].origin },
+                { label: 'redefinition', file: loc.file, line: loc.line, origin: loc.origin }
             ]
         });
         return;
@@ -468,7 +542,7 @@ function processFile(filePath, ctx) {
             const comment = line.substr(sigIdx + 1).trim();
             const parsed = parseSignatureComment(comment);
             if (parsed) {
-                recordSignature(ctx, parsed, location(filePath, lineNumber));
+                recordSignature(ctx, parsed, location(filePath, lineNumber, parsed.origin));
             }
         }
 
@@ -477,7 +551,7 @@ function processFile(filePath, ctx) {
             const comment = line.substr(expectsIdx + 1).trim();
             const parsed = parseExpectsComment(comment);
             if (parsed) {
-                addCallExpectation(ctx, parsed, location(filePath, lineNumber));
+                addCallExpectation(ctx, parsed, location(filePath, lineNumber, parsed.origin));
             }
         }
     }
@@ -493,8 +567,8 @@ function compareExternSets(kind, externMap, exportMap, ctx, comparator, mismatch
                             severity: 'error',
                             message: `${kind} ${name} has conflicting extern declarations`,
                             locations: [
-                                { label: 'first declaration', file: entries[i].location.file, line: entries[i].location.line },
-                                { label: 'second declaration', file: entries[j].location.file, line: entries[j].location.line }
+                                { label: 'first declaration', file: entries[i].location.file, line: entries[i].location.line, origin: entries[i].location.origin },
+                                { label: 'second declaration', file: entries[j].location.file, line: entries[j].location.line, origin: entries[j].location.origin }
                             ]
                         });
                     }
@@ -513,8 +587,8 @@ function compareExternSets(kind, externMap, exportMap, ctx, comparator, mismatch
                         severity: 'error',
                         message: `${kind} ${name} does not match its definition`,
                         locations: [
-                            { label: 'definition', file: exportEntry.locations[0].file, line: exportEntry.locations[0].line },
-                            { label: 'extern declaration', file: entry.location.file, line: entry.location.line }
+                            { label: 'definition', file: exportEntry.locations[0].file, line: exportEntry.locations[0].line, origin: exportEntry.locations[0].origin },
+                            { label: 'extern declaration', file: entry.location.file, line: entry.location.line, origin: entry.location.origin }
                         ]
                     });
                 }
@@ -530,7 +604,8 @@ function compareExternSets(kind, externMap, exportMap, ctx, comparator, mismatch
                 locations: entries.map(entry => ({
                     label: 'extern declaration',
                     file: entry.location.file,
-                    line: entry.location.line
+                    line: entry.location.line,
+                    origin: entry.location.origin
                 }))
             });
         }
@@ -550,8 +625,8 @@ function validateCalls(ctx) {
                     severity: 'error',
                     message: `Call to ${call.name} does not match its definition`,
                     locations: [
-                        { label: 'definition', file: exportEntry.locations[0].file, line: exportEntry.locations[0].line },
-                        { label: 'call site', file: call.location.file, line: call.location.line }
+                        { label: 'definition', file: exportEntry.locations[0].file, line: exportEntry.locations[0].line, origin: exportEntry.locations[0].origin },
+                        { label: 'call site', file: call.location.file, line: call.location.line, origin: call.location.origin }
                     ]
                 });
             }
@@ -571,8 +646,8 @@ function validateCalls(ctx) {
                     severity: 'error',
                     message: `Call to ${call.name} does not match extern declaration`,
                     locations: [
-                        { label: 'extern declaration', file: externEntries[0].location.file, line: externEntries[0].location.line },
-                        { label: 'call site', file: call.location.file, line: call.location.line }
+                        { label: 'extern declaration', file: externEntries[0].location.file, line: externEntries[0].location.line, origin: externEntries[0].location.origin },
+                        { label: 'call site', file: call.location.file, line: call.location.line, origin: call.location.origin }
                     ]
                 });
             }
@@ -583,7 +658,7 @@ function validateCalls(ctx) {
             severity: 'warning',
             message: `No signature metadata found for function ${call.name}`,
             locations: [
-                { label: 'call site', file: call.location.file, line: call.location.line }
+                { label: 'call site', file: call.location.file, line: call.location.line, origin: call.location.origin }
             ]
         });
     });
@@ -629,8 +704,36 @@ function validateContext(ctx) {
     validateCalls(ctx);
 }
 
+function formatOriginText(origin) {
+    if (!origin) {
+        return null;
+    }
+
+    const parts = [];
+    if (origin.file) {
+        parts.push(origin.file);
+    }
+    if (origin.line != null) {
+        parts.push(String(origin.line));
+    }
+    if (origin.column != null) {
+        parts.push(String(origin.column));
+    }
+
+    if (parts.length > 0) {
+        return parts.join(':');
+    }
+
+    return origin.raw || null;
+}
+
 function formatLocation(loc) {
-    return `${loc.file}:${loc.line}`;
+    const base = `${loc.file}:${loc.line}`;
+    const originText = formatOriginText(loc.origin);
+    if (originText) {
+        return `${base} (origin ${originText})`;
+    }
+    return base;
 }
 
 function reportDiagnostics(ctx) {


### PR DESCRIPTION
## Summary
- extend the Impala JSPEG compiler to compute origin strings, thread `sourceName` through symbols, and append `@ path:line:column` to signature comments
- update the JSPEG runner, fixtures, and Impala golden outputs so regenerated `.gazl` files include origin markers
- teach `gazl-validate` to parse origin markers for diagnostics and refresh the docs and implementation plan to cover the new metadata

## Testing
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d3e9664e98833292fcaa0cec0dd8a6