### PR TITLE
Run gazl-validate when regenerating JSPEG fixtures

### DIFF
--- a/docs/ImpalaTypeCheckingSpec.md
+++ b/docs/ImpalaTypeCheckingSpec.md
@@ -107,8 +107,8 @@ However, those `ArgsDecl` entries are discarded once `declare` runs, so `FuncCal
 
 ## Implementation Plan
 
-- [ ] **Compiler plumbing**
-  - [ ] Modify the generated compiler (`impala/jspeg/impala.jspeg`) so `FuncDecl`, `ExternDecl`, `GlobalDecl`, `ConstDecl`, and call emission helpers append inline signature comments (`; signature …` / `; expects …`) directly to the output buffer. Reuse the existing type codes and argument arrays so no additional inference is required.
+- [x] **Compiler plumbing**
+  - [x] Modify the generated compiler (`impala/jspeg/impala.jspeg`) so `FuncDecl`, `ExternDecl`, `GlobalDecl`, `ConstDecl`, and call emission helpers append inline signature comments (`; signature …` / `; expects …`) directly to the output buffer. Reuse the existing type codes and argument arrays so no additional inference is required.
     - [x] Attach signature metadata for function definitions, globals, constants, and call sites.
     - [x] Extend extern declarations to emit or preserve compatible signature comments.
   - [x] Persist the ordered parameter list from `ArgsDecl` in each function symbol, compare it against the call-site operands inside `FuncCall`, and invoke `typeError` when intra-unit calls disagree on category or arity before emitting the `()` instruction.【F:impala/jspeg/impala.jspeg†L1006-L1055】【F:impala/jspeg/impala.jspeg†L1719-L1738】【F:impala/jspeg/impala.jspeg†L1834-L1916】
@@ -118,10 +118,10 @@ However, those `ArgsDecl` entries are discarded once `declare` runs, so `FuncCal
       - [x] Expose a stable `sourceName` option on the compiler entry points and store it alongside the existing `sourceCode`/`sourceOffset` metadata for declarations and call sites.
       - [x] Derive 1-based line/column coordinates from the stored offsets and stash a formatted origin string on each signature or call expectation.
       - [x] Extend the signature-formatting helpers to append `@ <origin>` tokens to inline and standalone comments when origin data exists.
-- [ ] **Comment schema**
+- [x] **Comment schema**
   - [x] Lock down the comment grammar (for example, `FUNC foo    ; signature func foo(int a, ptr b) -> int` and `CALL foo    ; expects foo(int, ptr) -> int`) and document it alongside the Impala assembly reference so downstream tooling knows how to parse it.
   - [x] Ensure comments never break layout-sensitive sections by routing them through the same helpers that already insert `;`-prefixed notes when `-g` is enabled today.
-- [ ] **Validator tool**
+- [x] **Validator tool**
   - [x] Create `tools/gazl-validate.{js,cmd}` (mirroring existing script conventions) that parses the signature comments, performs the matching described above, and exits non-zero on fatal mismatches unless `--warn-only` is passed.【F:tools/gazl-validate.js†L1-L338】【F:tools/gazl-validate.js†L486-L679】
   - [x] Add integration to `build.sh` behind an environment toggle (`GAZL_VALIDATE=1`), letting CI enable it without slowing local builds immediately.【F:build.sh†L18-L33】【F:build.cmd†L27-L42】
   - [x] Parse optional `@ <origin>` markers so mismatch diagnostics can cite both the importer and exporter spans when metadata is available.

--- a/tools/regen-jspeg-fixtures.cmd
+++ b/tools/regen-jspeg-fixtures.cmd
@@ -1,4 +1,5 @@
 @ECHO OFF
+SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
 REM Regenerate impala\jspeg\testdata\*.pika.gazl from their .impala sources
 REM using the PPEG PikaScript-based Impala compiler (via output\PikaCmd).
 
@@ -14,12 +15,37 @@ IF NOT EXIST "%CMD%" (
 SET SCRIPT=impala.pika
 SET TESTDIR=impala\jspeg\testdata
 SET SEED=42
+SET FOUND=0
 
 FOR %%F IN ("%TESTDIR%\*.impala") DO (
   SET SRC=%%~fF
   SET OUT=%%~dpnF.pika.gazl
   CALL "%CMD%" "%SCRIPT" compile "%%SRC%%" "%%OUT%%" %SEED% >NUL
+  IF ERRORLEVEL 1 EXIT /b %ERRORLEVEL%
   ECHO Rebuilt %%OUT%%
+  SET FOUND=1
 )
+
+IF %FOUND%==0 (
+  ECHO No .impala sources found in %TESTDIR%
+  EXIT /b 1
+)
+
+SET FILES=
+FOR %%G IN ("%TESTDIR%\*.pika.gazl") DO (
+  IF NOT DEFINED FILES (
+    SET FILES="%%~fG"
+  ) ELSE (
+    SET FILES=!FILES! "%%~fG"
+  )
+)
+
+IF NOT DEFINED FILES (
+  ECHO No .pika.gazl outputs found in %TESTDIR%
+  EXIT /b 1
+)
+
+CALL tools\gazl-validate.cmd !FILES!
+IF ERRORLEVEL 1 EXIT /b %ERRORLEVEL%
 
 EXIT /b 0

--- a/tools/regen-jspeg-fixtures.sh
+++ b/tools/regen-jspeg-fixtures.sh
@@ -31,4 +31,12 @@ if [ $changed -eq 0 ]; then
     exit 1
 fi
 
+gazl_files=("$testdir"/*.pika.gazl)
+if [ ${#gazl_files[@]} -eq 0 ]; then
+    echo "No .pika.gazl outputs found in $testdir" >&2
+    exit 1
+fi
+
+node ./tools/gazl-validate.js "${gazl_files[@]}"
+
 exit 0


### PR DESCRIPTION
## Summary
- run gazl-validate on regenerated JSPEG fixtures in both the Bash and CMD harness scripts
- improve the Windows helper to surface missing inputs and propagate validator/compile failures
- mark the Impala type checking implementation plan milestones as complete in the specification

## Testing
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d400e901fc8332936742d39fd73029