### PR TITLE
Simplify Impala JS compiler runner internals

### DIFF
--- a/docs/impalaJsCompilerRunner_simplification.md
+++ b/docs/impalaJsCompilerRunner_simplification.md
@@ -1,0 +1,10 @@
+# impalaJsCompilerRunner.js simplification ideas
+
+## Potential refactors
+
+- **Share newline scanning logic** – both `findLineBounds` and `renderErrorContext` walk the source string character by character to find line starts, ends, and printable fragments. Replacing the manual scans with a shared helper that slices once or leverages `source.slice(0, index).split(/\r\n|\n|\r/)` would reduce duplicated control flow and make the intent clearer.【F:impala/jspeg/impalaJsCompilerRunner.js†L57-L152】
+- **Lean on `String.prototype.replace` for tab handling** – `retabulate` currently maintains explicit `tabIndex`, `outPosition`, and a `while` loop to emit tabs and spaces. Converting tabs via `line.replace(/\t/g, callback)` (where the callback computes the next stop) would eliminate the manual loop state and clarify that the goal is just to expand tabs to aligned indentation.【F:impala/jspeg/impalaJsCompilerRunner.js†L10-L41】
+- **Collapse `withGlobalBindings` bookkeeping** – the helper first builds a `Set`, then populates a `Map`, and later iterates it twice. Capturing the previous values in a plain object and iterating a single list of keys would achieve the same restore semantics with less scaffolding.【F:impala/jspeg/impalaJsCompilerRunner.js†L183-L211】
+- **Normalize compiler option plumbing** – `compileWithJsImpala` contains several ternaries that handle `compilerPath`, `compilerSource`, and `sourceName`. Destructuring `options` up front (e.g., `const { compilerPath, compilerSource, sourceName, retabulate = true, trailingNewline } = options;`) would remove repetitive property checks and make the defaulting behavior more declarative.【F:impala/jspeg/impalaJsCompilerRunner.js†L228-L280】
+
+These cleanups avoid altering behavior while making the runner easier to follow and maintain.

--- a/impala/jspeg/impalaJsCompilerRunner.js
+++ b/impala/jspeg/impalaJsCompilerRunner.js
@@ -13,140 +13,99 @@ function retabulate(line) {
 		return "";
 	}
 
-	let outPosition = 0;
-	let tabIndex = 0;
-	let lastIndex = 0;
 	let result = "";
+	let column = 0;
+	let tabIndex = 0;
 
-	const advanceToReach = () => {
-		const stop = INPUT_TAB_STOPS[tabIndex];
-		const reach = Math.max(stop !== undefined ? stop : -Infinity, outPosition + 1);
-		let next;
-		while ((next = outPosition + OUTPUT_TAB_WIDTH - (outPosition % OUTPUT_TAB_WIDTH)) <= reach) {
+	const align = (target) => {
+		while (column < target) {
+			const remainder = column % OUTPUT_TAB_WIDTH;
+			const next = column + (remainder === 0 ? OUTPUT_TAB_WIDTH : OUTPUT_TAB_WIDTH - remainder);
+			if (next > target) {
+				break;
+			}
 			result += "\t";
-			outPosition = next;
+			column = next;
 		}
-		const spaces = reach - outPosition;
-		if (spaces > 0) {
-			result += " ".repeat(spaces);
-			outPosition = reach;
+		if (column < target) {
+			result += " ".repeat(target - column);
+			column = target;
 		}
-		tabIndex += 1;
 	};
 
-	advanceToReach();
-
-	line.replace(/\t/g, (_match, offset) => {
-		const segment = line.slice(lastIndex, offset);
-		if (segment.length > 0) {
-			result += segment;
-			outPosition += segment.length;
-		}
-		advanceToReach();
-		lastIndex = offset + 1;
-		return "";
-	});
-
-	const tail = line.slice(lastIndex);
-	if (tail.length > 0) {
-		result += tail;
-		outPosition += tail.length;
+	for (const segment of line.split("\t")) {
+		const stop = INPUT_TAB_STOPS[tabIndex] ?? -Infinity;
+		align(Math.max(stop, column + 1));
+		tabIndex += 1;
+		result += segment;
+		column += segment.length;
 	}
 
 	return result;
 }
 
 function clampIndex(value, min, max) {
-	if (!Number.isFinite(value)) {
-		return min;
-	}
-	if (value < min) {
-		return min;
-	}
-	if (value > max) {
-		return max;
-	}
-	return Math.floor(value);
+	return Number.isFinite(value) ? Math.min(Math.max(Math.floor(value), min), max) : min;
 }
 
 function getLineInfo(source, rawIndex) {
 	const index = clampIndex(rawIndex, 0, source.length);
-	const before = source.slice(0, index);
-	const lineParts = before.split(LINE_BREAK_PATTERN);
-	const line = lineParts.length;
-	const lastSegment = lineParts[lineParts.length - 1] ?? "";
-	const lineStart = index - lastSegment.length;
-	const rest = source.slice(index);
-	const match = rest.match(LINE_BREAK_PATTERN);
+	const head = source.slice(0, index);
+	const segments = head.split(LINE_BREAK_PATTERN);
+	const last = segments[segments.length - 1] ?? "";
+	const lineStart = index - last.length;
+	const match = source.slice(index).match(LINE_BREAK_PATTERN);
 	const lineEnd = match ? index + match.index : source.length;
-	const lineText = source.slice(lineStart, lineEnd);
-	return { index, line, lineStart, lineEnd, lineText };
-}
-
-function findLineBounds(source, index) {
-	const { line, lineStart, lineEnd } = getLineInfo(source, index);
-	return { line, lineStart, lineEnd };
+	return {
+		index,
+		line: segments.length,
+		lineStart,
+		lineEnd,
+		lineText: source.slice(lineStart, lineEnd),
+	};
 }
 
 function renderErrorContext(lineText, pointerOffset) {
 	let displayLine = "";
-	let pointerLine = "";
-	let runningColumn = 1;
-	let pointerColumn = 1;
+	let pointerColumn = 0;
+	let column = 0;
 
-	for (let pos = 0; pos < lineText.length; ++pos) {
-		const ch = lineText[pos];
+	for (let i = 0; i < lineText.length; i += 1) {
+		const ch = lineText[i];
 		if (ch === "\t") {
-			const spaces = OUTPUT_TAB_WIDTH - ((runningColumn - 1) % OUTPUT_TAB_WIDTH);
+			const spaces = ((column + OUTPUT_TAB_WIDTH) & ~(OUTPUT_TAB_WIDTH - 1)) - column;
 			displayLine += " ".repeat(spaces);
-			runningColumn += spaces;
-			if (pos < pointerOffset) {
-				pointerLine += " ".repeat(spaces);
+			if (i < pointerOffset) {
 				pointerColumn += spaces;
 			}
+			column += spaces;
 			continue;
 		}
 		const code = ch.charCodeAt(0);
-		const safeChar = code >= 0x20 && code !== 0x7f ? ch : " ";
-		displayLine += safeChar;
-		runningColumn += 1;
-		if (pos < pointerOffset) {
-			pointerLine += " ";
+		displayLine += code >= 0x20 && code !== 0x7f ? ch : " ";
+		if (i < pointerOffset) {
 			pointerColumn += 1;
 		}
+		column += 1;
 	}
 
 	if (pointerOffset >= lineText.length) {
-		pointerColumn = runningColumn;
+		pointerColumn = column;
 	}
-
-	pointerLine += "^";
 
 	return {
 		displayLine,
-		pointerLine,
-		column: pointerColumn,
+		pointerLine: `${" ".repeat(pointerColumn)}^`,
+		column: pointerColumn + 1,
 	};
 }
 
 function formatErrorWithLocation(source, options, rawIndex, baseMessage, explicitLocationLabel) {
 	const { index, line, lineStart, lineEnd, lineText } = getLineInfo(source, rawIndex);
 	const context = renderErrorContext(lineText, index - lineStart);
-	let locationLabel;
-	if (explicitLocationLabel !== undefined) {
-		locationLabel = explicitLocationLabel;
-	} else if (options && options.sourceName) {
-		locationLabel = ` ${options.sourceName}`;
-	} else {
-		locationLabel = " source";
-	}
-	let message = `${baseMessage}${locationLabel} at line ${line}, column ${context.column}, offset ${index}.`;
-	if (context.displayLine.length > 0 || lineEnd > lineStart) {
-		message += `\n${context.displayLine}\n${context.pointerLine}`;
-	} else {
-		message += "\n^";
-	}
-	return message;
+	const locationLabel = explicitLocationLabel ?? (options && options.sourceName ? ` ${options.sourceName}` : " source");
+	const detail = context.displayLine.length > 0 || lineEnd > lineStart ? `\n${context.displayLine}\n${context.pointerLine}` : "\n^";
+	return `${baseMessage}${locationLabel} at line ${line}, column ${context.column}, offset ${index}.${detail}`;
 }
 
 function formatThrownCompilerError(err, source, options) {
@@ -234,9 +193,7 @@ function compileWithJsImpala(source, options = {}) {
 		randomId = 12345678,
 	} = options;
 
-	const compilerPath = compilerPathOption
-		? path.resolve(compilerPathOption)
-		: path.join(__dirname, "impalaCompiler.js");
+	const compilerPath = compilerPathOption ? path.resolve(compilerPathOption) : path.join(__dirname, "impalaCompiler.js");
 	const compilerText = compilerSource ?? fs.readFileSync(compilerPath, "utf8");
 
 	const outputLines = [];

--- a/impala/jspeg/impalaJsCompilerRunner.js
+++ b/impala/jspeg/impalaJsCompilerRunner.js
@@ -6,39 +6,54 @@ const Module = require("module");
 
 const OUTPUT_TAB_WIDTH = 4;
 const INPUT_TAB_STOPS = [0, 20, 32, 64];
+const LINE_BREAK_PATTERN = /\r\n|\r|\n/;
 
 function retabulate(line) {
 	if (line.length === 0) {
 		return "";
 	}
 
-	let out = "";
-	let tabIndex = 0;
 	let outPosition = 0;
-	const segments = line.split("\t");
+	let tabIndex = 0;
+	let lastIndex = 0;
+	let result = "";
 
-	for (const segment of segments) {
+	const advanceToReach = () => {
 		const stop = INPUT_TAB_STOPS[tabIndex];
 		const reach = Math.max(stop !== undefined ? stop : -Infinity, outPosition + 1);
-
 		let next;
 		while ((next = outPosition + OUTPUT_TAB_WIDTH - (outPosition % OUTPUT_TAB_WIDTH)) <= reach) {
-			out += "\t";
+			result += "\t";
 			outPosition = next;
 		}
-
 		const spaces = reach - outPosition;
 		if (spaces > 0) {
-			out += " ".repeat(spaces);
+			result += " ".repeat(spaces);
 			outPosition = reach;
 		}
-
-		out += segment;
-		outPosition += segment.length;
 		tabIndex += 1;
+	};
+
+	advanceToReach();
+
+	line.replace(/\t/g, (_match, offset) => {
+		const segment = line.slice(lastIndex, offset);
+		if (segment.length > 0) {
+			result += segment;
+			outPosition += segment.length;
+		}
+		advanceToReach();
+		lastIndex = offset + 1;
+		return "";
+	});
+
+	const tail = line.slice(lastIndex);
+	if (tail.length > 0) {
+		result += tail;
+		outPosition += tail.length;
 	}
 
-	return out;
+	return result;
 }
 
 function clampIndex(value, min, max) {
@@ -54,54 +69,38 @@ function clampIndex(value, min, max) {
 	return Math.floor(value);
 }
 
+function getLineInfo(source, rawIndex) {
+	const index = clampIndex(rawIndex, 0, source.length);
+	const before = source.slice(0, index);
+	const lineParts = before.split(LINE_BREAK_PATTERN);
+	const line = lineParts.length;
+	const lastSegment = lineParts[lineParts.length - 1] ?? "";
+	const lineStart = index - lastSegment.length;
+	const rest = source.slice(index);
+	const match = rest.match(LINE_BREAK_PATTERN);
+	const lineEnd = match ? index + match.index : source.length;
+	const lineText = source.slice(lineStart, lineEnd);
+	return { index, line, lineStart, lineEnd, lineText };
+}
+
 function findLineBounds(source, index) {
-	const length = source.length;
-	let line = 1;
-	let position = 0;
-	let lineStart = 0;
-	while (position < index) {
-		const code = source.charCodeAt(position);
-		if (code === 0x0d) {
-			const next = position + 1;
-			position = next < length && source.charCodeAt(next) === 0x0a ? next + 1 : next;
-			line += 1;
-			lineStart = position;
-			continue;
-		}
-		if (code === 0x0a) {
-			position += 1;
-			line += 1;
-			lineStart = position;
-			continue;
-		}
-		position += 1;
-	}
-
-	let lineEnd = length;
-	for (let pos = index; pos < length; ++pos) {
-		const code = source.charCodeAt(pos);
-		if (code === 0x0a || code === 0x0d) {
-			lineEnd = pos;
-			break;
-		}
-	}
-
+	const { line, lineStart, lineEnd } = getLineInfo(source, index);
 	return { line, lineStart, lineEnd };
 }
 
-function renderErrorContext(source, lineStart, lineEnd, pointerIndex) {
+function renderErrorContext(lineText, pointerOffset) {
 	let displayLine = "";
 	let pointerLine = "";
 	let runningColumn = 1;
 	let pointerColumn = 1;
 
-	for (let pos = lineStart; pos < lineEnd; ++pos) {
-		const ch = source[pos];
+	for (let pos = 0; pos < lineText.length; ++pos) {
+		const ch = lineText[pos];
 		if (ch === "\t") {
 			const spaces = OUTPUT_TAB_WIDTH - ((runningColumn - 1) % OUTPUT_TAB_WIDTH);
 			displayLine += " ".repeat(spaces);
 			runningColumn += spaces;
-			if (pos < pointerIndex) {
+			if (pos < pointerOffset) {
 				pointerLine += " ".repeat(spaces);
 				pointerColumn += spaces;
 			}
@@ -111,13 +110,13 @@ function renderErrorContext(source, lineStart, lineEnd, pointerIndex) {
 		const safeChar = code >= 0x20 && code !== 0x7f ? ch : " ";
 		displayLine += safeChar;
 		runningColumn += 1;
-		if (pos < pointerIndex) {
+		if (pos < pointerOffset) {
 			pointerLine += " ";
 			pointerColumn += 1;
 		}
 	}
 
-	if (pointerIndex >= lineEnd) {
+	if (pointerOffset >= lineText.length) {
 		pointerColumn = runningColumn;
 	}
 
@@ -131,9 +130,8 @@ function renderErrorContext(source, lineStart, lineEnd, pointerIndex) {
 }
 
 function formatErrorWithLocation(source, options, rawIndex, baseMessage, explicitLocationLabel) {
-	const index = clampIndex(rawIndex, 0, source.length);
-	const { line, lineStart, lineEnd } = findLineBounds(source, index);
-	const context = renderErrorContext(source, lineStart, lineEnd, index);
+	const { index, line, lineStart, lineEnd, lineText } = getLineInfo(source, rawIndex);
+	const context = renderErrorContext(lineText, index - lineStart);
 	let locationLabel;
 	if (explicitLocationLabel !== undefined) {
 		locationLabel = explicitLocationLabel;
@@ -181,13 +179,13 @@ function resolveCompilerExport(candidate) {
 const GLOBAL_SENTINEL = Symbol("missing");
 
 function withGlobalBindings(bindings, fn, preserve = []) {
-	const snapshot = new Map();
-	const keys = new Set([...Object.keys(bindings), ...preserve]);
+	const keys = Array.from(new Set([...Object.keys(bindings), ...preserve]));
+	const snapshot = {};
 	for (const key of keys) {
 		if (Object.prototype.hasOwnProperty.call(globalThis, key)) {
-			snapshot.set(key, globalThis[key]);
+			snapshot[key] = globalThis[key];
 		} else {
-			snapshot.set(key, GLOBAL_SENTINEL);
+			snapshot[key] = GLOBAL_SENTINEL;
 		}
 	}
 	try {
@@ -200,7 +198,8 @@ function withGlobalBindings(bindings, fn, preserve = []) {
 		}
 		return fn();
 	} finally {
-		for (const [key, value] of snapshot.entries()) {
+		for (const key of keys) {
+			const value = snapshot[key];
 			if (value === GLOBAL_SENTINEL) {
 				delete globalThis[key];
 			} else {
@@ -226,22 +225,32 @@ function loadCompilerModule(compilerSource, compilerFilename) {
 }
 
 function compileWithJsImpala(source, options = {}) {
-	const compilerPath = options.compilerPath ? path.resolve(options.compilerPath) : path.join(__dirname, "impalaCompiler.js");
-	const compilerSource = options.compilerSource ?? fs.readFileSync(compilerPath, "utf8");
+	const {
+		compilerPath: compilerPathOption,
+		compilerSource,
+		sourceName,
+		retabulate: shouldRetabulate = true,
+		trailingNewline,
+		randomId = 12345678,
+	} = options;
+
+	const compilerPath = compilerPathOption
+		? path.resolve(compilerPathOption)
+		: path.join(__dirname, "impalaCompiler.js");
+	const compilerText = compilerSource ?? fs.readFileSync(compilerPath, "utf8");
 
 	const outputLines = [];
-	const compilerExports = loadCompilerModule(compilerSource, compilerPath);
+	const compilerExports = loadCompilerModule(compilerText, compilerPath);
 	const compilerFn = resolveCompilerExport(compilerExports);
 	if (typeof compilerFn !== "function") {
 		throw new Error("JSPEG impala compiler did not export a function");
 	}
 
-	const compilerOptions =
-		options && Object.prototype.hasOwnProperty.call(options, "sourceName") ? { sourceName: options.sourceName } : undefined;
+	const compilerOptions = sourceName !== undefined ? { sourceName } : undefined;
 	const compileResult = withGlobalBindings(
 		{
 			output: (line) => outputLines.push(line),
-			impalaRandomId: options.randomId ?? 12345678,
+			impalaRandomId: randomId,
 		},
 		() => {
 			try {
@@ -264,14 +273,12 @@ function compileWithJsImpala(source, options = {}) {
 		return "";
 	}
 
-	const shouldRetabulate = options.retabulate !== false;
 	const formatted = shouldRetabulate ? outputLines.map(retabulate) : outputLines;
 	let outputText = formatted.join("\n");
 
-	const trailingNewlineOption = options.trailingNewline;
-	if (trailingNewlineOption === true || (trailingNewlineOption === undefined && shouldRetabulate)) {
+	if (trailingNewline === true || (trailingNewline === undefined && shouldRetabulate)) {
 		outputText += "\n";
-	} else if (!shouldRetabulate && trailingNewlineOption !== true) {
+	} else if (!shouldRetabulate && trailingNewline !== true) {
 		while (outputText.endsWith("\n")) {
 			outputText = outputText.slice(0, -1);
 		}


### PR DESCRIPTION
## Summary
- Rebuild `retabulate` around a replace-driven helper that clarifies tab alignment
- Add a shared line information helper and reuse it for error context rendering
- Streamline global binding snapshotting and option destructuring in the compiler runner

## Testing
- timeout 180 ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68e7cee64eec8332ae523055411a1504